### PR TITLE
Implement a local state class and replace the queryString in the state

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -89,7 +89,7 @@ public final class ComparatorHelper {
             String firstQueryString = String.format(queryFormatString, originalQueryString, resultSet.size());
             String secondQueryString = String.format(queryFormatString,
                     combinedString.stream().collect(Collectors.joining(";")), secondResultSet.size());
-            state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
+            state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
             String assertionMessage = String.format("the size of the result sets mismatch (%d and %d)!\n%s\n%s",
                     resultSet.size(), secondResultSet.size(), firstQueryString, secondQueryString);
             throw new AssertionError(assertionMessage);
@@ -108,7 +108,7 @@ public final class ComparatorHelper {
             String secondQueryString = String.format(queryFormatString,
                     combinedString.stream().collect(Collectors.joining(";")), secondResultSetMisses);
             // update the SELECT queries to be logged at the bottom of the error log file
-            state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
+            state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
             String assertionMessage = String.format("the content of the result sets mismatch!\n%s\n%s",
                     firstQueryString, secondQueryString);
             throw new AssertionError(assertionMessage);

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -233,9 +233,6 @@ public final class Main {
                 }
                 sb.append('\n');
             }
-            if (state.getQueryString() != null) {
-                sb.append(state.getQueryString() + ";\n");
-            }
             try {
                 writer.write(sb.toString());
             } catch (IOException e) {

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -1,5 +1,6 @@
 package sqlancer;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -22,12 +23,6 @@ public class StateToReproduce {
 
     private final List<Query> statements = new ArrayList<>();
 
-    /**
-     * The string printed at the bottom of the error log file, which contains the queries that caused the test to fail
-     * and information about their results.
-     */
-    public String queryString;
-
     private final String databaseName;
 
     public String databaseVersion;
@@ -41,6 +36,8 @@ public class StateToReproduce {
     public String queryTargetedTablesString;
 
     public String queryTargetedColumnsString;
+
+    public OracleRunReproductionState localState;
 
     public StateToReproduce(String databaseName) {
         this.databaseName = databaseName;
@@ -88,12 +85,18 @@ public class StateToReproduce {
         return Collections.unmodifiableList(statements);
     }
 
-    public String getQueryString() {
-        return queryString;
-    }
-
     public long getSeedValue() {
         return seedValue;
+    }
+
+    /**
+     * Returns a local state in which a test oracle can save useful information about a single run. If the local state
+     * is closed without indicating access to it, the local statements will be added to the global state.
+     *
+     * @return
+     */
+    public OracleRunReproductionState getLocalState() {
+        return localState;
     }
 
     public static class MySQLStateToReproduce extends StateToReproduce {
@@ -179,6 +182,45 @@ public class StateToReproduce {
             return whereClause;
         }
 
+    }
+
+    /**
+     * State information that is logged if the test oracle finds a bug or if an exception is thrown.
+     */
+    public class OracleRunReproductionState implements Closeable {
+
+        private final List<Query> statements = new ArrayList<>();
+
+        public boolean success;
+
+        public OracleRunReproductionState() {
+            StateToReproduce.this.localState = this;
+        }
+
+        public void executedWithoutError() {
+            this.success = true;
+        }
+
+        public void log(Query q) {
+            statements.add(q);
+        }
+
+        public void log(String s) {
+            statements.add(new QueryAdapter(s));
+        }
+
+        @Override
+        public void close() {
+            if (!success) {
+                StateToReproduce.this.statements.addAll(statements);
+            }
+
+        }
+
+    }
+
+    public OracleRunReproductionState createLocalState() {
+        return new OracleRunReproductionState();
     }
 
 }

--- a/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPAggregateOracle.java
+++ b/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPAggregateOracle.java
@@ -89,8 +89,8 @@ public class ClickHouseTLPAggregateOracle implements TestOracle {
             // TODO
             throw new IgnoreMeException();
         }
-        state.getState().queryString = "--" + originalQuery + "\n--" + metamorphicText + "\n-- " + firstResult + "\n-- "
-                + secondResult;
+        state.getState().getLocalState()
+                .log("--" + originalQuery + "\n--" + metamorphicText + "\n-- " + firstResult + "\n-- " + secondResult);
         if ((firstResult == null && secondResult != null
                 || firstResult != null && !firstResult.contentEquals(secondResult))
                 && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {

--- a/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
@@ -60,7 +60,7 @@ public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState> im
             throw new IgnoreMeException();
         }
         if (optimizableCount != nonOptimizableCount) {
-            state.getState().queryString = optimizedQueryString + ";\n" + unoptimizedQueryString + ";";
+            state.getState().getLocalState().log(optimizedQueryString + ";\n" + unoptimizedQueryString + ";");
             throw new AssertionError(CockroachDBVisitor.asString(whereCondition));
         }
     }

--- a/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
@@ -84,8 +84,8 @@ public class CockroachDBTLPAggregateOracle implements TestOracle {
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, from);
         secondResult = getAggregateResult(metamorphicQuery);
 
-        state.getState().queryString = "--" + originalQuery + ";\n--" + metamorphicQuery + "\n-- " + firstResult
-                + "\n-- " + secondResult;
+        state.getState().getLocalState().log(
+                "--" + originalQuery + ";\n--" + metamorphicQuery + "\n-- " + firstResult + "\n-- " + secondResult);
         if (firstResult == null && secondResult != null
                 || firstResult != null && (!firstResult.contentEquals(secondResult)
                         && !ComparatorHelper.isEqualDouble(firstResult, secondResult))) {

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
@@ -64,8 +64,8 @@ public class DuckDBQueryPartitioningAggregateTester extends DuckDBQueryPartition
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
         secondResult = getAggregateResult(metamorphicQuery);
 
-        state.getState().queryString = "--" + originalQuery + ";\n--" + metamorphicQuery + "\n-- " + firstResult
-                + "\n-- " + secondResult;
+        state.getState().getLocalState().log(
+                "--" + originalQuery + ";\n--" + metamorphicQuery + "\n-- " + firstResult + "\n-- " + secondResult);
         if (firstResult == null && secondResult != null
                 || firstResult != null && (!firstResult.contentEquals(secondResult)
                         && !ComparatorHelper.isEqualDouble(firstResult, secondResult))) {

--- a/src/sqlancer/mariadb/oracle/MariaDBNoRECOracle.java
+++ b/src/sqlancer/mariadb/oracle/MariaDBNoRECOracle.java
@@ -63,7 +63,7 @@ public class MariaDBNoRECOracle extends NoRECBase<MariaDBGlobalState> implements
             throw new IgnoreMeException();
         }
         if (optimizedCount != unoptimizedCount) {
-            state.getState().queryString = optimizedQueryString + ";\n" + unoptimizedQueryString + ";";
+            state.getState().getLocalState().log(optimizedQueryString + ";\n" + unoptimizedQueryString + ";");
             throw new AssertionError(optimizedCount + " " + unoptimizedCount);
         }
     }

--- a/src/sqlancer/mysql/oracle/MySQLPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/mysql/oracle/MySQLPivotedQuerySynthesisOracle.java
@@ -219,7 +219,7 @@ public class MySQLPivotedQuerySynthesisOracle implements TestOracle {
         }
 
         String resultingQueryString = sb.toString();
-        state.queryString = resultingQueryString;
+        state.getLocalState().log(resultingQueryString);
         if (globalState.getOptions().logEachSelect()) {
             globalState.getLogger().writeCurrent(resultingQueryString);
         }

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -49,8 +49,6 @@ public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implemen
 
     @Override
     public void check() throws SQLException {
-        // clear left-over query string from previous test
-        state.getState().queryString = null;
         PostgresTables randomTables = s.getRandomTableNonEmptyTables();
         List<PostgresColumn> columns = randomTables.getColumns();
         PostgresExpression randomWhereCondition = getRandomWhereCondition(columns);
@@ -68,8 +66,8 @@ public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implemen
             String queryFormatString = "-- %s;\n-- count: %d";
             String firstQueryStringWithCount = String.format(queryFormatString, optimizedQueryString, firstCount);
             String secondQueryStringWithCount = String.format(queryFormatString, unoptimizedQueryString, secondCount);
-            state.getState().queryString = String.format("%s\n%s", firstQueryStringWithCount,
-                    secondQueryStringWithCount);
+            state.getState().getLocalState()
+                    .log(String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount));
             String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", firstCount, secondCount,
                     firstQueryStringWithCount, secondQueryStringWithCount);
             throw new AssertionError(assertionMessage);

--- a/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresPivotedQuerySynthesisOracle.java
@@ -49,12 +49,10 @@ public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
 
     @Override
     public void check() throws SQLException {
-        // clear left-over query string from previous test
-        state.queryString = null;
         String queryString = getQueryThatContainsAtLeastOneRow(state);
-        state.queryString = queryString;
+        state.getLocalState().log(queryString);
         if (options.logEachSelect()) {
-            logger.writeCurrent(state.queryString);
+            logger.writeCurrent(queryString);
         }
 
         boolean isContainedIn = isContainedIn(queryString, options, logger);
@@ -179,7 +177,7 @@ public class PostgresPivotedQuerySynthesisOracle implements TestOracle {
         }
         String resultingQueryString = sb.toString();
         // log both SELECT queries at the bottom of the error log file
-        state.queryString = String.format("-- %s;\n-- %s;", queryString, resultingQueryString);
+        state.getLocalState().log(String.format("-- %s;\n-- %s;", queryString, resultingQueryString));
         if (options.logEachSelect()) {
             logger.writeCurrent(resultingQueryString);
         }

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -67,7 +67,7 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
         String queryFormatString = "-- %s;\n-- result: %s";
         String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
         String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
-        state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
+        state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
         if (firstResult == null && secondResult != null || firstResult != null && secondResult == null
                 || firstResult != null && !firstResult.contentEquals(secondResult)
                         && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
@@ -44,8 +44,6 @@ public class PostgresTLPBase extends TernaryLogicPartitioningOracleBase<Postgres
 
     @Override
     public void check() throws SQLException {
-        // clear left-over query string from previous test
-        state.getState().queryString = null;
         s = state.getSchema();
         targetTables = s.getRandomTableNonEmptyTables();
         gen = new PostgresExpressionGenerator(state).setColumns(targetTables.getColumns());

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -68,7 +68,7 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
             throw new IgnoreMeException();
         }
         if (optimizedCount != unoptimizedCount) {
-            state.getState().queryString = optimizedQueryString + ";\n" + unoptimizedQueryString + ";";
+            state.getState().getLocalState().log(optimizedQueryString + ";\n" + unoptimizedQueryString + ";");
             throw new AssertionError(optimizedCount + " " + unoptimizedCount);
         }
 

--- a/src/sqlancer/sqlite3/oracle/SQLite3PivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3PivotedQuerySynthesisOracle.java
@@ -232,7 +232,7 @@ public class SQLite3PivotedQuerySynthesisOracle implements TestOracle {
         sb.append(query.getQueryString());
         sb.append(")");
         String resultingQueryString = sb.toString();
-        state.queryString = resultingQueryString;
+        state.getLocalState().log(resultingQueryString);
         Query finalQuery = new QueryAdapter(resultingQueryString, query.getExpectedErrors());
         try (ResultSet result = createStatement.executeQuery(finalQuery.getQueryString())) {
             boolean isContainedIn = !result.isClosed();

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
@@ -95,8 +95,8 @@ public class SQLite3TLPAggregateOracle implements TestOracle {
             // TODO
             throw new IgnoreMeException();
         }
-        state.getState().queryString = "--" + originalQuery + "\n--" + metamorphicText + "\n-- " + firstResult + "\n-- "
-                + secondResult;
+        state.getState().getLocalState()
+                .log("--" + originalQuery + "\n--" + metamorphicText + "\n-- " + firstResult + "\n-- " + secondResult);
         if ((firstResult == null && secondResult != null
                 || firstResult != null && !firstResult.contentEquals(secondResult))
                 && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {


### PR DESCRIPTION
The idea behind this PR is to have a local state object that lives only for one call to the `check()` method in the `TestOracle`. The test oracle can add information that is relevant only if the oracle detects an error of throws an exception, in which case the statements are added to the `StateToReproduce` statements, which are subsequently written to the log file.

@nukoyluoglu, do you have any feedback since you recently improved the logging logic?