### PR TITLE
Print an execution summary before exiting SQLancer

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -415,6 +415,30 @@ public final class Main {
 
         if (options.printProgressInformation()) {
             startProgressMonitor();
+            if (options.printProgressSummary()) {
+                Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        System.out.println("Overall execution statistics");
+                        System.out.println("============================");
+                        System.out.println(formatInteger(nrQueries.get()) + " queries");
+                        System.out.println(formatInteger(nrDatabases.get()) + " databases");
+                        System.out.println(
+                                formatInteger(nrSuccessfulActions.get()) + " successfully-executed statements");
+                        System.out.println(
+                                formatInteger(nrUnsuccessfulActions.get()) + " unsuccessfuly-executed statements");
+                    }
+
+                    private String formatInteger(long intValue) {
+                        if (intValue > 1000) {
+                            return String.format("%,9dk", intValue / 1000);
+                        } else {
+                            return String.format("%,10d", intValue);
+                        }
+                    }
+                }));
+            }
         }
 
         ExecutorService execService = Executors.newFixedThreadPool(options.getNumberConcurrentThreads());
@@ -499,6 +523,7 @@ public final class Main {
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
+
         return threadsShutdown == 0 ? 0 : options.getErrorExitCode();
     }
 

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -48,6 +48,9 @@ public class MainOptions {
     @Parameter(names = "--print-progress-information", description = "Whether to print progress information such as the number of databases generated or queries issued", arity = 1)
     private boolean printProgressInformation = true; // NOPMD
 
+    @Parameter(names = "--print-progress-summary", description = "Whether to print an execution summary when exiting SQLancer", arity = 1)
+    private boolean printProgressSummary; // NOPMD
+
     @Parameter(names = "--timeout-seconds", description = "The timeout in seconds")
     private int timeoutSeconds = -1; // NOPMD
 
@@ -133,6 +136,10 @@ public class MainOptions {
 
     public boolean printProgressInformation() {
         return printProgressInformation;
+    }
+
+    public boolean printProgressSummary() {
+        return printProgressSummary;
     }
 
     public int getTimeoutSeconds() {


### PR DESCRIPTION
This option is currently disabled by default, since the summary is not very insightful (yet).