### PR TITLE
Explicit dependency on ecj

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>plexus-compiler-eclipse</artifactId>
             <version>2.8.6</version>
           </dependency>
+          <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>ecj</artifactId>
+            <version>3.22.0</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>


### PR DESCRIPTION
Closes #67

Eclipse was added as a compiler, but it should be installed as a prerequisite if dependency is not resolved via Maven. I guess it is easier to add package to maven.

There is also a way to allow several build profiles if we want to allow different compilers like here https://stackoverflow.com/questions/33164976/using-eclipse-java-compiler-ecj-in-maven-builds