### PR TITLE
Test DuckDB as part of the SQLancer CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following commands clone SQLancer, create a JAR, and start SQLancer to fuzz 
 ```
 git clone https://github.com/sqlancer/sqlancer
 cd sqlancer
-mvn package
+mvn package -DskipTests
 cd target
 java -jar SQLancer-0.0.1-SNAPSHOT.jar --num-threads 4 sqlite3 --oracle NoREC
 ```

--- a/test/sqlancer/TestMain.java
+++ b/test/sqlancer/TestMain.java
@@ -11,10 +11,11 @@ public class TestMain {
 
     @Test
     public void testDuckDB() {
-        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", SECONDS, "--num-queries", NUM_QUERIES,
-                "duckdb", "--oracle", "NoREC" }));
-        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", SECONDS, "--num-queries", NUM_QUERIES,
-                "duckdb", "--oracle", "QUERY_PARTITIONING" }));
+        // run with one thread due to multithreading issues, see https://github.com/sqlancer/sqlancer/pull/45
+        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", SECONDS, "--num-threads", "1",
+                "--num-queries", NUM_QUERIES, "duckdb", "--oracle", "NoREC" }));
+        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", SECONDS, "--num-threads", "1",
+                "--num-queries", NUM_QUERIES, "duckdb", "--oracle", "QUERY_PARTITIONING" }));
     }
 
 }

--- a/test/sqlancer/TestMain.java
+++ b/test/sqlancer/TestMain.java
@@ -1,5 +1,20 @@
 package sqlancer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
 public class TestMain {
+
+    private static final String NUM_QUERIES = "1000";
+    private static final String SECONDS = "300";
+
+    @Test
+    public void testDuckDB() {
+        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", SECONDS, "--num-queries", NUM_QUERIES,
+                "duckdb", "--oracle", "NoREC" }));
+        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", SECONDS, "--num-queries", NUM_QUERIES,
+                "duckdb", "--oracle", "QUERY_PARTITIONING" }));
+    }
 
 }


### PR DESCRIPTION
Partly addresses https://github.com/sqlancer/sqlancer/issues/3. DuckDB will also run SQLancer as part of the CI, see https://github.com/cwida/duckdb/pull/708.