### PR TITLE
Introduce a wrapped result set

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -1,7 +1,6 @@
 package sqlancer;
 
 import java.io.IOException;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -46,7 +45,7 @@ public final class ComparatorHelper {
         }
         QueryAdapter q = new QueryAdapter(queryString, errors);
         List<String> resultSet = new ArrayList<>();
-        ResultSet result = null;
+        SQLancerResultSet result = null;
         try {
             result = q.executeAndGet(state);
             if (result == null) {
@@ -55,7 +54,6 @@ public final class ComparatorHelper {
             while (result.next()) {
                 resultSet.add(result.getString(1));
             }
-            result.getStatement().close();
         } catch (Exception e) {
             if (e instanceof IgnoreMeException) {
                 throw e;
@@ -75,7 +73,6 @@ public final class ComparatorHelper {
             throw new AssertionError(queryString, e);
         } finally {
             if (result != null && !result.isClosed()) {
-                result.getStatement().close();
                 result.close();
             }
         }

--- a/src/sqlancer/GlobalState.java
+++ b/src/sqlancer/GlobalState.java
@@ -1,7 +1,6 @@
 package sqlancer;
 
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import sqlancer.Main.QueryManager;
@@ -129,11 +128,19 @@ public abstract class GlobalState<O, S> {
         return success;
     }
 
-    public ResultSet executeStatementAndGet(Query q, String... fills) throws SQLException {
+    public SQLancerResultSet executeStatementAndGet(Query q, String... fills) throws SQLException {
         ExecutionTimer timer = executePrologue(q);
-        ResultSet result = manager.executeAndGet(q, fills);
+        SQLancerResultSet result = manager.executeAndGet(q, fills);
         boolean success = result != null;
-        executeEpilogue(q, success, timer);
+        if (success) {
+            result.registerEpilogue(() -> {
+                try {
+                    executeEpilogue(q, success, timer);
+                } catch (SQLException e) {
+                    throw new AssertionError(e);
+                }
+            });
+        }
         return result;
     }
 

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -8,7 +8,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.text.DateFormat;
@@ -260,9 +259,9 @@ public final class Main {
             return success;
         }
 
-        public ResultSet executeAndGet(Query q, String... fills) throws SQLException {
+        public SQLancerResultSet executeAndGet(Query q, String... fills) throws SQLException {
             globalState.getState().logStatement(q);
-            ResultSet result;
+            SQLancerResultSet result;
             result = q.executeAndGet(globalState, fills);
             Main.nrSuccessfulActions.addAndGet(1);
             return result;

--- a/src/sqlancer/Query.java
+++ b/src/sqlancer/Query.java
@@ -1,6 +1,5 @@
 package sqlancer;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 
@@ -32,7 +31,7 @@ public abstract class Query {
         return getQueryString();
     }
 
-    public ResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws SQLException {
+    public SQLancerResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws SQLException {
         throw new AssertionError();
     }
 
@@ -41,7 +40,7 @@ public abstract class Query {
         return execute(globalState);
     }
 
-    public ResultSet executeAndGetLogged(GlobalState<?, ?> globalState) throws SQLException {
+    public SQLancerResultSet executeAndGetLogged(GlobalState<?, ?> globalState) throws SQLException {
         logQueryString(globalState);
         return executeAndGet(globalState);
     }

--- a/src/sqlancer/QueryAdapter.java
+++ b/src/sqlancer/QueryAdapter.java
@@ -97,7 +97,7 @@ public class QueryAdapter extends Query {
     }
 
     @Override
-    public ResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws SQLException {
+    public SQLancerResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws SQLException {
         Statement s;
         if (fills.length > 0) {
             s = globalState.getConnection().prepareStatement(getQueryString());
@@ -115,7 +115,10 @@ public class QueryAdapter extends Query {
                 result = s.executeQuery(query);
             }
             Main.nrSuccessfulActions.addAndGet(1);
-            return result;
+            if (result == null) {
+                return null;
+            }
+            return new SQLancerResultSet(result);
         } catch (Exception e) {
             s.close();
             Main.nrUnsuccessfulActions.addAndGet(1);

--- a/src/sqlancer/SQLancerResultSet.java
+++ b/src/sqlancer/SQLancerResultSet.java
@@ -1,0 +1,53 @@
+package sqlancer;
+
+import java.io.Closeable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SQLancerResultSet implements Closeable {
+
+    ResultSet rs;
+    private Runnable runnableEpilogue;
+
+    public SQLancerResultSet(ResultSet rs) {
+        this.rs = rs;
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (runnableEpilogue != null) {
+                runnableEpilogue.run();
+            }
+            rs.getStatement().close();
+            rs.close();
+        } catch (SQLException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public boolean next() throws SQLException {
+        return rs.next();
+    }
+
+    public int getInt(int i) throws SQLException {
+        return rs.getInt(i);
+    }
+
+    public String getString(int i) throws SQLException {
+        return rs.getString(i);
+    }
+
+    public boolean isClosed() throws SQLException {
+        return rs.isClosed();
+    }
+
+    public long getLong(int i) throws SQLException {
+        return rs.getLong(i);
+    }
+
+    public void registerEpilogue(Runnable runnableEpilogue) {
+        this.runnableEpilogue = runnableEpilogue;
+    }
+
+}

--- a/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPAggregateOracle.java
+++ b/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPAggregateOracle.java
@@ -1,6 +1,5 @@
 package sqlancer.clickhouse.oracle.tlp;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
@@ -10,6 +9,7 @@ import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.clickhouse.ClickHouseProvider;
 import sqlancer.clickhouse.ClickHouseSchema;
@@ -69,7 +69,7 @@ public class ClickHouseTLPAggregateOracle implements TestOracle {
         String firstResult;
         String secondResult;
         QueryAdapter q = new QueryAdapter(originalQuery);
-        try (ResultSet result = q.executeAndGet(state)) {
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }
@@ -80,7 +80,7 @@ public class ClickHouseTLPAggregateOracle implements TestOracle {
         }
 
         QueryAdapter q2 = new QueryAdapter(metamorphicText);
-        try (ResultSet result = q2.executeAndGet(state)) {
+        try (SQLancerResultSet result = q2.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }

--- a/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
@@ -1,6 +1,5 @@
 package sqlancer.cockroachdb.oracle;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,6 +13,7 @@ import sqlancer.NoRECBase;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.cockroachdb.CockroachDBCommon;
 import sqlancer.cockroachdb.CockroachDBErrors;
@@ -137,7 +137,7 @@ public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState> im
 
     private int getCount(GlobalState<?, ?> globalState, Query q) throws AssertionError {
         int count = 0;
-        try (ResultSet rs = q.executeAndGet(globalState)) {
+        try (SQLancerResultSet rs = q.executeAndGet(globalState)) {
             if (rs == null) {
                 return -1;
             }

--- a/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
@@ -1,6 +1,5 @@
 package sqlancer.cockroachdb.oracle.tlp;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -15,6 +14,7 @@ import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.cockroachdb.CockroachDBCommon;
 import sqlancer.cockroachdb.CockroachDBErrors;
@@ -118,7 +118,7 @@ public class CockroachDBTLPAggregateOracle implements TestOracle {
     private String getAggregateResult(String queryString) throws SQLException {
         String resultString;
         QueryAdapter q = new QueryAdapter(queryString, errors);
-        try (ResultSet result = q.executeAndGet(state)) {
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }

--- a/src/sqlancer/duckdb/test/DuckDBNoRECOracle.java
+++ b/src/sqlancer/duckdb/test/DuckDBNoRECOracle.java
@@ -13,6 +13,7 @@ import sqlancer.NoRECBase;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.ast.newast.ColumnReferenceNode;
 import sqlancer.ast.newast.NewPostfixTextNode;
@@ -83,7 +84,7 @@ public class DuckDBNoRECOracle extends NoRECBase<DuckDBGlobalState> implements T
         unoptimizedQueryString = "SELECT SUM(count) FROM (" + DuckDBToStringVisitor.asString(select) + ") as res";
         errors.add("canceling statement due to statement timeout");
         Query q = new QueryAdapter(unoptimizedQueryString, errors);
-        ResultSet rs;
+        SQLancerResultSet rs;
         try {
             rs = q.executeAndGetLogged(state);
         } catch (Exception e) {

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
@@ -1,6 +1,5 @@
 package sqlancer.duckdb.test;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,6 +9,7 @@ import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.ast.newast.NewAliasNode;
 import sqlancer.ast.newast.NewBinaryOperatorNode;
@@ -100,7 +100,7 @@ public class DuckDBQueryPartitioningAggregateTester extends DuckDBQueryPartition
     private String getAggregateResult(String queryString) throws SQLException {
         String resultString;
         QueryAdapter q = new QueryAdapter(queryString, errors);
-        try (ResultSet result = q.executeAndGet(state)) {
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }

--- a/src/sqlancer/mariadb/oracle/MariaDBNoRECOracle.java
+++ b/src/sqlancer/mariadb/oracle/MariaDBNoRECOracle.java
@@ -1,6 +1,5 @@
 package sqlancer.mariadb.oracle;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -9,6 +8,7 @@ import java.util.List;
 import sqlancer.IgnoreMeException;
 import sqlancer.NoRECBase;
 import sqlancer.QueryAdapter;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.mariadb.MariaDBProvider.MariaDBGlobalState;
 import sqlancer.mariadb.MariaDBSchema;
@@ -82,15 +82,13 @@ public class MariaDBNoRECOracle extends NoRECBase<MariaDBGlobalState> implements
 
         unoptimizedQueryString = "SELECT SUM(count) FROM (" + MariaDBVisitor.asString(select) + ") as asdf";
         QueryAdapter q = new QueryAdapter(unoptimizedQueryString, errors);
-        try (ResultSet rs = q.executeAndGet(state)) {
+        try (SQLancerResultSet rs = q.executeAndGet(state)) {
             if (rs == null) {
                 return NOT_FOUND;
             } else {
                 while (rs.next()) {
                     secondCount = rs.getInt(1);
-                    rs.getStatement().close();
                 }
-                rs.getStatement().close();
             }
         }
 
@@ -111,13 +109,12 @@ public class MariaDBNoRECOracle extends NoRECBase<MariaDBGlobalState> implements
         int firstCount = 0;
         optimizedQueryString = MariaDBVisitor.asString(select);
         QueryAdapter q = new QueryAdapter(optimizedQueryString, errors);
-        try (ResultSet rs = q.executeAndGet(state)) {
+        try (SQLancerResultSet rs = q.executeAndGet(state)) {
             if (rs == null) {
                 firstCount = NOT_FOUND;
             } else {
                 rs.next();
                 firstCount = rs.getInt(1);
-                rs.getStatement().close();
             }
         } catch (Exception e) {
             throw new AssertionError(optimizedQueryString, e);

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -13,6 +13,7 @@ import sqlancer.NoRECBase;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.postgres.PostgresCompoundDataType;
 import sqlancer.postgres.PostgresGlobalState;
@@ -118,7 +119,7 @@ public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implemen
         }
         errors.add("canceling statement due to statement timeout");
         Query q = new QueryAdapter(unoptimizedQueryString, errors);
-        ResultSet rs;
+        SQLancerResultSet rs;
         try {
             rs = q.executeAndGet(state);
         } catch (Exception e) {

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -1,7 +1,6 @@
 package sqlancer.postgres.oracle.tlp;
 
 import java.io.IOException;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -13,6 +12,7 @@ import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
@@ -112,7 +112,7 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
         }
         String resultString;
         QueryAdapter q = new QueryAdapter(queryString, errors);
-        try (ResultSet result = q.executeAndGet(state)) {
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3IndexGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3IndexGenerator.java
@@ -71,6 +71,8 @@ public class SQLite3IndexGenerator {
         sb.append(" INDEX");
         if (Randomly.getBoolean()) {
             sb.append(" IF NOT EXISTS");
+        } else {
+            errors.add("already exists");
         }
         sb.append(" ");
         sb.append(SQLite3Common.getFreeIndexName(globalState.getSchema()));

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -1,6 +1,5 @@
 package sqlancer.sqlite3.oracle;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +9,7 @@ import sqlancer.IgnoreMeException;
 import sqlancer.NoRECBase;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3Provider.SQLite3GlobalState;
@@ -111,7 +111,7 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
 
     private int countRows(QueryAdapter q) {
         int count = 0;
-        try (ResultSet rs = q.executeAndGet(state)) {
+        try (SQLancerResultSet rs = q.executeAndGet(state)) {
             if (rs == null) {
                 return NO_VALID_RESULT;
             } else {
@@ -122,7 +122,6 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
                 } catch (SQLException e) {
                     count = NO_VALID_RESULT;
                 }
-                rs.getStatement().close();
             }
         } catch (Exception e) {
             if (e instanceof IgnoreMeException) {
@@ -135,7 +134,7 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
 
     private int extractCounts(QueryAdapter q) {
         int count = 0;
-        try (ResultSet rs = q.executeAndGet(state)) {
+        try (SQLancerResultSet rs = q.executeAndGet(state)) {
             if (rs == null) {
                 return NO_VALID_RESULT;
             } else {
@@ -146,7 +145,6 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
                 } catch (SQLException e) {
                     count = NO_VALID_RESULT;
                 }
-                rs.getStatement().close();
             }
         } catch (Exception e) {
             if (e instanceof IgnoreMeException) {

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
@@ -1,6 +1,5 @@
 package sqlancer.sqlite3.oracle.tlp;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,6 +9,7 @@ import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.TestOracle;
 import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3Provider.SQLite3GlobalState;
@@ -75,7 +75,7 @@ public class SQLite3TLPAggregateOracle implements TestOracle {
         String firstResult;
         String secondResult;
         QueryAdapter q = new QueryAdapter(originalQuery, errors);
-        try (ResultSet result = q.executeAndGet(state)) {
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }
@@ -86,7 +86,7 @@ public class SQLite3TLPAggregateOracle implements TestOracle {
         }
 
         QueryAdapter q2 = new QueryAdapter(metamorphicText, errors);
-        try (ResultSet result = q2.executeAndGet(state)) {
+        try (SQLancerResultSet result = q2.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }

--- a/src/sqlancer/sqlite3/schema/SQLite3Schema.java
+++ b/src/sqlancer/sqlite3/schema/SQLite3Schema.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLancerResultSet;
 import sqlancer.StateToReproduce.SQLite3StateToReproduce;
 import sqlancer.schema.AbstractTable;
 import sqlancer.schema.AbstractTableColumn;
@@ -354,14 +355,12 @@ public class SQLite3Schema {
                 "misuse of window function"));
         SQLite3Errors.addExpectedExpressionErrors(errors);
         QueryAdapter q = new QueryAdapter(string, errors);
-        try (ResultSet query = q.executeAndGet(globalState)) {
+        try (SQLancerResultSet query = q.executeAndGet(globalState)) {
             if (query == null) {
                 throw new IgnoreMeException();
             }
             query.next();
-            int int1 = query.getInt(1);
-            query.getStatement().close();
-            return int1;
+            return query.getInt(1);
         }
     }
 


### PR DESCRIPTION
This allows registering a callback to correctly log the time for queries that iterate through a result set.

Addresses https://github.com/sqlancer/sqlancer/issues/94 for queries.