### PR TITLE
Check for null second result in PostgresTLPAggregateOracle

### DIFF
--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -68,10 +68,10 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
         String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
         String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
         state.getState().queryString = String.format("%s\n%s", firstQueryString, secondQueryString);
-        if (firstResult == null && secondResult != null
-                || firstResult != null && (!firstResult.contentEquals(secondResult)
-                        && !ComparatorHelper.isEqualDouble(firstResult, secondResult))) {
-            if (secondResult.contains("Inf")) {
+        if (firstResult == null && secondResult != null || firstResult != null && secondResult == null
+                || firstResult != null && !firstResult.contentEquals(secondResult)
+                        && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
+            if (secondResult != null && secondResult.contains("Inf")) {
                 throw new IgnoreMeException(); // FIXME: average computation
             }
             String assertionMessage = String.format("the results mismatch!\n%s\n%s", firstQueryString,


### PR DESCRIPTION
Currently, the code only checks whether the first result fetched by the TLP Aggregate Oracle is null. This misses the case where the second case could be null and cause nullpointer errors.