### PR TITLE
Add option to specify connection URL

### DIFF
--- a/src/sqlancer/postgres/PostgresOptions.java
+++ b/src/sqlancer/postgres/PostgresOptions.java
@@ -28,6 +28,9 @@ public class PostgresOptions {
     @Parameter(names = "--test-collations", arity = 1)
     public boolean testCollations = true;
 
+    @Parameter(names = "--connection-url")
+    public String connectionURL = "postgresql://localhost:5432/test";
+
     public enum PostgresOracle {
         NOREC {
             @Override


### PR DESCRIPTION
This PR adds the option for the user to specify the initial connection URL in the Postgres implementation. This allows more flexibility in connecting with different users, hosts, ports, and optional connection parameters. The logging also includes the full URL instead of only the database name. The provided URL is checked for correct format, and parsed. If a username and password is specified in the URL, these overwrite the username and password set by the MainOptions (with sqlancer as default). When calling DriverManager to get connection, the username and password are removed from the URL string to avoid confusion.