### PR TITLE
Support Subqueries in Postgres

### DIFF
--- a/src/sqlancer/postgres/PostgresExpectedValueVisitor.java
+++ b/src/sqlancer/postgres/PostgresExpectedValueVisitor.java
@@ -18,6 +18,7 @@ import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
 import sqlancer.postgres.ast.PostgresSimilarTo;
+import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;
 
 public final class PostgresExpectedValueVisitor implements PostgresVisitor {
 
@@ -159,6 +160,11 @@ public final class PostgresExpectedValueVisitor implements PostgresVisitor {
     @Override
     public void visit(PostgresCTE cte) {
         print(cte);
+    }
+
+    @Override
+    public void visit(PostgresTableReference ref) {
+        print(ref);
     }
 
 }

--- a/src/sqlancer/postgres/PostgresExpectedValueVisitor.java
+++ b/src/sqlancer/postgres/PostgresExpectedValueVisitor.java
@@ -16,9 +16,8 @@ import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
-import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
+import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
 import sqlancer.postgres.ast.PostgresSimilarTo;
-import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;
 
 public final class PostgresExpectedValueVisitor implements PostgresVisitor {
 
@@ -158,13 +157,8 @@ public final class PostgresExpectedValueVisitor implements PostgresVisitor {
     }
 
     @Override
-    public void visit(PostgresCTE cte) {
-        print(cte);
-    }
-
-    @Override
-    public void visit(PostgresTableReference ref) {
-        print(ref);
+    public void visit(PostgresSubquery subquery) {
+        print(subquery);
     }
 
 }

--- a/src/sqlancer/postgres/PostgresExpectedValueVisitor.java
+++ b/src/sqlancer/postgres/PostgresExpectedValueVisitor.java
@@ -16,6 +16,7 @@ import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
+import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
 import sqlancer.postgres.ast.PostgresSimilarTo;
 
 public final class PostgresExpectedValueVisitor implements PostgresVisitor {
@@ -153,6 +154,11 @@ public final class PostgresExpectedValueVisitor implements PostgresVisitor {
     @Override
     public void visit(PostgresFromTable from) {
         print(from);
+    }
+
+    @Override
+    public void visit(PostgresCTE cte) {
+        print(cte);
     }
 
 }

--- a/src/sqlancer/postgres/PostgresToStringVisitor.java
+++ b/src/sqlancer/postgres/PostgresToStringVisitor.java
@@ -22,6 +22,7 @@ import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
+import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
 import sqlancer.postgres.ast.PostgresSimilarTo;
 import sqlancer.visitor.ToStringVisitor;
 
@@ -76,6 +77,14 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
     }
 
     @Override
+    public void visit(PostgresCTE cte) {
+        sb.append("(");
+        visit(cte.getSelect());
+        sb.append(") AS ");
+        sb.append(cte.getName());
+    }
+
+    @Override
     public void visit(PostgresSelect s) {
         sb.append("SELECT ");
         switch (s.getSelectOption()) {
@@ -126,7 +135,11 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
                 throw new AssertionError(j.getType());
             }
             sb.append(" ");
-            sb.append(j.getTable().getName());
+            if (j.joinCTE()) {
+                visit(j.getCTE());
+            } else {
+                sb.append(j.getTable().getName());
+            }
             if (j.getType() != PostgresJoinType.CROSS) {
                 sb.append(" ON ");
                 visit(j.getOnClause());

--- a/src/sqlancer/postgres/PostgresToStringVisitor.java
+++ b/src/sqlancer/postgres/PostgresToStringVisitor.java
@@ -15,6 +15,7 @@ import sqlancer.postgres.ast.PostgresFunction;
 import sqlancer.postgres.ast.PostgresInOperation;
 import sqlancer.postgres.ast.PostgresJoin;
 import sqlancer.postgres.ast.PostgresJoin.PostgresJoinType;
+import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;
 import sqlancer.postgres.ast.PostgresOrderByTerm;
 import sqlancer.postgres.ast.PostgresPOSIXRegularExpression;
 import sqlancer.postgres.ast.PostgresPostfixOperation;
@@ -85,6 +86,11 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
     }
 
     @Override
+    public void visit(PostgresTableReference ref) {
+        visit(ref.getTableReference());
+    }
+
+    @Override
     public void visit(PostgresSelect s) {
         sb.append("SELECT ");
         switch (s.getSelectOption()) {
@@ -135,11 +141,7 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
                 throw new AssertionError(j.getType());
             }
             sb.append(" ");
-            if (j.joinCTE()) {
-                visit(j.getCTE());
-            } else {
-                sb.append(j.getTable().getName());
-            }
+            visit(j.getTableReference());
             if (j.getType() != PostgresJoinType.CROSS) {
                 sb.append(" ON ");
                 visit(j.getOnClause());

--- a/src/sqlancer/postgres/PostgresToStringVisitor.java
+++ b/src/sqlancer/postgres/PostgresToStringVisitor.java
@@ -15,7 +15,6 @@ import sqlancer.postgres.ast.PostgresFunction;
 import sqlancer.postgres.ast.PostgresInOperation;
 import sqlancer.postgres.ast.PostgresJoin;
 import sqlancer.postgres.ast.PostgresJoin.PostgresJoinType;
-import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;
 import sqlancer.postgres.ast.PostgresOrderByTerm;
 import sqlancer.postgres.ast.PostgresPOSIXRegularExpression;
 import sqlancer.postgres.ast.PostgresPostfixOperation;
@@ -23,7 +22,7 @@ import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
-import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
+import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
 import sqlancer.postgres.ast.PostgresSimilarTo;
 import sqlancer.visitor.ToStringVisitor;
 
@@ -78,16 +77,11 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
     }
 
     @Override
-    public void visit(PostgresCTE cte) {
+    public void visit(PostgresSubquery subquery) {
         sb.append("(");
-        visit(cte.getSelect());
+        visit(subquery.getSelect());
         sb.append(") AS ");
-        sb.append(cte.getName());
-    }
-
-    @Override
-    public void visit(PostgresTableReference ref) {
-        visit(ref.getTableReference());
+        sb.append(subquery.getName());
     }
 
     @Override

--- a/src/sqlancer/postgres/PostgresVisitor.java
+++ b/src/sqlancer/postgres/PostgresVisitor.java
@@ -20,6 +20,7 @@ import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
+import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
 import sqlancer.postgres.ast.PostgresSimilarTo;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
 
@@ -57,6 +58,8 @@ public interface PostgresVisitor {
 
     void visit(PostgresFromTable from);
 
+    void visit(PostgresCTE cte);
+
     default void visit(PostgresExpression expression) {
         if (expression instanceof PostgresConstant) {
             visit((PostgresConstant) expression);
@@ -90,6 +93,8 @@ public interface PostgresVisitor {
             visit((PostgresCollate) expression);
         } else if (expression instanceof PostgresFromTable) {
             visit((PostgresFromTable) expression);
+        } else if (expression instanceof PostgresCTE) {
+            visit((PostgresCTE) expression);
         } else {
             throw new AssertionError(expression);
         }

--- a/src/sqlancer/postgres/PostgresVisitor.java
+++ b/src/sqlancer/postgres/PostgresVisitor.java
@@ -20,10 +20,9 @@ import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
-import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
+import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
 import sqlancer.postgres.ast.PostgresSimilarTo;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
-import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;;
 
 public interface PostgresVisitor {
 
@@ -59,9 +58,7 @@ public interface PostgresVisitor {
 
     void visit(PostgresFromTable from);
 
-    void visit(PostgresCTE cte);
-
-    void visit(PostgresTableReference ref);
+    void visit(PostgresSubquery subquery);
 
     default void visit(PostgresExpression expression) {
         if (expression instanceof PostgresConstant) {
@@ -96,10 +93,8 @@ public interface PostgresVisitor {
             visit((PostgresCollate) expression);
         } else if (expression instanceof PostgresFromTable) {
             visit((PostgresFromTable) expression);
-        } else if (expression instanceof PostgresCTE) {
-            visit((PostgresCTE) expression);
-        } else if (expression instanceof PostgresTableReference) {
-            visit((PostgresTableReference) expression);
+        } else if (expression instanceof PostgresSubquery) {
+            visit((PostgresSubquery) expression);
         } else {
             throw new AssertionError(expression);
         }

--- a/src/sqlancer/postgres/PostgresVisitor.java
+++ b/src/sqlancer/postgres/PostgresVisitor.java
@@ -23,6 +23,7 @@ import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
 import sqlancer.postgres.ast.PostgresSimilarTo;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
+import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;;
 
 public interface PostgresVisitor {
 
@@ -60,6 +61,8 @@ public interface PostgresVisitor {
 
     void visit(PostgresCTE cte);
 
+    void visit(PostgresTableReference ref);
+
     default void visit(PostgresExpression expression) {
         if (expression instanceof PostgresConstant) {
             visit((PostgresConstant) expression);
@@ -95,6 +98,8 @@ public interface PostgresVisitor {
             visit((PostgresFromTable) expression);
         } else if (expression instanceof PostgresCTE) {
             visit((PostgresCTE) expression);
+        } else if (expression instanceof PostgresTableReference) {
+            visit((PostgresTableReference) expression);
         } else {
             throw new AssertionError(expression);
         }

--- a/src/sqlancer/postgres/ast/PostgresJoin.java
+++ b/src/sqlancer/postgres/ast/PostgresJoin.java
@@ -4,6 +4,7 @@ import sqlancer.Randomly;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
+import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 
 public class PostgresJoin implements PostgresExpression {
 
@@ -16,34 +17,36 @@ public class PostgresJoin implements PostgresExpression {
 
     }
 
-    private final PostgresTable table;
+    private final PostgresTableReference tableReference;
     private final PostgresExpression onClause;
     private final PostgresJoinType type;
-    private PostgresCTE CTE = null;
 
-    public PostgresJoin(PostgresTable table, PostgresExpression onClause, PostgresJoinType type) {
-        this.table = table;
+    public static class PostgresTableReference implements PostgresExpression {
+
+        private final PostgresExpression tableReference;
+
+        public PostgresTableReference(PostgresCTE cte) {
+            this.tableReference = cte;
+        }
+
+        public PostgresTableReference(PostgresTable table) {
+            this.tableReference = new PostgresFromTable(table, Randomly.getBoolean());
+        }
+
+        public PostgresExpression getTableReference() {
+            return tableReference;
+        }
+
+    }
+
+    public PostgresJoin(PostgresTableReference tableReference, PostgresExpression onClause, PostgresJoinType type) {
+        this.tableReference = tableReference;
         this.onClause = onClause;
         this.type = type;
     }
 
-    public PostgresJoin(PostgresCTE CTE, PostgresExpression onClause, PostgresJoinType type) {
-        this.CTE = CTE;
-        this.onClause = onClause;
-        this.type = type;
-        this.table = null;
-    }
-
-    public PostgresTable getTable() {
-        return table;
-    }
-
-    public PostgresCTE getCTE() {
-        return CTE;
-    }
-
-    public boolean joinCTE() {
-        return (CTE != null);
+    public PostgresTableReference getTableReference() {
+        return tableReference;
     }
 
     public PostgresExpression getOnClause() {

--- a/src/sqlancer/postgres/ast/PostgresJoin.java
+++ b/src/sqlancer/postgres/ast/PostgresJoin.java
@@ -2,9 +2,6 @@ package sqlancer.postgres.ast;
 
 import sqlancer.Randomly;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
-import sqlancer.postgres.PostgresSchema.PostgresTable;
-import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
-import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 
 public class PostgresJoin implements PostgresExpression {
 
@@ -17,35 +14,17 @@ public class PostgresJoin implements PostgresExpression {
 
     }
 
-    private final PostgresTableReference tableReference;
+    private final PostgresExpression tableReference;
     private final PostgresExpression onClause;
     private final PostgresJoinType type;
 
-    public static class PostgresTableReference implements PostgresExpression {
-
-        private final PostgresExpression tableReference;
-
-        public PostgresTableReference(PostgresCTE cte) {
-            this.tableReference = cte;
-        }
-
-        public PostgresTableReference(PostgresTable table) {
-            this.tableReference = new PostgresFromTable(table, Randomly.getBoolean());
-        }
-
-        public PostgresExpression getTableReference() {
-            return tableReference;
-        }
-
-    }
-
-    public PostgresJoin(PostgresTableReference tableReference, PostgresExpression onClause, PostgresJoinType type) {
+    public PostgresJoin(PostgresExpression tableReference, PostgresExpression onClause, PostgresJoinType type) {
         this.tableReference = tableReference;
         this.onClause = onClause;
         this.type = type;
     }
 
-    public PostgresTableReference getTableReference() {
+    public PostgresExpression getTableReference() {
         return tableReference;
     }
 

--- a/src/sqlancer/postgres/ast/PostgresJoin.java
+++ b/src/sqlancer/postgres/ast/PostgresJoin.java
@@ -3,6 +3,7 @@ package sqlancer.postgres.ast;
 import sqlancer.Randomly;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
+import sqlancer.postgres.ast.PostgresSelect.PostgresCTE;
 
 public class PostgresJoin implements PostgresExpression {
 
@@ -18,6 +19,7 @@ public class PostgresJoin implements PostgresExpression {
     private final PostgresTable table;
     private final PostgresExpression onClause;
     private final PostgresJoinType type;
+    private PostgresCTE CTE = null;
 
     public PostgresJoin(PostgresTable table, PostgresExpression onClause, PostgresJoinType type) {
         this.table = table;
@@ -25,8 +27,23 @@ public class PostgresJoin implements PostgresExpression {
         this.type = type;
     }
 
+    public PostgresJoin(PostgresCTE CTE, PostgresExpression onClause, PostgresJoinType type) {
+        this.CTE = CTE;
+        this.onClause = onClause;
+        this.type = type;
+        this.table = null;
+    }
+
     public PostgresTable getTable() {
         return table;
+    }
+
+    public PostgresCTE getCTE() {
+        return CTE;
+    }
+
+    public boolean joinCTE() {
+        return (CTE != null);
     }
 
     public PostgresExpression getOnClause() {

--- a/src/sqlancer/postgres/ast/PostgresSelect.java
+++ b/src/sqlancer/postgres/ast/PostgresSelect.java
@@ -56,11 +56,11 @@ public class PostgresSelect extends SelectBase<PostgresExpression> implements Po
         }
     }
 
-    public static class PostgresCTE implements PostgresExpression {
+    public static class PostgresSubquery implements PostgresExpression {
         private final PostgresSelect s;
         private final String name;
 
-        public PostgresCTE(PostgresSelect s, String name) {
+        public PostgresSubquery(PostgresSelect s, String name) {
             this.s = s;
             this.name = name;
         }

--- a/src/sqlancer/postgres/ast/PostgresSelect.java
+++ b/src/sqlancer/postgres/ast/PostgresSelect.java
@@ -56,6 +56,29 @@ public class PostgresSelect extends SelectBase<PostgresExpression> implements Po
         }
     }
 
+    public static class PostgresCTE implements PostgresExpression {
+        private final PostgresSelect s;
+        private final String name;
+
+        public PostgresCTE(PostgresSelect s, String name) {
+            this.s = s;
+            this.name = name;
+        }
+
+        public PostgresSelect getSelect() {
+            return s;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public PostgresDataType getExpressionType() {
+            return null;
+        }
+    }
+
     public enum SelectType {
         DISTINCT, ALL;
 

--- a/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
@@ -91,7 +91,7 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         return new PostgresExpressionGenerator(globalState).generateExpression(0);
     }
 
-    PostgresExpression generateExpression(int depth) {
+    public PostgresExpression generateExpression(int depth) {
         return generateExpression(depth, PostgresDataType.getRandomType());
     }
 

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -27,6 +27,7 @@ import sqlancer.postgres.ast.PostgresColumnValue;
 import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresJoin;
 import sqlancer.postgres.ast.PostgresJoin.PostgresJoinType;
+import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;
 import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
@@ -83,7 +84,7 @@ public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implemen
             PostgresTable table = Randomly.fromList(tables);
             tables.remove(table);
             PostgresJoinType options = PostgresJoinType.getRandom();
-            PostgresJoin j = new PostgresJoin(table, joinClause, options);
+            PostgresJoin j = new PostgresJoin(new PostgresTableReference(table), joinClause, options);
             joinStatements.add(j);
         }
         return joinStatements;

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -27,13 +27,14 @@ import sqlancer.postgres.ast.PostgresColumnValue;
 import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresJoin;
 import sqlancer.postgres.ast.PostgresJoin.PostgresJoinType;
-import sqlancer.postgres.ast.PostgresJoin.PostgresTableReference;
 import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
+import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
 import sqlancer.postgres.ast.PostgresSelect.SelectType;
 import sqlancer.postgres.gen.PostgresCommon;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
+import sqlancer.postgres.oracle.tlp.PostgresTLPBase;
 
 public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implements TestOracle {
 
@@ -84,7 +85,15 @@ public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implemen
             PostgresTable table = Randomly.fromList(tables);
             tables.remove(table);
             PostgresJoinType options = PostgresJoinType.getRandom();
-            PostgresJoin j = new PostgresJoin(new PostgresTableReference(table), joinClause, options);
+            PostgresJoin j = new PostgresJoin(new PostgresFromTable(table, Randomly.getBoolean()), joinClause, options);
+            joinStatements.add(j);
+        }
+        // JOIN subqueries
+        for (int i = 0; i < Randomly.smallNumber(); i++) {
+            PostgresSubquery subquery = PostgresTLPBase.createSubquery(globalState, String.format("sub%d", i));
+            PostgresExpression joinClause = gen.generateExpression(PostgresDataType.BOOLEAN);
+            PostgresJoinType options = PostgresJoinType.getRandom();
+            PostgresJoin j = new PostgresJoin(subquery, joinClause, options);
             joinStatements.add(j);
         }
         return joinStatements;

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
@@ -72,7 +72,7 @@ public class PostgresTLPBase extends TernaryLogicPartitioningOracleBase<Postgres
         return gen;
     }
 
-    public static PostgresCTE createCTE(PostgresGlobalState globalState, PostgresTables tables) {
+    public static PostgresCTE createSubquery(PostgresGlobalState globalState, PostgresTables tables) {
         PostgresExpressionGenerator gen = new PostgresExpressionGenerator(globalState).setColumns(tables.getColumns());
         PostgresSelect selectCTE = new PostgresSelect();
         selectCTE.setFromList(tables.getTables().stream().map(t -> new PostgresFromTable(t, Randomly.getBoolean()))


### PR DESCRIPTION
This PR implements support for subqueries for the PostgreSQL implementation, as well as add a function to create subqueries in the PostgresTLPBase class, which can be called as desired.