### PR TITLE
prevent SQL injection with prepared & filled-in statements

### DIFF
--- a/src/sqlancer/GlobalState.java
+++ b/src/sqlancer/GlobalState.java
@@ -1,6 +1,7 @@
 package sqlancer;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import sqlancer.Main.QueryManager;
@@ -89,7 +90,7 @@ public abstract class GlobalState<O, S> {
         this.databaseName = databaseName;
     }
 
-    public boolean executeStatement(Query q) throws SQLException {
+    public ExecutionTimer executePrologue(Query q) throws SQLException {
         boolean logExecutionTime = getOptions().logExecutionTime();
         ExecutionTimer timer = null;
         if (logExecutionTime) {
@@ -105,7 +106,11 @@ public abstract class GlobalState<O, S> {
                 getLogger().writeCurrent(q.getQueryString());
             }
         }
-        boolean success = manager.execute(q);
+        return timer;
+    }
+
+    public void executeEpilogue(Query q, boolean success, ExecutionTimer timer) throws SQLException {
+        boolean logExecutionTime = getOptions().logExecutionTime();
         if (success && getOptions().printSucceedingStatements()) {
             System.out.println(q.getQueryString());
         }
@@ -115,7 +120,21 @@ public abstract class GlobalState<O, S> {
         if (q.couldAffectSchema()) {
             updateSchema();
         }
+    }
+
+    public boolean executeStatement(Query q, String... fills) throws SQLException {
+        ExecutionTimer timer = executePrologue(q);
+        boolean success = manager.execute(q, fills);
+        executeEpilogue(q, success, timer);
         return success;
+    }
+
+    public ResultSet executeStatementAndGet(Query q, String... fills) throws SQLException {
+        ExecutionTimer timer = executePrologue(q);
+        ResultSet result = manager.executeAndGet(q, fills);
+        boolean success = result != null;
+        executeEpilogue(q, success, timer);
+        return result;
     }
 
     public S getSchema() {

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -8,6 +8,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.text.DateFormat;
@@ -253,11 +254,20 @@ public final class Main {
             this.globalState = globalState;
         }
 
-        public boolean execute(Query q) throws SQLException {
+        public boolean execute(Query q, String... fills) throws SQLException {
             globalState.getState().logStatement(q);
-            boolean success = q.execute(globalState);
+            boolean success;
+            success = q.execute(globalState, fills);
             Main.nrSuccessfulActions.addAndGet(1);
             return success;
+        }
+
+        public ResultSet executeAndGet(Query q, String... fills) throws SQLException {
+            globalState.getState().logStatement(q);
+            ResultSet result;
+            result = q.executeAndGet(globalState, fills);
+            Main.nrSuccessfulActions.addAndGet(1);
+            return result;
         }
 
         public void incrementSelectQueryCount() {

--- a/src/sqlancer/Query.java
+++ b/src/sqlancer/Query.java
@@ -23,7 +23,7 @@ public abstract class Query {
      *
      * @throws SQLException
      */
-    public abstract boolean execute(GlobalState<?, ?> globalState) throws SQLException;
+    public abstract boolean execute(GlobalState<?, ?> globalState, String... fills) throws SQLException;
 
     public abstract Collection<String> getExpectedErrors();
 
@@ -32,7 +32,7 @@ public abstract class Query {
         return getQueryString();
     }
 
-    public ResultSet executeAndGet(GlobalState<?, ?> globalState) throws SQLException {
+    public ResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws SQLException {
         throw new AssertionError();
     }
 

--- a/src/sqlancer/QueryResultCheckAdapter.java
+++ b/src/sqlancer/QueryResultCheckAdapter.java
@@ -15,7 +15,7 @@ public class QueryResultCheckAdapter extends QueryAdapter {
     }
 
     @Override
-    public boolean execute(GlobalState<?, ?> globalState) throws SQLException {
+    public boolean execute(GlobalState<?, ?> globalState, String... fills) throws SQLException {
         try (Statement s = globalState.getConnection().createStatement()) {
             ResultSet rs = s.executeQuery(getQueryString());
             rsChecker.accept(rs);

--- a/src/sqlancer/postgres/gen/PostgresQueryCatalogGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresQueryCatalogGenerator.java
@@ -33,7 +33,7 @@ public final class PostgresQueryCatalogGenerator {
                         "pg_ts_template", "pg_type", "pg_user_mapping"));
         return new QueryAdapter(sb.toString()) {
             @Override
-            public boolean execute(GlobalState<?, ?> globalState) throws SQLException {
+            public boolean execute(GlobalState<?, ?> globalState, String... fills) throws SQLException {
                 try (Statement s = globalState.getConnection().createStatement()) {
                     try (ResultSet rs = s.executeQuery(getQueryString())) {
                         // CHECKSTYLE:OFF

--- a/src/sqlancer/sqlite3/gen/SQLite3VacuumGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3VacuumGenerator.java
@@ -21,7 +21,8 @@ public final class SQLite3VacuumGenerator {
             sb.append(" ");
             sb.append(Randomly.fromOptions("temp", "main"));
         }
-        return new QueryAdapter(sb.toString(), Arrays.asList("cannot VACUUM from within a transaction"));
+        return new QueryAdapter(sb.toString(),
+                Arrays.asList("cannot VACUUM from within a transaction", "cannot VACUUM - SQL statements in progress"));
     }
 
 }


### PR DESCRIPTION
This code allows the option to pass in a template SQL statement and variables to fill in, which prevents [SQL injection](https://www.w3schools.com/sql/sql_injection.asp). It also diversifies the query execution options across classes by including the executeAndGet function in more places.