### PR TITLE
standardizing logs & current logs across test oracles & within the PostgreSQL implementation

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -85,7 +85,7 @@ public final class ComparatorHelper {
     public static void assumeResultSetsAreEqual(List<String> resultSet, List<String> secondResultSet,
             String originalQueryString, List<String> combinedString, GlobalState<?, ?> state) {
         if (resultSet.size() != secondResultSet.size()) {
-            String queryFormatString = "%s; -- cardinality: %d";
+            String queryFormatString = "-- %s;\n-- cardinality: %d";
             String firstQueryString = String.format(queryFormatString, originalQueryString, resultSet.size());
             String secondQueryString = String.format(queryFormatString,
                     combinedString.stream().collect(Collectors.joining(";")), secondResultSet.size());
@@ -103,12 +103,11 @@ public final class ComparatorHelper {
             firstResultSetMisses.removeAll(secondHashSet);
             Set<String> secondResultSetMisses = new HashSet<>(secondHashSet);
             secondResultSetMisses.removeAll(firstHashSet);
-            String queryFormatString = "--%s;\n-- misses: %s";
+            String queryFormatString = "-- %s;\n-- misses: %s";
             String firstQueryString = String.format(queryFormatString, originalQueryString, firstResultSetMisses);
             String secondQueryString = String.format(queryFormatString,
                     combinedString.stream().collect(Collectors.joining(";")), secondResultSetMisses);
-            state.getState().statements.add(new QueryAdapter(firstQueryString));
-            state.getState().statements.add(new QueryAdapter(secondQueryString));
+            // update the SELECT queries to be logged at the bottom of the error log file
             state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
             String assertionMessage = String.format("the content of the result sets mismatch!\n%s\n%s",
                     firstQueryString, secondQueryString);

--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -89,8 +89,6 @@ public final class ComparatorHelper {
             String firstQueryString = String.format(queryFormatString, originalQueryString, resultSet.size());
             String secondQueryString = String.format(queryFormatString,
                     combinedString.stream().collect(Collectors.joining(";")), secondResultSet.size());
-            state.getState().statements.add(new QueryAdapter(firstQueryString));
-            state.getState().statements.add(new QueryAdapter(secondQueryString));
             state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
             String assertionMessage = String.format("the size of the result sets mismatch (%d and %d)!\n%s\n%s",
                     resultSet.size(), secondResultSet.size(), firstQueryString, secondQueryString);

--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -91,6 +91,7 @@ public final class ComparatorHelper {
                     combinedString.stream().collect(Collectors.joining(";")), secondResultSet.size());
             state.getState().statements.add(new QueryAdapter(firstQueryString));
             state.getState().statements.add(new QueryAdapter(secondQueryString));
+            state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
             String assertionMessage = String.format("the size of the result sets mismatch (%d and %d)!\n%s\n%s",
                     resultSet.size(), secondResultSet.size(), firstQueryString, secondQueryString);
             throw new AssertionError(assertionMessage);
@@ -104,12 +105,13 @@ public final class ComparatorHelper {
             firstResultSetMisses.removeAll(secondHashSet);
             Set<String> secondResultSetMisses = new HashSet<>(secondHashSet);
             secondResultSetMisses.removeAll(firstHashSet);
-            String queryFormatString = "%s; -- misses: %s";
+            String queryFormatString = "--%s;\n-- misses: %s";
             String firstQueryString = String.format(queryFormatString, originalQueryString, firstResultSetMisses);
             String secondQueryString = String.format(queryFormatString,
                     combinedString.stream().collect(Collectors.joining(";")), secondResultSetMisses);
             state.getState().statements.add(new QueryAdapter(firstQueryString));
             state.getState().statements.add(new QueryAdapter(secondQueryString));
+            state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
             String assertionMessage = String.format("the content of the result sets mismatch!\n%s\n%s",
                     firstQueryString, secondQueryString);
             throw new AssertionError(assertionMessage);

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -20,6 +20,11 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
 public class StateToReproduce {
 
     public final List<Query> statements = new ArrayList<>();
+
+    /**
+     * The string printed at the bottom of the error log file, which contains 
+     * the queries that caused the test to fail and information about their results.
+     */
     public String queryString;
 
     private final String databaseName;

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -22,8 +22,8 @@ public class StateToReproduce {
     public final List<Query> statements = new ArrayList<>();
 
     /**
-     * The string printed at the bottom of the error log file, which contains 
-     * the queries that caused the test to fail and information about their results.
+     * The string printed at the bottom of the error log file, which contains the queries that caused the test to fail
+     * and information about their results.
      */
     public String queryString;
 

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -78,9 +78,14 @@ public class PostgresNoRECOracle implements TestOracle {
             throw new IgnoreMeException();
         }
         if (firstCount != secondCount) {
-            state.queryString = firstCount + " " + secondCount + " " + firstQueryString + ";\n" + secondQueryString
-                    + ";";
-            throw new AssertionError(firstQueryString + secondQueryString + firstCount + " " + secondCount);
+            String queryFormatString = "%s; -- count: %d";
+            String firstQueryStringWithCount = String.format(queryFormatString, firstQueryString, firstCount);
+            String secondQueryStringWithCount = String.format(queryFormatString, secondQueryString, secondCount);
+            state.statements.add(new QueryAdapter(firstQueryStringWithCount));
+            state.statements.add(new QueryAdapter(secondQueryStringWithCount));
+            state.queryString = String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount);
+            String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", firstCount, secondCount, firstQueryStringWithCount, secondQueryStringWithCount);
+            throw new AssertionError(assertionMessage);
         }
     }
 

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -81,8 +81,6 @@ public class PostgresNoRECOracle implements TestOracle {
             String queryFormatString = "%s; -- count: %d";
             String firstQueryStringWithCount = String.format(queryFormatString, firstQueryString, firstCount);
             String secondQueryStringWithCount = String.format(queryFormatString, secondQueryString, secondCount);
-            state.statements.add(new QueryAdapter(firstQueryStringWithCount));
-            state.statements.add(new QueryAdapter(secondQueryStringWithCount));
             state.queryString = String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount);
             String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", firstCount, secondCount, firstQueryStringWithCount, secondQueryStringWithCount);
             throw new AssertionError(assertionMessage);

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -62,6 +62,8 @@ public class PostgresNoRECOracle implements TestOracle {
 
     @Override
     public void check() throws SQLException {
+        // clear left-over query string from previous test
+        state.queryString = null;
         PostgresCommon.addCommonExpressionErrors(errors);
         PostgresCommon.addCommonFetchErrors(errors);
         PostgresTables randomTables = s.getRandomTableNonEmptyTables();

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -78,7 +78,7 @@ public class PostgresNoRECOracle implements TestOracle {
             throw new IgnoreMeException();
         }
         if (firstCount != secondCount) {
-            String queryFormatString = "%s; -- count: %d";
+            String queryFormatString = "-- %s;\n-- count: %d";
             String firstQueryStringWithCount = String.format(queryFormatString, firstQueryString, firstCount);
             String secondQueryStringWithCount = String.format(queryFormatString, secondQueryString, secondCount);
             state.queryString = String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount);

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -84,7 +84,8 @@ public class PostgresNoRECOracle implements TestOracle {
             String firstQueryStringWithCount = String.format(queryFormatString, firstQueryString, firstCount);
             String secondQueryStringWithCount = String.format(queryFormatString, secondQueryString, secondCount);
             state.queryString = String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount);
-            String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", firstCount, secondCount, firstQueryStringWithCount, secondQueryStringWithCount);
+            String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", firstCount, secondCount,
+                    firstQueryStringWithCount, secondQueryStringWithCount);
             throw new AssertionError(assertionMessage);
         }
     }

--- a/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
@@ -50,6 +50,8 @@ public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
 
     @Override
     public void check() throws SQLException {
+        // clear left-over query string from previous test
+        state.queryString = null;
         String queryString = getQueryThatContainsAtLeastOneRow(state);
         state.queryString = queryString;
         if (options.logEachSelect()) {

--- a/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
@@ -58,7 +58,7 @@ public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
 
         boolean isContainedIn = isContainedIn(queryString, options, logger);
         if (!isContainedIn) {
-            String assertionMessage = String.format("the query doesn't contain at least 1 row!\n%s", queryString);
+            String assertionMessage = String.format("the query doesn't contain at least 1 row!\n-- %s;", queryString);
             throw new AssertionError(assertionMessage);
         }
 
@@ -175,7 +175,8 @@ public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
             }
         }
         String resultingQueryString = sb.toString();
-        state.queryString = resultingQueryString;
+        // log both SELECT queries at the bottom of the error log file
+        state.queryString = String.format("-- %s;\n-- %s;", queryString, resultingQueryString);
         if (options.logEachSelect()) {
             logger.writeCurrent(resultingQueryString);
         }

--- a/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
@@ -27,7 +27,6 @@ import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
-import sqlancer.QueryAdapter;
 
 public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
 

--- a/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
@@ -27,6 +27,7 @@ import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
+import sqlancer.QueryAdapter;
 
 public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
 
@@ -57,7 +58,9 @@ public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
 
         boolean isContainedIn = isContainedIn(queryString, options, logger);
         if (!isContainedIn) {
-            throw new AssertionError(queryString);
+            state.statements.add(new QueryAdapter(queryString));
+            String assertionMessage = String.format("the query doesn't contain at least 1 row!\n%s", queryString);
+            throw new AssertionError(assertionMessage);
         }
 
     }

--- a/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
@@ -58,7 +58,6 @@ public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
 
         boolean isContainedIn = isContainedIn(queryString, options, logger);
         if (!isContainedIn) {
-            state.statements.add(new QueryAdapter(queryString));
             String assertionMessage = String.format("the query doesn't contain at least 1 row!\n%s", queryString);
             throw new AssertionError(assertionMessage);
         }

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import java.io.IOException;
 import org.postgresql.util.PSQLException;
 
 import sqlancer.ComparatorHelper;
@@ -63,7 +64,7 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
         secondResult = getAggregateResult(metamorphicQuery);
 
-        String queryFormatString = "--%s;\n-- result: %s";
+        String queryFormatString = "-- %s;\n-- result: %s";
         String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
         String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
         state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
@@ -98,6 +99,17 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
     }
 
     private String getAggregateResult(String queryString) throws SQLException {
+        // log TLP Aggregate SELECT queries on the current log file
+        if (state.getOptions().logEachSelect()) {
+            // TODO: refactor me
+            state.getLogger().writeCurrent(queryString);
+            try {
+                state.getLogger().getCurrentFileWriter().flush();
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
         String resultString;
         QueryAdapter q = new QueryAdapter(queryString, errors);
         try (ResultSet result = q.executeAndGet(state)) {

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -66,8 +66,6 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
         String queryFormatString = "--%s;\n-- result: %s";
         String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
         String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
-        state.getState().statements.add(new QueryAdapter(firstQueryString));
-        state.getState().statements.add(new QueryAdapter(secondQueryString));
         state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
         if (firstResult == null && secondResult != null
                 || firstResult != null && (!firstResult.contentEquals(secondResult)

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -74,8 +74,8 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
             if (secondResult.contains("Inf")) {
                 throw new IgnoreMeException(); // FIXME: average computation
             }
-            String assertionMessage = String.format("the results mismatch!\n%s\n%s",
-                    firstQueryString, secondQueryString);
+            String assertionMessage = String.format("the results mismatch!\n%s\n%s", firstQueryString,
+                    secondQueryString);
             throw new AssertionError(assertionMessage);
         }
 

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
@@ -48,6 +48,8 @@ public class PostgresTLPBase implements TestOracle {
 
     @Override
     public void check() throws SQLException {
+        // clear left-over query string from previous test
+        state.getState().queryString = null;
         s = state.getSchema();
         targetTables = s.getRandomTableNonEmptyTables();
         gen = new PostgresExpressionGenerator(state).setColumns(targetTables.getColumns());


### PR DESCRIPTION
Proposed changes:

General:
- Updating the `state.queryString` variable inside ComparatorHelper when the test fails for the other TLP Oracles (in the current scenario, the `state.queryString` is still set to the left-over value from the last TLP Aggregate Oracle testing, so the query printed at the bottom of the log file with preceding "--" is the wrong query)
- Not adding the query string to `state.statements` in `ComparatorHelper` (since `state.queryString` will now be set to the query string, adding the query string to `state.statements` causes the query to be printed twice at the bottom of the log file)
- Standardizing the format of the `state.queryString` and AssertionError messages being printed in `ComparatorHelper`

Postgres:
- Including SELECT queries generated by the Postgres TLP Aggregate Oracle in the "-cur.log" files if the `logEachSelect()` option is on
- Setting `state.queryString` to "null" in the beginning of each test for all oracles in the Postgres implementation, in order to clear the value from the previous test (in the current scenario, if there is an exception in the middle of the test before the results are compared, the `state.queryString` from the previous test is printed at the bottom of the log file)
- Standardizing the format of the `state.queryString` and AssertionError messages being printed