### PR TITLE
Add the option to use a random seed to deterministically generate pse…

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -307,6 +307,12 @@ public final class Main {
         ExecutorService executor = Executors.newFixedThreadPool(options.getNumberConcurrentThreads());
         for (int i = 0; i < options.getTotalNumberTries(); i++) {
             final String databaseName = "database" + i;
+            final long seed;
+            if (options.getRandomSeed() == -1) {
+                seed = -1;
+            } else {
+                seed = options.getRandomSeed() + i;
+            }
 
             executor.execute(new Runnable() {
 
@@ -333,7 +339,12 @@ public final class Main {
                         stateToRepro = provider.getStateToReproduce(databaseName);
                         state.setState(stateToRepro);
                         logger = new StateLogger(databaseName, provider, options);
-                        Randomly r = new Randomly();
+                        Randomly r;
+                        if (seed == -1) {
+                            r = new Randomly();
+                        } else {
+                            r = new Randomly(seed);
+                        }
                         state.setRandomly(r);
                         state.setDatabaseName(databaseName);
                         state.setMainOptions(options);

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -11,6 +11,10 @@ public class MainOptions {
             "--num-threads" }, description = "How many threads should run concurrently to test separate databases")
     private int nrConcurrentThreads = 16;
 
+    @Parameter(names = {
+            "--random-seed" }, description = "A seed value != -1 that can be set to make the query and database generation deterministic")
+    private long randomSeed = -1;
+
     @Parameter(names = { "--num-tries" }, description = "Specifies after how many found errors to stop testing")
     private int totalNumberTries = 100;
 
@@ -108,6 +112,10 @@ public class MainOptions {
 
     public int getErrorExitCode() {
         return errorExitCode;
+    }
+
+    public long getRandomSeed() {
+        return randomSeed;
     }
 
 }

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 import java.util.function.Supplier;
 
 public final class Randomly {
@@ -19,6 +19,8 @@ public final class Randomly {
     private static final String ALPHABET = new String(
             "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzöß!#<>/.,~-+'*()[]{} ^*?%_\t\n\r|&\\");
     private Supplier<String> provider;
+
+    private static final ThreadLocal<Random> THREAD_RANDOM = new ThreadLocal<>();
 
     private void addToCache(long val) {
         if (USE_CACHING && cachedLongs.size() < CACHE_SIZE && !cachedLongs.contains(val)) {
@@ -94,28 +96,28 @@ public final class Randomly {
     }
 
     private static boolean cacheProbability() {
-        return USE_CACHING && ThreadLocalRandom.current().nextInt(3) == 1;
+        return USE_CACHING && getNextLong(0, 3) == 1;
     }
 
     // CACHING END
 
     public static <T> T fromList(List<T> list) {
-        return list.get(ThreadLocalRandom.current().nextInt(list.size()));
+        return list.get((int) getNextLong(0, list.size()));
     }
 
     @SafeVarargs
     public static <T> T fromOptions(T... options) {
-        return options[ThreadLocalRandom.current().nextInt(options.length)];
+        return options[getNextInt(0, options.length)];
     }
 
     @SafeVarargs
     public static <T> List<T> nonEmptySubset(T... options) {
-        int nr = 1 + ThreadLocalRandom.current().nextInt(options.length);
+        int nr = 1 + getNextInt(0, options.length);
         return extractNrRandomColumns(Arrays.asList(options), nr);
     }
 
     public static <T> List<T> nonEmptySubset(List<T> columns) {
-        int nr = 1 + ThreadLocalRandom.current().nextInt(columns.size());
+        int nr = 1 + getNextInt(0, columns.size());
         return nonEmptySubset(columns, nr);
     }
 
@@ -135,7 +137,7 @@ public final class Randomly {
     }
 
     public static <T> List<T> subset(List<T> columns) {
-        int nr = ThreadLocalRandom.current().nextInt(columns.size() + 1);
+        int nr = getNextInt(0, columns.size() + 1);
         return extractNrRandomColumns(columns, nr);
     }
 
@@ -160,18 +162,26 @@ public final class Randomly {
         List<T> selectedColumns = new ArrayList<>();
         List<T> remainingColumns = new ArrayList<>(columns);
         for (int i = 0; i < nr; i++) {
-            selectedColumns.add(remainingColumns.remove(ThreadLocalRandom.current().nextInt(remainingColumns.size())));
+            selectedColumns.add(remainingColumns.remove(getNextInt(0, remainingColumns.size())));
         }
         return selectedColumns;
     }
 
     public static int smallNumber() {
         // no need to cache for small numbers
-        return (int) (Math.abs(ThreadLocalRandom.current().nextGaussian()) * 2);
+        return (int) (Math.abs(getThreadRandom().get().nextGaussian()) * 2);
     }
 
     public static boolean getBoolean() {
-        return ThreadLocalRandom.current().nextBoolean();
+        return getThreadRandom().get().nextBoolean();
+    }
+
+    private static ThreadLocal<Random> getThreadRandom() {
+        if (THREAD_RANDOM.get() == null) {
+            // a static method has been called, before Randomly was instantiated
+            THREAD_RANDOM.set(new Random());
+        }
+        return THREAD_RANDOM;
     }
 
     public long getInteger() {
@@ -184,7 +194,7 @@ public final class Randomly {
                     return l;
                 }
             }
-            long nextLong = ThreadLocalRandom.current().nextInt();
+            long nextLong = getThreadRandom().get().nextInt();
             addToCache(nextLong);
             return nextLong;
         }
@@ -218,7 +228,7 @@ public final class Randomly {
                     sb.append(val);
                 }
             } else {
-                sb.append(ALPHABET.charAt(ThreadLocalRandom.current().nextInt(n)));
+                sb.append(ALPHABET.charAt(getNextInt(0, n)));
             }
         }
         while (Randomly.getBooleanWithSmallProbability()) {
@@ -248,7 +258,7 @@ public final class Randomly {
     public byte[] getBytes() {
         int size = Randomly.smallNumber();
         byte[] arr = new byte[size];
-        ThreadLocalRandom.current().nextBytes(arr);
+        getThreadRandom().get().nextBytes(arr);
         return arr;
     }
 
@@ -282,7 +292,7 @@ public final class Randomly {
         if (smallBiasProbability()) {
             value = Randomly.fromOptions(0L, Long.MAX_VALUE, 1L);
         } else {
-            value = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+            value = getNextLong(0, Long.MAX_VALUE);
         }
         addToCache(value);
         assert value >= 0;
@@ -308,17 +318,17 @@ public final class Randomly {
                 return d;
             }
         }
-        double value = ThreadLocalRandom.current().nextDouble();
+        double value = getThreadRandom().get().nextDouble();
         addToCache(value);
         return value;
     }
 
     private static boolean smallBiasProbability() {
-        return ThreadLocalRandom.current().nextInt(100) == 1;
+        return getThreadRandom().get().nextInt(100) == 1;
     }
 
     public static boolean getBooleanWithRatherLowProbability() {
-        return ThreadLocalRandom.current().nextInt(10) == 1;
+        return getThreadRandom().get().nextInt(10) == 1;
     }
 
     public static boolean getBooleanWithSmallProbability() {
@@ -329,18 +339,19 @@ public final class Randomly {
         if (left == right) {
             return left;
         }
-        return ThreadLocalRandom.current().nextInt(left, right);
+        return (int) getLong(left, right);
     }
 
+    // TODO redundant?
     public long getLong(long left, long right) {
         if (left == right) {
             return left;
         }
-        return ThreadLocalRandom.current().nextLong(left, right);
+        return getNextLong(left, right);
     }
 
     public BigDecimal getRandomBigDecimal() {
-        return new BigDecimal(ThreadLocalRandom.current().nextDouble());
+        return new BigDecimal(getThreadRandom().get().nextDouble());
     }
 
     public long getPositiveIntegerNotNull() {
@@ -353,19 +364,19 @@ public final class Randomly {
     }
 
     public static long getNonCachedInteger() {
-        return ThreadLocalRandom.current().nextLong();
+        return getThreadRandom().get().nextLong();
     }
 
     public static long getPositiveNonCachedInteger() {
-        return ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE);
+        return getNextLong(1, Long.MAX_VALUE);
     }
 
     public static long getPositiveOrZeroNonCachedInteger() {
-        return ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE);
+        return getNextLong(0, Long.MAX_VALUE);
     }
 
     public static long getNotCachedInteger(int lower, int upper) {
-        return ThreadLocalRandom.current().nextLong(lower, upper);
+        return getNextLong(lower, upper);
     }
 
     public Randomly(Supplier<String> provider) {
@@ -373,10 +384,15 @@ public final class Randomly {
     }
 
     public Randomly() {
+        getThreadRandom().set(new Random());
+    }
+
+    public Randomly(long seed) {
+        getThreadRandom().set(new Random(seed));
     }
 
     public static double getUncachedDouble() {
-        return ThreadLocalRandom.current().nextDouble();
+        return getThreadRandom().get().nextDouble();
     }
 
     public String getChar() {
@@ -386,6 +402,20 @@ public final class Randomly {
                 return s.substring(0, 1);
             }
         }
+    }
+
+    // see https://stackoverflow.com/a/2546158
+    // uniformity does not seem to be important for us
+    // SQLancer previously used ThreadLocalRandom.current().nextLong(lower, upper)
+    private static long getNextLong(long lower, long upper) {
+        if (lower > upper) {
+            throw new IllegalArgumentException(lower + " " + upper);
+        }
+        return lower + ((long) (getThreadRandom().get().nextDouble() * (upper - lower)));
+    }
+
+    private static int getNextInt(int lower, int upper) {
+        return (int) getNextLong(lower, upper);
     }
 
 }


### PR DESCRIPTION
…udo-random numbers

Introduce a new option `--random-seed` to make the randomly-generated data reproducible. It can be used as follows:
```
$ java -jar SQLancer-0.0.1-SNAPSHOT.jar --random-seed -1 duckdb
```
Each thread derives its own seed from the specified random seed, so that each thread consistently generates the same data when given the same random seed.