### PR TITLE
Record basic coverage information using Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ script:
 - cd target
 - java -jar SQLancer-0.0.1-SNAPSHOT.jar --timeout-seconds 60 sqlite3
 - java -jar SQLancer-0.0.1-SNAPSHOT.jar --timeout-seconds 60 duckdb
-
 cache:
   directories:
   - target/lib
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ cache:
   - target/lib
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+after_failure:
+  - cat target/pmd.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: java
 jdk: oraclejdk11
 script:
-- cd target
-- java -jar SQLancer-0.0.1-SNAPSHOT.jar --timeout-seconds 60 sqlite3
-- java -jar SQLancer-0.0.1-SNAPSHOT.jar --timeout-seconds 60 duckdb
+- mvn test
 cache:
   directories:
   - target/lib

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,32 @@
 	</properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
+		<testSourceDirectory>test</testSourceDirectory>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.5</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
@@ -168,6 +193,12 @@
 			<groupId>org.duckdb</groupId>
 			<artifactId>duckdb_jdbc</artifactId>
 			<version>0.1.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -309,7 +309,7 @@ public final class Main {
         }
 
         if (options.printProgressInformation()) {
-            startProgressMonitor(options);
+            startProgressMonitor();
         }
 
         ExecutorService executor = Executors.newFixedThreadPool(options.getNumberConcurrentThreads());
@@ -409,8 +409,8 @@ public final class Main {
         return threadsShutdown == 0 ? 0 : THREADS_SHUTDOWN_EXIT_CODE;
     }
 
-    private static void startProgressMonitor(MainOptions options) {
-        final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(2);
+    private static void startProgressMonitor() {
+        final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
         scheduler.scheduleAtFixedRate(new Runnable() {
 
             private long timeMillis = System.currentTimeMillis();

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -271,10 +271,10 @@ public final class Main {
     }
 
     public static void main(String[] args) {
-        executeMain(args);
+        System.exit(executeMain(args));
     }
 
-    private static int executeMain(String[] args) throws AssertionError {
+    public static int executeMain(String[] args) throws AssertionError {
         List<DatabaseProvider<?, ?>> providers = new ArrayList<>();
         providers.add(new SQLite3Provider());
         providers.add(new CockroachDBProvider());

--- a/test/sqlancer/TestMain.java
+++ b/test/sqlancer/TestMain.java
@@ -1,17 +1,20 @@
 package sqlancer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 
 public class TestMain {
 
     @Test
     public void testSQLite() {
-        Main.main(new String[] { "--timeout-seconds", "30", "sqlite3", "--oracle", "NoREC" });
+        // do not check the result, since we still find bugs in the SQLite3 version included in the JDBC driver
+        Main.executeMain(new String[] { "--timeout-seconds", "30", "sqlite3", "--oracle", "NoREC" });
     }
 
     @Test
     public void testDuckDB() {
-        Main.main(new String[] { "--timeout-seconds", "30", "duckdb", "--oracle", "NoREC" });
+        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", "30", "duckdb", "--oracle", "NoREC" }));
     }
 
 }

--- a/test/sqlancer/TestMain.java
+++ b/test/sqlancer/TestMain.java
@@ -1,0 +1,17 @@
+package sqlancer;
+
+import org.junit.jupiter.api.Test;
+
+public class TestMain {
+
+    @Test
+    public void testSQLite() {
+        Main.main(new String[] { "--timeout-seconds", "30", "sqlite3", "--oracle", "NoREC" });
+    }
+
+    @Test
+    public void testDuckDB() {
+        Main.main(new String[] { "--timeout-seconds", "30", "duckdb", "--oracle", "NoREC" });
+    }
+
+}


### PR DESCRIPTION
Add coverage information and ensure that the process does not exit prematurely. Addresses https://github.com/sqlancer/sqlancer/issues/20.