### PR TITLE
Prepared statement execution & Deterministic states to reproduce

### DIFF
--- a/src/sqlancer/QueryAdapter.java
+++ b/src/sqlancer/QueryAdapter.java
@@ -61,9 +61,9 @@ public class QueryAdapter extends Query {
     public boolean execute(GlobalState<?, ?> globalState, String... fills) throws SQLException {
         Statement s;
         if (fills.length > 0) {
-            s = globalState.getConnection().prepareStatement(getQueryString());
-            for (int i = 0; i < fills.length; i++) {
-                ((PreparedStatement) s).setString(i + 1, fills[i]);
+            s = globalState.getConnection().prepareStatement(fills[0]);
+            for (int i = 1; i < fills.length; i++) {
+                ((PreparedStatement) s).setString(i, fills[i]);
             }
         } else {
             s = globalState.getConnection().createStatement();
@@ -100,9 +100,9 @@ public class QueryAdapter extends Query {
     public SQLancerResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws SQLException {
         Statement s;
         if (fills.length > 0) {
-            s = globalState.getConnection().prepareStatement(getQueryString());
-            for (int i = 0; i < fills.length; i++) {
-                ((PreparedStatement) s).setString(i + 1, fills[i]);
+            s = globalState.getConnection().prepareStatement(fills[0]);
+            for (int i = 1; i < fills.length; i++) {
+                ((PreparedStatement) s).setString(i, fills[i]);
             }
         } else {
             s = globalState.getConnection().createStatement();

--- a/src/sqlancer/postgres/PostgresSchema.java
+++ b/src/sqlancer/postgres/PostgresSchema.java
@@ -264,7 +264,7 @@ public class PostgresSchema {
             List<PostgresTable> databaseTables = new ArrayList<>();
             try (Statement s = con.createStatement()) {
                 try (ResultSet rs = s.executeQuery(
-                        "SELECT table_name, table_schema, table_type, is_insertable_into FROM information_schema.tables WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%';")) {
+                        "SELECT table_name, table_schema, table_type, is_insertable_into FROM information_schema.tables WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%' ORDER BY table_name;")) {
                     while (rs.next()) {
                         String tableName = rs.getString("table_name");
                         String tableTypeSchema = rs.getString("table_schema");
@@ -297,7 +297,7 @@ public class PostgresSchema {
     private static List<PostgresStatisticsObject> getStatistics(Connection con) throws SQLException {
         List<PostgresStatisticsObject> statistics = new ArrayList<>();
         try (Statement s = con.createStatement()) {
-            try (ResultSet rs = s.executeQuery("SELECT stxname FROM pg_statistic_ext;")) {
+            try (ResultSet rs = s.executeQuery("SELECT stxname FROM pg_statistic_ext ORDER BY stxname;")) {
                 while (rs.next()) {
                     statistics.add(new PostgresStatisticsObject(rs.getString("stxname")));
                 }
@@ -321,8 +321,8 @@ public class PostgresSchema {
     private static List<PostgresIndex> getIndexes(Connection con, String tableName) throws SQLException {
         List<PostgresIndex> indexes = new ArrayList<>();
         try (Statement s = con.createStatement()) {
-            try (ResultSet rs = s
-                    .executeQuery(String.format("SELECT indexname FROM pg_indexes WHERE tablename='%s';", tableName))) {
+            try (ResultSet rs = s.executeQuery(String
+                    .format("SELECT indexname FROM pg_indexes WHERE tablename='%s' ORDER BY indexname;", tableName))) {
                 while (rs.next()) {
                     String indexName = rs.getString("indexname");
                     if (indexName.length() != 2) {
@@ -341,7 +341,7 @@ public class PostgresSchema {
         try (Statement s = con.createStatement()) {
             try (ResultSet rs = s
                     .executeQuery("select column_name, data_type from INFORMATION_SCHEMA.COLUMNS where table_name = '"
-                            + tableName + "'")) {
+                            + tableName + "' ORDER BY column_name")) {
                 while (rs.next()) {
                     String columnName = rs.getString("column_name");
                     String dataType = rs.getString("data_type");


### PR DESCRIPTION
This PR has 2 purposes implemented via the 2 commits:
1. Currently, for prepared statements, since the template without fills is being passed in as the query string, this causes the log outputs to include '?' in them rather than the fill-ins. I resorted back to passing in the filled-in statement as the query string, and passing both the template and the fill-ins as variable-length arguments.
2. Currently, the order of reading from the Postgres schema is non-deterministic and depends on the order Postgres outputs the SELECTed rows. This has caused issues in using a seed to reproduce a run. This commit makes the ordering deterministic by adding ORDER BY clauses.