### PR TITLE
Fix in comparing table columns

### DIFF
--- a/src/sqlancer/schema/AbstractTableColumn.java
+++ b/src/sqlancer/schema/AbstractTableColumn.java
@@ -52,7 +52,10 @@ public class AbstractTableColumn<T extends AbstractTable<?, ?>, U> implements Co
         } else {
             @SuppressWarnings("unchecked")
             AbstractTableColumn<T, U> c = (AbstractTableColumn<T, U>) obj;
-            return table.getName().contentEquals(getName()) && getName().equals(c.getName());
+            if (c.getTable() == null) {
+                return getName().equals(c.getName());
+            }
+            return table.getName().contentEquals(c.getTable().getName()) && getName().equals(c.getName());
         }
     }
 


### PR DESCRIPTION
Currently, the method used to compare AbstractTableColumns a) assumes that the column was initiated with a specified (which is not always the case, see PostgresColumn constructer), and b) incorrectly compares between table name and column name (on the line `table.getName().contentEquals(getName())`). This is a fix for both of these problems.