### PR TITLE
[ClickHouse] implement GROUP BY TLP Oracle.

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -144,11 +144,14 @@ public final class ComparatorHelper {
     public static List<String> getCombinedResultSetNoDuplicates(String firstQueryString, String secondQueryString,
             String thirdQueryString, List<String> combinedString, boolean asUnion, GlobalState<?> state,
             Set<String> errors) throws SQLException {
-        if (!asUnion) {
-            throw new AssertionError();
+        String unionString;
+        if (asUnion) {
+            unionString = firstQueryString + " UNION " + secondQueryString + " UNION " + thirdQueryString;
+        } else {
+            unionString = "SELECT DISTINCT * FROM (" + firstQueryString + " UNION ALL " + secondQueryString
+                    + " UNION ALL " + thirdQueryString + ")";
         }
         List<String> secondResultSet;
-        String unionString = firstQueryString + " UNION " + secondQueryString + " UNION " + thirdQueryString;
         combinedString.add(unionString);
         secondResultSet = getResultSetFirstColumnAsString(unionString, errors, state.getConnection(), state);
         return secondResultSet;

--- a/src/sqlancer/clickhouse/ClickHouseErrors.java
+++ b/src/sqlancer/clickhouse/ClickHouseErrors.java
@@ -28,6 +28,8 @@ public final class ClickHouseErrors {
         errors.add("There is no supertype for types");
         errors.add("Bad get: has Int64, requested UInt64");
         errors.add("Cannot convert string");
+        errors.add("Cannot read floating point value");
+        errors.add("Cannot parse infinity.");
         errors.add("Attempt to read after eof: while converting");
         errors.add("doesn't exist"); // TODO: consecutive test runs can lead to dropped database
         errors.add("is not under aggregate function");

--- a/src/sqlancer/clickhouse/ClickHouseOptions.java
+++ b/src/sqlancer/clickhouse/ClickHouseOptions.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import sqlancer.MainOptions;
 import sqlancer.TestOracle;
+import sqlancer.clickhouse.oracle.tlp.ClickHouseTLPGroupByOracle;
 import sqlancer.clickhouse.oracle.tlp.ClickHouseTLPWhereOracle;
 import sqlancer.clickhouse.oracle.tlp.ClickHouseTLPHavingOracle;
 
@@ -27,7 +28,13 @@ public class ClickHouseOptions extends MainOptions {
                 return new ClickHouseTLPWhereOracle(globalState);
             }
         },
-        HAVING {
+        TLPGroupBy {
+            @Override
+            public TestOracle create(ClickHouseProvider.ClickHouseGlobalState globalState) throws SQLException {
+                return new ClickHouseTLPGroupByOracle(globalState);
+            }
+        },
+        TLPHaving {
             @Override
             public TestOracle create(ClickHouseProvider.ClickHouseGlobalState globalState) throws SQLException {
                 return new ClickHouseTLPHavingOracle(globalState);

--- a/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPGroupByOracle.java
+++ b/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPGroupByOracle.java
@@ -1,0 +1,52 @@
+package sqlancer.clickhouse.oracle.tlp;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.clickhouse.ClickHouseProvider;
+import sqlancer.clickhouse.ClickHouseVisitor;
+import sqlancer.clickhouse.ast.ClickHouseColumnReference;
+import sqlancer.clickhouse.ast.ClickHouseExpression;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ClickHouseTLPGroupByOracle extends ClickHouseTLPBase {
+
+    public ClickHouseTLPGroupByOracle(ClickHouseProvider.ClickHouseGlobalState state) {
+        super(state);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        select.setGroupByClause(select.getFetchColumns());
+        select.setWhereClause(null);
+        String originalQueryString = ClickHouseVisitor.asString(select);
+
+        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
+                state.getConnection(), state);
+
+        select.setWhereClause(predicate);
+        String firstQueryString = ClickHouseVisitor.asString(select);
+        select.setWhereClause(negatedPredicate);
+        String secondQueryString = ClickHouseVisitor.asString(select);
+        select.setWhereClause(isNullPredicate);
+        String thirdQueryString = ClickHouseVisitor.asString(select);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
+                secondQueryString, thirdQueryString, combinedString, false, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
+                state);
+    }
+
+    @Override
+    List<ClickHouseExpression> generateFetchColumns() {
+        List<ClickHouseExpression> columns;
+        columns = Randomly.nonEmptySubset(targetTables.getColumns()).stream()
+                .map(c -> new ClickHouseColumnReference(c, null)).collect(Collectors.toList());
+        return columns;
+    }
+
+}

--- a/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPHavingOracle.java
+++ b/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPHavingOracle.java
@@ -69,7 +69,13 @@ public class ClickHouseTLPHavingOracle extends ClickHouseTLPBase {
             state.getLogger().writeCurrent(combinedString);
         }
         if (new HashSet<>(resultSet).size() != new HashSet<>(secondResultSet).size()) {
-            throw new AssertionError(originalQueryString + ";\n" + combinedString + ";");
+            HashSet<String> diffLeft = new HashSet<>(resultSet);
+            HashSet<String> tmpLeft = new HashSet<>(resultSet);
+            HashSet<String> diffRight = new HashSet<>(secondResultSet);
+            diffLeft.removeAll(diffRight);
+            diffRight.removeAll(tmpLeft);
+            throw new AssertionError(originalQueryString + ";\n" + combinedString + ";\n" + "Left: "
+                    + diffLeft.toString() + "\nRight: " + diffRight.toString());
         }
     }
 }

--- a/test/sqlancer/dbms/TestClickHouse.java
+++ b/test/sqlancer/dbms/TestClickHouse.java
@@ -11,20 +11,18 @@ import sqlancer.dbms.TestConfig;
 public class TestClickHouse {
 
     @Test
-    public void testClickHouseTLPWhereHAVING() {
-
+    public void testClickHouseTLPWhereHaving() {
         String clickHouseAvailable = System.getenv("CLICKHOUSE_AVAILABLE");
         boolean clickHouseIsAvailable = clickHouseAvailable != null && clickHouseAvailable.equalsIgnoreCase("true");
         assumeTrue(clickHouseIsAvailable);
         Assertions.assertEquals(0,
-                Main.executeMain(
-                        new String[] { "--timeout-seconds", TestConfig.SECONDS, "--num-queries", TestConfig.NUM_QUERIES,
-                                "--num-threads", "50", "clickhouse", "--oracle", "TLPWhere", "--oracle", "HAVING" }));
+                Main.executeMain(new String[] { "--timeout-seconds", TestConfig.SECONDS, "--num-queries",
+                        TestConfig.NUM_QUERIES, "--num-threads", "50", "clickhouse", "--oracle", "TLPWhere", "--oracle",
+                        "TLPHaving" }));
     }
 
     @Test
     public void testClickHouseTLPWhere() {
-
         String clickHouseAvailable = System.getenv("CLICKHOUSE_AVAILABLE");
         boolean clickHouseIsAvailable = clickHouseAvailable != null && clickHouseAvailable.equalsIgnoreCase("true");
         assumeTrue(clickHouseIsAvailable);
@@ -39,7 +37,15 @@ public class TestClickHouse {
         boolean clickHouseIsAvailable = clickHouseAvailable != null && clickHouseAvailable.equalsIgnoreCase("true");
         assumeTrue(clickHouseIsAvailable);
         assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", TestConfig.SECONDS, "--num-queries",
-                TestConfig.NUM_QUERIES, "--num-threads", "30", "clickhouse", "--oracle", "HAVING" }));
+                TestConfig.NUM_QUERIES, "--num-threads", "30", "clickhouse", "--oracle", "TLPHaving" }));
     }
 
+    @Test
+    public void testClickHouseTLPGroupBy() {
+        String clickHouseAvailable = System.getenv("CLICKHOUSE_AVAILABLE");
+        boolean clickHouseIsAvailable = clickHouseAvailable != null && clickHouseAvailable.equalsIgnoreCase("true");
+        assumeTrue(clickHouseIsAvailable);
+        assertEquals(0, Main.executeMain(new String[] { "--timeout-seconds", TestConfig.SECONDS, "--num-queries",
+                TestConfig.NUM_QUERIES, "--num-threads", "30", "clickhouse", "--oracle", "TLPGroupBy" }));
+    }
 }


### PR DESCRIPTION
Also added `getCombinedResultSetNoDuplicates` via `UNION ALL` when `UNION` is not supported. Probably DISTINCT here can hide bugs that result in duplicates