### PR TITLE
Cache the Maven dependencies in the Travis gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ script:
 - cd target
 - java -jar SQLancer-0.0.1-SNAPSHOT.jar --timeout-seconds 60 sqlite3
 - java -jar SQLancer-0.0.1-SNAPSHOT.jar --timeout-seconds 60 duckdb
+
+cache:
+  directories:
+  - target/lib


### PR DESCRIPTION
Add a cache, see https://docs.travis-ci.com/user/caching/.