### PR TITLE
Add an expected error class

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -31,7 +31,7 @@ public final class ComparatorHelper {
         return Math.abs(a - b) < 0.0001 * Math.max(Math.abs(a), Math.abs(b));
     }
 
-    public static List<String> getResultSetFirstColumnAsString(String queryString, Set<String> errors,
+    public static List<String> getResultSetFirstColumnAsString(String queryString, ExpectedErrors errors,
             GlobalState<?, ?> state) throws SQLException {
         if (state.getOptions().logEachSelect()) {
             // TODO: refactor me
@@ -65,10 +65,8 @@ public final class ComparatorHelper {
             if (e.getMessage() == null) {
                 throw new AssertionError(queryString, e);
             }
-            for (String error : errors) {
-                if (e.getMessage().contains(error)) {
-                    throw new IgnoreMeException();
-                }
+            if (errors.errorIsExpected(e.getMessage())) {
+                throw new IgnoreMeException();
             }
             throw new AssertionError(queryString, e);
         } finally {
@@ -114,7 +112,7 @@ public final class ComparatorHelper {
 
     public static List<String> getCombinedResultSet(String firstQueryString, String secondQueryString,
             String thirdQueryString, List<String> combinedString, boolean asUnion, GlobalState<?, ?> state,
-            Set<String> errors) throws SQLException {
+            ExpectedErrors errors) throws SQLException {
         List<String> secondResultSet;
         if (asUnion) {
             String unionString = firstQueryString + " UNION ALL " + secondQueryString + " UNION ALL "
@@ -135,7 +133,7 @@ public final class ComparatorHelper {
 
     public static List<String> getCombinedResultSetNoDuplicates(String firstQueryString, String secondQueryString,
             String thirdQueryString, List<String> combinedString, boolean asUnion, GlobalState<?, ?> state,
-            Set<String> errors) throws SQLException {
+            ExpectedErrors errors) throws SQLException {
         String unionString;
         if (asUnion) {
             unionString = firstQueryString + " UNION " + secondQueryString + " UNION " + thirdQueryString;

--- a/src/sqlancer/ExpectedErrors.java
+++ b/src/sqlancer/ExpectedErrors.java
@@ -1,0 +1,58 @@
+package sqlancer;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class represents the errors that executing a statement might result in. For example, an INSERT statement might
+ * result in an error "UNIQUE constraint violated" when it attempts to insert a duplicate value in a column declared as
+ * UNIQUE.
+ */
+public class ExpectedErrors {
+
+    private final Set<String> errors = new HashSet<>();
+
+    public ExpectedErrors add(String error) {
+        if (error == null) {
+            throw new IllegalArgumentException();
+        }
+        errors.add(error);
+        return this;
+    }
+
+    /**
+     * Checks whether the error message (e.g., returned by the DBMS under test) contains any of the added error
+     * messages.
+     *
+     * @param error
+     *            the error message
+     *
+     * @return whether the error message contains any of the substrings specified as expected errors
+     */
+    public boolean errorIsExpected(String error) {
+        if (error == null) {
+            throw new IllegalArgumentException();
+        }
+        for (String s : errors) {
+            if (error.contains(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public ExpectedErrors addAll(Collection<String> list) {
+        errors.addAll(list);
+        return this;
+    }
+
+    public static ExpectedErrors from(String... errors) {
+        ExpectedErrors expectedErrors = new ExpectedErrors();
+        for (String error : errors) {
+            expectedErrors.add(error);
+        }
+        return expectedErrors;
+    }
+
+}

--- a/src/sqlancer/NoRECBase.java
+++ b/src/sqlancer/NoRECBase.java
@@ -1,15 +1,13 @@
 package sqlancer;
 
 import java.sql.Connection;
-import java.util.HashSet;
-import java.util.Set;
 
 import sqlancer.Main.StateLogger;
 
 public abstract class NoRECBase<S extends GlobalState<?, ?>> implements TestOracle {
 
     protected final S state;
-    protected final Set<String> errors = new HashSet<>();
+    protected final ExpectedErrors errors = new ExpectedErrors();
     protected final StateLogger logger;
     protected final MainOptions options;
     protected final Connection con;

--- a/src/sqlancer/Query.java
+++ b/src/sqlancer/Query.java
@@ -1,7 +1,6 @@
 package sqlancer;
 
 import java.sql.SQLException;
-import java.util.Collection;
 
 public abstract class Query {
 
@@ -24,7 +23,7 @@ public abstract class Query {
      */
     public abstract boolean execute(GlobalState<?, ?> globalState, String... fills) throws SQLException;
 
-    public abstract Collection<String> getExpectedErrors();
+    public abstract ExpectedErrors getExpectedErrors();
 
     @Override
     public String toString() {

--- a/src/sqlancer/QueryAdapter.java
+++ b/src/sqlancer/QueryAdapter.java
@@ -4,31 +4,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Collection;
 
 public class QueryAdapter extends Query {
 
     private final String query;
-    private final Collection<String> expectedErrors;
+    private final ExpectedErrors expectedErrors;
     private final boolean couldAffectSchema;
 
     public QueryAdapter(String query) {
-        this(query, new ArrayList<>());
+        this(query, new ExpectedErrors());
     }
 
     public QueryAdapter(String query, boolean couldAffectSchema) {
-        this(query, new ArrayList<>(), couldAffectSchema);
+        this(query, new ExpectedErrors(), couldAffectSchema);
     }
 
-    public QueryAdapter(String query, Collection<String> expectedErrors) {
-        this.query = canonicalizeString(query);
-        this.expectedErrors = expectedErrors;
-        this.couldAffectSchema = false;
-        checkQueryString();
+    public QueryAdapter(String query, ExpectedErrors expectedErrors) {
+        this(query, expectedErrors, false);
     }
 
-    public QueryAdapter(String query, Collection<String> expectedErrors, boolean couldAffectSchema) {
+    public QueryAdapter(String query, ExpectedErrors expectedErrors, boolean couldAffectSchema) {
         this.query = canonicalizeString(query);
         this.expectedErrors = expectedErrors;
         this.couldAffectSchema = couldAffectSchema;
@@ -84,14 +79,7 @@ public class QueryAdapter extends Query {
     }
 
     public void checkException(Exception e) throws AssertionError {
-        boolean isExcluded = false;
-        for (String expectedError : expectedErrors) {
-            if (e.getMessage().contains(expectedError)) {
-                isExcluded = true;
-                break;
-            }
-        }
-        if (!isExcluded) {
+        if (!expectedErrors.errorIsExpected(e.getMessage())) {
             throw new AssertionError(query, e);
         }
     }
@@ -133,7 +121,7 @@ public class QueryAdapter extends Query {
     }
 
     @Override
-    public Collection<String> getExpectedErrors() {
+    public ExpectedErrors getExpectedErrors() {
         return expectedErrors;
     }
 

--- a/src/sqlancer/TernaryLogicPartitioningOracleBase.java
+++ b/src/sqlancer/TernaryLogicPartitioningOracleBase.java
@@ -1,8 +1,5 @@
 package sqlancer;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import sqlancer.gen.ExpressionGenerator;
 
 /**
@@ -20,7 +17,7 @@ public abstract class TernaryLogicPartitioningOracleBase<E, S> implements TestOr
     protected E isNullPredicate;
 
     protected final S state;
-    protected final Set<String> errors = new HashSet<>();
+    protected final ExpectedErrors errors = new ExpectedErrors();
 
     protected TernaryLogicPartitioningOracleBase(S state) {
         this.state = state;

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -8,13 +8,12 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import sqlancer.AbstractAction;
 import sqlancer.CompositeTestOracle;
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -452,8 +451,8 @@ public class CitusProvider extends PostgresProvider {
         return "citus";
     }
 
-    private static Set<String> getCitusErrors() {
-        Set<String> errors = new HashSet<>();
+    private static ExpectedErrors getCitusErrors() {
+        ExpectedErrors errors = new ExpectedErrors();
         CitusCommon.addCitusErrors(errors);
         return errors;
     }

--- a/src/sqlancer/citus/gen/CitusAlterTableGenerator.java
+++ b/src/sqlancer/citus/gen/CitusAlterTableGenerator.java
@@ -1,8 +1,8 @@
 package sqlancer.citus.gen;
 
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.postgres.PostgresGlobalState;
@@ -21,7 +21,7 @@ public class CitusAlterTableGenerator extends PostgresAlterTableGenerator {
     }
 
     @Override
-    public List<Action> getActions(Set<String> errors) {
+    public List<Action> getActions(ExpectedErrors errors) {
         List<Action> action = super.getActions(errors);
         CitusCommon.addCitusErrors(errors);
         action.remove(Action.ALTER_COLUMN_SET_STATISTICS);

--- a/src/sqlancer/citus/gen/CitusCommon.java
+++ b/src/sqlancer/citus/gen/CitusCommon.java
@@ -1,8 +1,6 @@
 package sqlancer.citus.gen;
 
-import java.util.Collection;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.gen.PostgresCommon;
@@ -12,7 +10,7 @@ public final class CitusCommon {
     private CitusCommon() {
     }
 
-    public static void addCitusErrors(Collection<String> errors) {
+    public static void addCitusErrors(ExpectedErrors errors) {
         errors.add("recursive CTEs are not supported in distributed queries");
         errors.add("could not run distributed query with GROUPING SETS, CUBE, or ROLLUP");
         errors.add("Subqueries in HAVING cannot refer to outer query");
@@ -68,7 +66,7 @@ public final class CitusCommon {
     }
 
     public static void addTableConstraint(StringBuilder sb, PostgresTable table, PostgresGlobalState globalState,
-            Set<String> errors) {
+            ExpectedErrors errors) {
         PostgresCommon.addTableConstraint(sb, table, globalState, errors);
         CitusCommon.addCitusErrors(errors);
     }

--- a/src/sqlancer/citus/gen/CitusDeleteGenerator.java
+++ b/src/sqlancer/citus/gen/CitusDeleteGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.citus.gen;
 
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.gen.PostgresDeleteGenerator;
@@ -13,7 +12,7 @@ public final class CitusDeleteGenerator {
 
     public static Query create(PostgresGlobalState globalState) {
         Query deleteQuery = PostgresDeleteGenerator.create(globalState);
-        Set<String> errors = (Set<String>) deleteQuery.getExpectedErrors();
+        ExpectedErrors errors = deleteQuery.getExpectedErrors();
         CitusCommon.addCitusErrors(errors);
         return deleteQuery;
     }

--- a/src/sqlancer/citus/gen/CitusIndexGenerator.java
+++ b/src/sqlancer/citus/gen/CitusIndexGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.citus.gen;
 
-import java.util.HashSet;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.gen.PostgresInsertGenerator;
@@ -13,7 +12,7 @@ public final class CitusIndexGenerator {
 
     public static Query generate(PostgresGlobalState globalState) {
         Query createIndexQuery = PostgresInsertGenerator.insert(globalState);
-        HashSet<String> errors = (HashSet<String>) createIndexQuery.getExpectedErrors();
+        ExpectedErrors errors = createIndexQuery.getExpectedErrors();
         CitusCommon.addCitusErrors(errors);
         return createIndexQuery;
     }

--- a/src/sqlancer/citus/gen/CitusInsertGenerator.java
+++ b/src/sqlancer/citus/gen/CitusInsertGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.citus.gen;
 
-import java.util.HashSet;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.gen.PostgresInsertGenerator;
@@ -13,7 +12,7 @@ public final class CitusInsertGenerator {
 
     public static Query insert(PostgresGlobalState globalState) {
         Query insertQuery = PostgresInsertGenerator.insert(globalState);
-        HashSet<String> errors = (HashSet<String>) insertQuery.getExpectedErrors();
+        ExpectedErrors errors = insertQuery.getExpectedErrors();
         CitusCommon.addCitusErrors(errors);
         return insertQuery;
     }

--- a/src/sqlancer/citus/gen/CitusSetGenerator.java
+++ b/src/sqlancer/citus/gen/CitusSetGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.citus.gen;
 
-import java.util.Collection;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.gen.PostgresSetGenerator;
@@ -13,7 +12,7 @@ public final class CitusSetGenerator {
 
     public static Query create(PostgresGlobalState globalState) {
         Query setQuery = PostgresSetGenerator.create(globalState);
-        Collection<String> errors = setQuery.getExpectedErrors();
+        ExpectedErrors errors = setQuery.getExpectedErrors();
         CitusCommon.addCitusErrors(errors);
         return setQuery;
     }

--- a/src/sqlancer/citus/gen/CitusUpdateGenerator.java
+++ b/src/sqlancer/citus/gen/CitusUpdateGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.citus.gen;
 
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.gen.PostgresUpdateGenerator;
@@ -13,7 +12,7 @@ public final class CitusUpdateGenerator {
 
     public static Query create(PostgresGlobalState globalState) {
         Query updateQuery = PostgresUpdateGenerator.create(globalState);
-        Set<String> errors = (Set<String>) updateQuery.getExpectedErrors();
+        ExpectedErrors errors = updateQuery.getExpectedErrors();
         CitusCommon.addCitusErrors(errors);
         return updateQuery;
     }

--- a/src/sqlancer/citus/gen/CitusViewGenerator.java
+++ b/src/sqlancer/citus/gen/CitusViewGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.citus.gen;
 
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.gen.PostgresViewGenerator;
@@ -13,7 +12,7 @@ public final class CitusViewGenerator {
 
     public static Query create(PostgresGlobalState globalState) {
         Query viewQuery = PostgresViewGenerator.create(globalState);
-        Set<String> errors = (Set<String>) viewQuery.getExpectedErrors();
+        ExpectedErrors errors = viewQuery.getExpectedErrors();
         CitusCommon.addCitusErrors(errors);
         return viewQuery;
     }

--- a/src/sqlancer/clickhouse/ClickHouseErrors.java
+++ b/src/sqlancer/clickhouse/ClickHouseErrors.java
@@ -1,13 +1,13 @@
 package sqlancer.clickhouse;
 
-import java.util.Set;
+import sqlancer.ExpectedErrors;
 
 public final class ClickHouseErrors {
 
     private ClickHouseErrors() {
     }
 
-    public static void addExpectedExpressionErrors(Set<String> errors) {
+    public static void addExpectedExpressionErrors(ExpectedErrors errors) {
         // errors.add("Illegal type (String) of argument of function not");
         // errors.add("Illegal type String of column for constant filter. Must be UInt8 or Nullable(UInt8)");
         // errors.add("Illegal type Int32 of column for constant filter. Must be UInt8 or Nullable(UInt8)");
@@ -37,19 +37,19 @@ public final class ClickHouseErrors {
         errors.add("argument of function");
     }
 
-    public static void addExpressionHavingErrors(Set<String> errors) {
+    public static void addExpressionHavingErrors(ExpectedErrors errors) {
         errors.add("Memory limit");
     }
 
-    public static void addQueryErrors(Set<String> errors) {
+    public static void addQueryErrors(ExpectedErrors errors) {
         errors.add("Memory limit");
     }
 
-    public static void addGroupingErrors(Set<String> errors) {
+    public static void addGroupingErrors(ExpectedErrors errors) {
         errors.add("Memory limit");
     }
 
-    public static void addTableManipulationErrors(Set<String> errors) {
+    public static void addTableManipulationErrors(ExpectedErrors errors) {
         errors.add("Memory limit");
         errors.add("Directory for table data");
         errors.add("Directory not empty");

--- a/src/sqlancer/clickhouse/gen/ClickHouseInsertGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseInsertGenerator.java
@@ -1,11 +1,10 @@
 package sqlancer.clickhouse.gen;
 
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.clickhouse.ClickHouseProvider.ClickHouseGlobalState;
@@ -17,7 +16,7 @@ import sqlancer.gen.AbstractInsertGenerator;
 public class ClickHouseInsertGenerator extends AbstractInsertGenerator<ClickHouseColumn> {
 
     private final ClickHouseGlobalState globalState;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private final ClickHouseExpressionGenerator gen;
 
     public ClickHouseInsertGenerator(ClickHouseGlobalState globalState) {

--- a/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
@@ -1,11 +1,10 @@
 package sqlancer.clickhouse.gen;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import ru.yandex.clickhouse.domain.ClickHouseDataType;
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -37,7 +36,7 @@ public class ClickHouseTableGenerator {
     public static Query createTableStatement(String tableName, ClickHouseProvider.ClickHouseGlobalState globalState) {
         ClickHouseTableGenerator chTableGenerator = new ClickHouseTableGenerator(tableName, globalState);
         chTableGenerator.start();
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         ClickHouseErrors.addTableManipulationErrors(errors);
         return new QueryAdapter(chTableGenerator.sb.toString(), errors, true);
     }

--- a/src/sqlancer/cockroachdb/CockroachDBErrors.java
+++ b/src/sqlancer/cockroachdb/CockroachDBErrors.java
@@ -1,13 +1,13 @@
 package sqlancer.cockroachdb;
 
-import java.util.Set;
+import sqlancer.ExpectedErrors;
 
 public final class CockroachDBErrors {
 
     private CockroachDBErrors() {
     }
 
-    public static void addExpressionErrors(Set<String> errors) {
+    public static void addExpressionErrors(ExpectedErrors errors) {
         errors.add(" non-streaming operator encountered when vectorize=auto");
 
         if (CockroachDBBugs.bug46915) {
@@ -182,7 +182,7 @@ public final class CockroachDBErrors {
         addArrayErrors(errors);
     }
 
-    private static void addArrayErrors(Set<String> errors) {
+    private static void addArrayErrors(ExpectedErrors errors) {
         // arrays
         errors.add("cannot determine type of empty array");
         errors.add("unknown signature: max(unknown[])");
@@ -232,16 +232,16 @@ public final class CockroachDBErrors {
         errors.add("to be of type unknown[]"); // IF with null array
     }
 
-    private static void addIntervalTypeErrors(Set<String> errors) {
+    private static void addIntervalTypeErrors(ExpectedErrors errors) {
         errors.add("overflow during Encode");
         errors.add("as type interval");
     }
 
-    private static void addJoinTypes(Set<String> errors) {
+    private static void addJoinTypes(ExpectedErrors errors) {
         errors.add("JOIN/USING types");
     }
 
-    private static void addGroupByErrors(Set<String> errors) {
+    private static void addGroupByErrors(ExpectedErrors errors) {
         errors.add("non-integer constant in GROUP BY");
 
         // https://github.com/cockroachdb/cockroach/pull/46649 -> aggregates on NULL are
@@ -265,7 +265,7 @@ public final class CockroachDBErrors {
 
     }
 
-    private static void addFunctionErrors(Set<String> errors) {
+    private static void addFunctionErrors(ExpectedErrors errors) {
         // functions
         errors.add("abs of min integer value (-9223372036854775808) not defined"); // ABS
         errors.add("the input string must not be empty"); // ASCII
@@ -284,7 +284,7 @@ public final class CockroachDBErrors {
         errors.add("must be greater than zero"); // split_part
     }
 
-    public static void addTransactionErrors(Set<String> errors) {
+    public static void addTransactionErrors(ExpectedErrors errors) {
         errors.add("current transaction is aborted");
     }
 

--- a/src/sqlancer/cockroachdb/gen/CockroachDBCommentOnGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBCommentOnGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -55,7 +54,7 @@ public final class CockroachDBCommentOnGenerator {
         sb.append(" IS '");
         sb.append(globalState.getRandomly().getString().replace("'", "''"));
         sb.append("'");
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         CockroachDBErrors.addTransactionErrors(errors);
         return new QueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/cockroachdb/gen/CockroachDBCreateStatisticsGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBCreateStatisticsGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -25,7 +24,7 @@ public final class CockroachDBCreateStatisticsGenerator {
         sb.append(randomTable.getName());
 
         return new QueryAdapter(sb.toString(),
-                Arrays.asList("current transaction is aborted, commands ignored until end of transaction block",
+                ExpectedErrors.from("current transaction is aborted, commands ignored until end of transaction block",
                         "ERROR: unable to encode table key: *tree.DArray" /*
                                                                            * https://github.com/cockroachdb/cockroach/
                                                                            * issues/46964

--- a/src/sqlancer/cockroachdb/gen/CockroachDBDeleteGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBDeleteGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -18,7 +16,7 @@ public final class CockroachDBDeleteGenerator {
     }
 
     public static Query delete(CockroachDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder();
         CockroachDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append("DELETE FROM ");

--- a/src/sqlancer/cockroachdb/gen/CockroachDBInsertGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBInsertGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -20,7 +19,7 @@ public final class CockroachDBInsertGenerator {
     }
 
     public static Query insert(CockroachDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
 
         CockroachDBErrors.addExpressionErrors(errors); // e.g., caused by computed columns
         errors.add("violates not-null constraint");

--- a/src/sqlancer/cockroachdb/gen/CockroachDBSetClusterSettingGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBSetClusterSettingGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Function;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -51,7 +50,7 @@ public final class CockroachDBSetClusterSettingGenerator {
         } else {
             sb.append(s.f.apply(globalState));
         }
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         CockroachDBErrors.addTransactionErrors(errors);
         errors.add("setting updated but timed out waiting to read new value");
 

--- a/src/sqlancer/cockroachdb/gen/CockroachDBSetSessionGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBSetSessionGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Function;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -52,7 +51,7 @@ public final class CockroachDBSetSessionGenerator {
         sb.append(s);
         sb.append("=");
         sb.append(s.f.apply(globalState));
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         CockroachDBErrors.addTransactionErrors(errors);
         return new QueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/cockroachdb/gen/CockroachDBShowGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBShowGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -20,7 +18,7 @@ public final class CockroachDBShowGenerator {
     }
 
     public static Query show(CockroachDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder();
         switch (Randomly.fromOptions(Option.values())) {
         case EXPERIMENTAL_FINGERPRINTS:

--- a/src/sqlancer/cockroachdb/gen/CockroachDBTruncateGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBTruncateGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -15,7 +13,7 @@ public final class CockroachDBTruncateGenerator {
 
     // https://www.cockroachlabs.com/docs/v19.2/truncate.html
     public static Query truncate(CockroachDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("is interleaved by table");
         errors.add("is referenced by foreign key");
 

--- a/src/sqlancer/cockroachdb/gen/CockroachDBUpdateGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBUpdateGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -20,7 +19,7 @@ public final class CockroachDBUpdateGenerator {
     }
 
     public static Query gen(CockroachDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         CockroachDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<CockroachDBColumn> columns = table.getRandomNonEmptyColumnSubset();
         CockroachDBExpressionGenerator gen = new CockroachDBExpressionGenerator(globalState).setColumns(columns);

--- a/src/sqlancer/cockroachdb/gen/CockroachDBViewGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBViewGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.cockroachdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -29,7 +27,7 @@ public final class CockroachDBViewGenerator {
         }
         sb.append(") AS ");
         sb.append(CockroachDBRandomQuerySynthesizer.generate(globalState, nrColumns).getQueryString());
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         CockroachDBErrors.addExpressionErrors(errors);
         CockroachDBErrors.addTransactionErrors(errors);
         errors.add("value type unknown cannot be used for table columns");

--- a/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
@@ -4,9 +4,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
 import sqlancer.NoRECBase;
@@ -98,7 +98,7 @@ public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState> im
     }
 
     private int getOptimizedResult(CockroachDBExpression whereCondition, List<CockroachDBExpression> tableList,
-            Set<String> errors, List<CockroachDBExpression> joinExpressions) throws SQLException {
+            ExpectedErrors errors, List<CockroachDBExpression> joinExpressions) throws SQLException {
         CockroachDBSelect select = new CockroachDBSelect();
         CockroachDBColumn c = new CockroachDBColumn("COUNT(*)", null, false, false);
         select.setFetchColumns(Arrays.asList(new CockroachDBColumnReference(c)));
@@ -118,7 +118,7 @@ public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState> im
     }
 
     private int getNonOptimizedResult(CockroachDBExpression whereCondition, List<CockroachDBExpression> tableList,
-            Set<String> errors, List<CockroachDBExpression> joinList) throws SQLException {
+            ExpectedErrors errors, List<CockroachDBExpression> joinList) throws SQLException {
         String fromString = tableList.stream().map(t -> ((CockroachDBTableReference) t).getTable().getName())
                 .collect(Collectors.joining(", "));
         if (!tableList.isEmpty() && !joinList.isEmpty()) {

--- a/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
@@ -3,14 +3,13 @@ package sqlancer.cockroachdb.oracle.tlp;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.postgresql.util.PSQLException;
 
 import sqlancer.ComparatorHelper;
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -39,7 +38,7 @@ import sqlancer.cockroachdb.oracle.CockroachDBNoRECOracle;
 public class CockroachDBTLPAggregateOracle implements TestOracle {
 
     private final CockroachDBGlobalState state;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private CockroachDBExpressionGenerator gen;
     private String firstResult;
     private String secondResult;

--- a/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPJoinOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPJoinOracle.java
@@ -3,12 +3,11 @@ package sqlancer.cockroachdb.oracle.tlp;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import sqlancer.ComparatorHelper;
+import sqlancer.ExpectedErrors;
 import sqlancer.Randomly;
 import sqlancer.TestOracle;
 import sqlancer.cockroachdb.CockroachDBErrors;
@@ -33,7 +32,7 @@ import sqlancer.cockroachdb.gen.CockroachDBExpressionGenerator;
 public class CockroachDBTLPJoinOracle implements TestOracle {
 
     final CockroachDBGlobalState state;
-    final Set<String> errors = new HashSet<>();
+    final ExpectedErrors errors = new ExpectedErrors();
 
     CockroachDBSchema s;
     CockroachDBTables targetTables;

--- a/src/sqlancer/duckdb/DuckDBErrors.java
+++ b/src/sqlancer/duckdb/DuckDBErrors.java
@@ -1,13 +1,13 @@
 package sqlancer.duckdb;
 
-import java.util.Set;
+import sqlancer.ExpectedErrors;
 
 public final class DuckDBErrors {
 
     private DuckDBErrors() {
     }
 
-    public static void addExpressionErrors(Set<String> errors) {
+    public static void addExpressionErrors(ExpectedErrors errors) {
         errors.add("Could not convert string");
         errors.add("ORDER term out of range - should be between ");
         errors.add("You might need to add explicit type casts.");
@@ -49,7 +49,7 @@ public final class DuckDBErrors {
         errors.add("Contents of view were altered: types don't match!");
     }
 
-    private static void addRegexErrors(Set<String> errors) {
+    private static void addRegexErrors(ExpectedErrors errors) {
         errors.add("missing ]");
         errors.add("missing )");
         errors.add("invalid escape sequence");
@@ -61,7 +61,7 @@ public final class DuckDBErrors {
         errors.add("width is not integer");
     }
 
-    private static void addFunctionErrors(Set<String> errors) {
+    private static void addFunctionErrors(ExpectedErrors errors) {
         errors.add("SUBSTRING cannot handle negative offsets");
         errors.add("is undefined outside [-1,1]"); // ACOS etc
         errors.add("invalid type specifier"); // PRINTF
@@ -74,7 +74,7 @@ public final class DuckDBErrors {
         errors.add("Could not choose a best candidate function for the function call"); // monthname
     }
 
-    public static void addInsertErrors(Set<String> errors) {
+    public static void addInsertErrors(ExpectedErrors errors) {
         errors.add("NOT NULL constraint failed");
         errors.add("PRIMARY KEY or UNIQUE constraint violated");
         errors.add("duplicate key value violates primary key or unique constraint");
@@ -89,7 +89,7 @@ public final class DuckDBErrors {
                                                                // the table has a primary key
     }
 
-    public static void addGroupByErrors(Set<String> errors) {
+    public static void addGroupByErrors(ExpectedErrors errors) {
         errors.add("must appear in the GROUP BY clause or be used in an aggregate function");
         errors.add("GROUP BY term out of range");
     }

--- a/src/sqlancer/duckdb/DuckDBProvider.java
+++ b/src/sqlancer/duckdb/DuckDBProvider.java
@@ -3,12 +3,11 @@ package sqlancer.duckdb;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import sqlancer.AbstractAction;
 import sqlancer.CompositeTestOracle;
+import sqlancer.ExpectedErrors;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
 import sqlancer.ProviderAdapter;
@@ -43,7 +42,7 @@ public class DuckDBProvider extends ProviderAdapter<DuckDBGlobalState, DuckDBOpt
         UPDATE(DuckDBUpdateGenerator::getQuery), //
         CREATE_VIEW(DuckDBViewGenerator::generate), //
         EXPLAIN((g) -> {
-            Set<String> errors = new HashSet<>();
+            ExpectedErrors errors = new ExpectedErrors();
             DuckDBErrors.addExpressionErrors(errors);
             DuckDBErrors.addGroupByErrors(errors);
             return new QueryAdapter(

--- a/src/sqlancer/duckdb/gen/DuckDBAlterTableGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBAlterTableGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.duckdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -22,7 +20,7 @@ public final class DuckDBAlterTableGenerator {
     }
 
     public static Query getQuery(DuckDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add(" does not have a column with name \"rowid\"");
         errors.add("Table does not contain column rowid referenced in alter statement");
         StringBuilder sb = new StringBuilder("ALTER TABLE ");

--- a/src/sqlancer/duckdb/gen/DuckDBDeleteGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBDeleteGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.duckdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -18,7 +16,7 @@ public final class DuckDBDeleteGenerator {
 
     public static Query generate(DuckDBGlobalState globalState) {
         StringBuilder sb = new StringBuilder("DELETE FROM ");
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.duckdb.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -20,7 +19,7 @@ public final class DuckDBIndexGenerator {
     }
 
     public static Query getQuery(DuckDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE ");
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/duckdb/gen/DuckDBInsertGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBInsertGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.duckdb.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -18,7 +17,7 @@ import sqlancer.gen.AbstractInsertGenerator;
 public class DuckDBInsertGenerator extends AbstractInsertGenerator<DuckDBColumn> {
 
     private final DuckDBGlobalState globalState;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
 
     public DuckDBInsertGenerator(DuckDBGlobalState globalState) {
         this.globalState = globalState;

--- a/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
@@ -1,11 +1,10 @@
 package sqlancer.duckdb.gen;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -22,7 +21,7 @@ import sqlancer.gen.UntypedExpressionGenerator;
 public class DuckDBTableGenerator {
 
     public Query getQuery(DuckDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder();
         String tableName = globalState.getSchema().getFreeTableName();
         sb.append("CREATE TABLE ");

--- a/src/sqlancer/duckdb/gen/DuckDBUpdateGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBUpdateGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.duckdb.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -22,7 +21,7 @@ public final class DuckDBUpdateGenerator {
 
     public static Query getQuery(DuckDBGlobalState globalState) {
         StringBuilder sb = new StringBuilder("UPDATE ");
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
         DuckDBExpressionGenerator gen = new DuckDBExpressionGenerator(globalState).setColumns(table.getColumns());

--- a/src/sqlancer/duckdb/gen/DuckDBViewGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBViewGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.duckdb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -30,7 +28,7 @@ public final class DuckDBViewGenerator {
         }
         sb.append(") AS ");
         sb.append(DuckDBToStringVisitor.asString(DuckDBRandomQuerySynthesizer.generateSelect(globalState, nrColumns)));
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         DuckDBErrors.addExpressionErrors(errors);
         DuckDBErrors.addGroupByErrors(errors);
         return new QueryAdapter(sb.toString(), errors, true);

--- a/src/sqlancer/gen/AbstractGenerator.java
+++ b/src/sqlancer/gen/AbstractGenerator.java
@@ -1,14 +1,12 @@
 package sqlancer.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 
 public abstract class AbstractGenerator {
 
-    protected final Set<String> errors = new HashSet<>();
+    protected final ExpectedErrors errors = new ExpectedErrors();
     protected final StringBuilder sb = new StringBuilder();
     protected boolean canAffectSchema;
 

--- a/src/sqlancer/mariadb/MariaDBErrors.java
+++ b/src/sqlancer/mariadb/MariaDBErrors.java
@@ -1,13 +1,13 @@
 package sqlancer.mariadb;
 
-import java.util.List;
+import sqlancer.ExpectedErrors;
 
 public final class MariaDBErrors {
 
     private MariaDBErrors() {
     }
 
-    public static void addInsertErrors(List<String> errors) {
+    public static void addInsertErrors(ExpectedErrors errors) {
         errors.add("Out of range");
         errors.add("Duplicate entry"); // violates UNIQUE constraint
         errors.add("cannot be null"); // violates NOT NULL constraint

--- a/src/sqlancer/mariadb/gen/MariaDBIndexGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBIndexGenerator.java
@@ -1,8 +1,8 @@
 package sqlancer.mariadb.gen;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -17,7 +17,7 @@ public final class MariaDBIndexGenerator {
     }
 
     public static Query generate(MariaDBSchema s) {
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder("CREATE ");
         errors.add("Key/Index cannot be defined on a virtual generated column");
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/mariadb/gen/MariaDBInsertGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBInsertGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.mariadb.gen;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -34,7 +32,7 @@ public final class MariaDBInsertGenerator {
             }
         }
         sb.append(")");
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         MariaDBErrors.addInsertErrors(errors);
         return new QueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/mariadb/gen/MariaDBTableGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBTableGenerator.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -22,7 +23,7 @@ public class MariaDBTableGenerator {
     private PrimaryKeyState primaryKeyState = Randomly.fromOptions(PrimaryKeyState.values());
     private final List<String> columnNames = new ArrayList<>();
     private final Randomly r;
-    private final List<String> errors = new ArrayList<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
 
     public MariaDBTableGenerator(String tableName, Randomly r, MariaDBSchema newSchema) {
         this.tableName = tableName;

--- a/src/sqlancer/mariadb/gen/MariaDBUpdateGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBUpdateGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.mariadb.gen;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -40,7 +38,7 @@ public final class MariaDBUpdateGenerator {
             }
             // [WHERE where_condition] [ORDER BY ...] [LIMIT row_count]
         }
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         MariaDBErrors.addInsertErrors(errors);
         return new QueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/mysql/MySQLErrors.java
+++ b/src/sqlancer/mysql/MySQLErrors.java
@@ -1,13 +1,13 @@
 package sqlancer.mysql;
 
-import java.util.Set;
+import sqlancer.ExpectedErrors;
 
 public final class MySQLErrors {
 
     private MySQLErrors() {
     }
 
-    public static void addExpressionErrors(Set<String> errors) {
+    public static void addExpressionErrors(ExpectedErrors errors) {
         errors.add("BIGINT value is out of range"); // e.g., CAST(-('-1e500') AS SIGNED)
         errors.add("is not valid for CHARACTER SET");
     }

--- a/src/sqlancer/mysql/gen/MySQLAlterTable.java
+++ b/src/sqlancer/mysql/gen/MySQLAlterTable.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -61,9 +62,8 @@ public class MySQLAlterTable {
     }
 
     private Query create() {
-        List<String> errors = new ArrayList<>(
-                Arrays.asList("does not support the create option", "doesn't have this option",
-                        "is not supported for this operation", "Data truncation", "Specified key was too long"));
+        ExpectedErrors errors = ExpectedErrors.from("does not support the create option", "doesn't have this option",
+                "is not supported for this operation", "Data truncation", "Specified key was too long");
         errors.add("Data truncated for functional index ");
         sb.append("ALTER TABLE ");
         MySQLTable table = schema.getRandomTable();

--- a/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.mysql.gen;
 
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -28,7 +27,7 @@ public class MySQLDeleteGenerator {
     private Query generate() {
         MySQLTable randomTable = globalState.getSchema().getRandomTable();
         MySQLExpressionGenerator gen = new MySQLExpressionGenerator(globalState).setColumns(randomTable.getColumns());
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         sb.append("DELETE");
         if (Randomly.getBoolean()) {
             sb.append(" LOW_PRIORITY");

--- a/src/sqlancer/mysql/gen/MySQLDropIndex.java
+++ b/src/sqlancer/mysql/gen/MySQLDropIndex.java
@@ -1,7 +1,6 @@
 package sqlancer.mysql.gen;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -45,8 +44,9 @@ public final class MySQLDropIndex {
             sb.append(Randomly.fromOptions("DEFAULT", "NONE", "SHARED", "EXCLUSIVE"));
         }
         return new QueryAdapter(sb.toString(),
-                Arrays.asList("LOCK=NONE is not supported", "ALGORITHM=INPLACE is not supported", "Data truncation",
-                        "Data truncated for functional index", "A primary key index cannot be invisible"));
+                ExpectedErrors.from("LOCK=NONE is not supported", "ALGORITHM=INPLACE is not supported",
+                        "Data truncation", "Data truncated for functional index",
+                        "A primary key index cannot be invisible"));
     }
 
 }

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -1,11 +1,10 @@
 package sqlancer.mysql.gen;
 
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -19,7 +18,7 @@ public class MySQLInsertGenerator {
     private final MySQLTable table;
     private final StringBuilder sb = new StringBuilder();
     boolean canFail;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private final MySQLGlobalState globalState;
 
     public MySQLInsertGenerator(MySQLGlobalState globalState) {

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -42,7 +43,7 @@ public class MySQLTableGenerator {
     }
 
     private Query create() {
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
 
         sb.append("CREATE");
         // TODO support temporary tables in the schema
@@ -86,7 +87,7 @@ public class MySQLTableGenerator {
 
     }
 
-    private void addCommonErrors(List<String> list) {
+    private void addCommonErrors(ExpectedErrors list) {
         list.add("The storage engine for the table doesn't support");
         list.add("doesn't have this option");
         list.add("must include all columns");

--- a/src/sqlancer/mysql/gen/MySQLTruncateTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTruncateTableGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.mysql.gen;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.mysql.MySQLGlobalState;
@@ -14,7 +13,7 @@ public final class MySQLTruncateTableGenerator {
     public static Query generate(MySQLGlobalState globalState) {
         StringBuilder sb = new StringBuilder("TRUNCATE TABLE ");
         sb.append(globalState.getSchema().getRandomTable().getName());
-        return new QueryAdapter(sb.toString(), Arrays.asList("doesn't have this option"));
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("doesn't have this option"));
     }
 
 }

--- a/src/sqlancer/mysql/gen/datadef/MySQLIndexGenerator.java
+++ b/src/sqlancer/mysql/gen/datadef/MySQLIndexGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.mysql.gen.datadef;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -38,7 +37,7 @@ public class MySQLIndexGenerator {
     }
 
     public Query create() {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         MySQLErrors.addExpressionErrors(errors);
         sb.append("CREATE ");
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.postgres.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -76,7 +75,7 @@ public class PostgresAlterTableGenerator {
         }
     };
 
-    public List<Action> getActions(Set<String> errors) {
+    public List<Action> getActions(ExpectedErrors errors) {
         PostgresCommon.addCommonExpressionErrors(errors);
         PostgresCommon.addCommonInsertUpdateErrors(errors);
         PostgresCommon.addCommonTableErrors(errors);
@@ -117,7 +116,7 @@ public class PostgresAlterTableGenerator {
     }
 
     public Query generate() {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         int i = 0;
         List<Action> action = getActions(errors);
         StringBuilder sb = new StringBuilder();

--- a/src/sqlancer/postgres/gen/PostgresAnalyzeGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresAnalyzeGenerator.java
@@ -1,8 +1,8 @@
 package sqlancer.postgres.gen;
 
-import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -37,7 +37,7 @@ public final class PostgresAnalyzeGenerator {
             }
         }
         // FIXME: bug in postgres?
-        return new QueryAdapter(sb.toString(), Arrays.asList("deadlock"));
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("deadlock"));
     }
 
 }

--- a/src/sqlancer/postgres/gen/PostgresClusterGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresClusterGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.postgres.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -15,7 +13,7 @@ public final class PostgresClusterGenerator {
     }
 
     public static Query create(PostgresGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("there is no previously clustered index for table");
         errors.add("cannot cluster a partitioned table");
         errors.add("access method does not support clustering");

--- a/src/sqlancer/postgres/gen/PostgresCommon.java
+++ b/src/sqlancer/postgres/gen/PostgresCommon.java
@@ -3,11 +3,11 @@ package sqlancer.postgres.gen;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.postgres.PostgresGlobalState;
@@ -22,7 +22,7 @@ public final class PostgresCommon {
     private PostgresCommon() {
     }
 
-    public static void addCommonFetchErrors(Set<String> errors) {
+    public static void addCommonFetchErrors(ExpectedErrors errors) {
         errors.add("FULL JOIN is only supported with merge-joinable or hash-joinable join conditions");
         errors.add("but it cannot be referenced from this part of the query");
         errors.add("missing FROM-clause entry for table");
@@ -30,12 +30,12 @@ public final class PostgresCommon {
         errors.add("canceling statement due to statement timeout");
     }
 
-    public static void addCommonTableErrors(Set<String> errors) {
+    public static void addCommonTableErrors(ExpectedErrors errors) {
         errors.add("is not commutative"); // exclude
         errors.add("operator requires run-time type coercion"); // exclude
     }
 
-    public static void addCommonExpressionErrors(Set<String> errors) {
+    public static void addCommonExpressionErrors(ExpectedErrors errors) {
         errors.add("You might need to add explicit type casts");
         errors.add("invalid regular expression");
         errors.add("could not determine which collation to use");
@@ -66,7 +66,7 @@ public final class PostgresCommon {
         addCommonRegexExpressionErrors(errors);
     }
 
-    private static void addToCharFunctionErrors(Set<String> errors) {
+    private static void addToCharFunctionErrors(ExpectedErrors errors) {
         errors.add("multiple decimal points");
         errors.add("and decimal point together");
         errors.add("multiple decimal points");
@@ -80,14 +80,14 @@ public final class PostgresCommon {
         errors.add("is not a number");
     }
 
-    private static void addBitStringOperationErrors(Set<String> errors) {
+    private static void addBitStringOperationErrors(ExpectedErrors errors) {
         errors.add("cannot XOR bit strings of different sizes");
         errors.add("cannot AND bit strings of different sizes");
         errors.add("cannot OR bit strings of different sizes");
         errors.add("must be type boolean, not type text");
     }
 
-    private static void addFunctionErrors(Set<String> errors) {
+    private static void addFunctionErrors(ExpectedErrors errors) {
         errors.add("out of valid range"); // get_bit/get_byte
         errors.add("cannot take logarithm of a negative number");
         errors.add("cannot take logarithm of zero");
@@ -101,18 +101,18 @@ public final class PostgresCommon {
         errors.add("invalid mask length"); // set_masklen
     }
 
-    private static void addCommonRegexExpressionErrors(Set<String> errors) {
+    private static void addCommonRegexExpressionErrors(ExpectedErrors errors) {
         errors.add("is not a valid hexadecimal digit");
     }
 
-    public static void addCommonRangeExpressionErrors(Set<String> errors) {
+    public static void addCommonRangeExpressionErrors(ExpectedErrors errors) {
         errors.add("range lower bound must be less than or equal to range upper bound");
         errors.add("result of range difference would not be contiguous");
         errors.add("out of range");
         errors.add("malformed range literal");
     }
 
-    public static void addCommonInsertUpdateErrors(Set<String> errors) {
+    public static void addCommonInsertUpdateErrors(ExpectedErrors errors) {
         errors.add("value too long for type character");
         errors.add("not found in view targetlist");
     }
@@ -219,7 +219,7 @@ public final class PostgresCommon {
         }
     }
 
-    public static void generateWith(StringBuilder sb, PostgresGlobalState globalState, Set<String> errors) {
+    public static void generateWith(StringBuilder sb, PostgresGlobalState globalState, ExpectedErrors errors) {
         if (Randomly.getBoolean()) {
             sb.append(" WITH (");
             ArrayList<StorageParameters> values = new ArrayList<>(Arrays.asList(StorageParameters.values()));
@@ -241,7 +241,7 @@ public final class PostgresCommon {
     }
 
     public static void addTableConstraints(boolean excludePrimaryKey, StringBuilder sb, PostgresTable table,
-            PostgresGlobalState globalState, Set<String> errors) {
+            PostgresGlobalState globalState, ExpectedErrors errors) {
         // TODO constraint name
         List<TableConstraints> tableConstraints = Randomly.nonEmptySubset(TableConstraints.values());
         if (excludePrimaryKey) {
@@ -258,12 +258,12 @@ public final class PostgresCommon {
     }
 
     public static void addTableConstraint(StringBuilder sb, PostgresTable table, PostgresGlobalState globalState,
-            Set<String> errors) {
+            ExpectedErrors errors) {
         addTableConstraint(sb, table, globalState, Randomly.fromOptions(TableConstraints.values()), errors);
     }
 
     private static void addTableConstraint(StringBuilder sb, PostgresTable table, PostgresGlobalState globalState,
-            TableConstraints t, Set<String> errors) {
+            TableConstraints t, ExpectedErrors errors) {
         List<PostgresColumn> randomNonEmptyColumnSubset = table.getRandomNonEmptyColumnSubset();
         List<PostgresColumn> otherColumns;
         PostgresCommon.addCommonExpressionErrors(errors);
@@ -362,7 +362,8 @@ public final class PostgresCommon {
         }
     }
 
-    private static void appendIndexParameters(StringBuilder sb, PostgresGlobalState globalState, Set<String> errors) {
+    private static void appendIndexParameters(StringBuilder sb, PostgresGlobalState globalState,
+            ExpectedErrors errors) {
         if (Randomly.getBoolean()) {
             generateWith(sb, globalState, errors);
         }
@@ -403,7 +404,7 @@ public final class PostgresCommon {
         sb.append(Randomly.fromOptions("NO ACTION", "RESTRICT", "CASCADE", "SET NULL", "SET DEFAULT"));
     }
 
-    public static void addGroupingErrors(Set<String> errors) {
+    public static void addGroupingErrors(ExpectedErrors errors) {
         errors.add("non-integer constant in GROUP BY"); // TODO
         errors.add("must appear in the GROUP BY clause or be used in an aggregate function");
         errors.add("is not in select list");

--- a/src/sqlancer/postgres/gen/PostgresDeleteGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDeleteGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.postgres.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -18,7 +16,7 @@ public final class PostgresDeleteGenerator {
 
     public static Query create(PostgresGlobalState globalState) {
         PostgresTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("violates foreign key constraint");
         errors.add("violates not-null constraint");
         errors.add("could not determine which collation to use for string comparison");

--- a/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.postgres.gen;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -26,7 +25,7 @@ public final class PostgresDiscardGenerator {
             what = Randomly.fromOptions("PLANS", "SEQUENCES");
         }
         sb.append(what);
-        return new QueryAdapter(sb.toString(), Arrays.asList("cannot run inside a transaction block")) {
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("cannot run inside a transaction block")) {
 
             @Override
             public boolean couldAffectSchema() {

--- a/src/sqlancer/postgres/gen/PostgresDropIndexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDropIndexGenerator.java
@@ -1,8 +1,8 @@
 package sqlancer.postgres.gen;
 
-import java.util.Arrays;
 import java.util.List;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -44,8 +44,8 @@ public final class PostgresDropIndexGenerator {
             sb.append(Randomly.fromOptions("CASCADE", "RESTRICT"));
         }
         return new QueryAdapter(sb.toString(),
-                Arrays.asList("cannot drop desired object(s) because other objects depend on them", "cannot drop index",
-                        "does not exist"),
+                ExpectedErrors.from("cannot drop desired object(s) because other objects depend on them",
+                        "cannot drop index", "does not exist"),
                 true);
     }
 

--- a/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.postgres.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -27,7 +26,7 @@ public final class PostgresIndexGenerator {
     }
 
     public static Query generate(PostgresGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE");
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/postgres/gen/PostgresInsertGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresInsertGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.postgres.gen;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -21,7 +20,7 @@ public final class PostgresInsertGenerator {
 
     public static Query insert(PostgresGlobalState globalState) {
         PostgresTable table = globalState.getSchema().getRandomTable(t -> t.isInsertable());
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("cannot insert into column");
         PostgresCommon.addCommonExpressionErrors(errors);
         PostgresCommon.addCommonInsertUpdateErrors(errors);

--- a/src/sqlancer/postgres/gen/PostgresReindexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresReindexGenerator.java
@@ -1,9 +1,9 @@
 package sqlancer.postgres.gen;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -21,7 +21,7 @@ public final class PostgresReindexGenerator {
     }
 
     public static Query create(PostgresGlobalState globalState) {
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("could not create unique index"); // CONCURRENT INDEX
         StringBuilder sb = new StringBuilder();
         sb.append("REINDEX");

--- a/src/sqlancer/postgres/gen/PostgresSequenceGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresSequenceGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.postgres.gen;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -14,7 +12,7 @@ public final class PostgresSequenceGenerator {
     }
 
     public static Query createSequence(PostgresGlobalState globalState) {
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder("CREATE");
         if (Randomly.getBoolean()) {
             sb.append(" ");

--- a/src/sqlancer/postgres/gen/PostgresStatisticsGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresStatisticsGenerator.java
@@ -1,9 +1,9 @@
 package sqlancer.postgres.gen;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -44,7 +44,8 @@ public final class PostgresStatisticsGenerator {
         sb.append(randomColumns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
         sb.append(" FROM ");
         sb.append(randomTable.getName());
-        return new QueryAdapter(sb.toString(), Arrays.asList("cannot have more than 8 columns in statistics"), true);
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("cannot have more than 8 columns in statistics"),
+                true);
     }
 
     public static Query remove(PostgresGlobalState globalState) {

--- a/src/sqlancer/postgres/gen/PostgresTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableGenerator.java
@@ -1,11 +1,10 @@
 package sqlancer.postgres.gen;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -27,7 +26,7 @@ public class PostgresTableGenerator {
     private boolean isTemporaryTable;
     private final PostgresSchema newSchema;
     private final List<PostgresColumn> columnsToBeAdded = new ArrayList<>();
-    protected final Set<String> errors = new HashSet<>();
+    protected final ExpectedErrors errors = new ExpectedErrors();
     private final PostgresTable table;
     private final boolean generateOnlyKnown;
     private final PostgresGlobalState globalState;

--- a/src/sqlancer/postgres/gen/PostgresTransactionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTransactionGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.postgres.gen;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -13,7 +11,7 @@ public final class PostgresTransactionGenerator {
     }
 
     public static Query executeBegin() {
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder("BEGIN");
         if (Randomly.getBoolean()) {
             errors.add("SET TRANSACTION ISOLATION LEVEL must be called before any query");

--- a/src/sqlancer/postgres/gen/PostgresTruncateGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTruncateGenerator.java
@@ -1,8 +1,8 @@
 package sqlancer.postgres.gen;
 
-import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -34,8 +34,8 @@ public final class PostgresTruncateGenerator {
             sb.append(" ");
             sb.append(Randomly.fromOptions("CASCADE", "RESTRICT"));
         }
-        return new QueryAdapter(sb.toString(),
-                Arrays.asList("cannot truncate a table referenced in a foreign key constraint", "is not a table"));
+        return new QueryAdapter(sb.toString(), ExpectedErrors
+                .from("cannot truncate a table referenced in a foreign key constraint", "is not a table"));
     }
 
 }

--- a/src/sqlancer/postgres/gen/PostgresUpdateGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresUpdateGenerator.java
@@ -1,10 +1,8 @@
 package sqlancer.postgres.gen;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -26,12 +24,12 @@ public final class PostgresUpdateGenerator {
         sb.append("UPDATE ");
         sb.append(randomTable.getName());
         sb.append(" SET ");
-        Set<String> errors = new HashSet<>(Arrays.asList("conflicting key value violates exclusion constraint",
+        ExpectedErrors errors = ExpectedErrors.from("conflicting key value violates exclusion constraint",
                 "reached maximum value of sequence", "violates foreign key constraint", "violates not-null constraint",
                 "violates unique constraint", "out of range", "cannot cast", "must be type boolean", "is not unique",
                 " bit string too long", "can only be updated to DEFAULT", "division by zero",
                 "You might need to add explicit type casts.", "invalid regular expression",
-                "View columns that are not columns of their base relation are not updatable"));
+                "View columns that are not columns of their base relation are not updatable");
         errors.add("multiple assignments to same column"); // view whose columns refer to a column in the referenced
                                                            // table multiple times
         List<PostgresColumn> columns = randomTable.getRandomNonEmptyColumnSubset();

--- a/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
@@ -2,9 +2,9 @@ package sqlancer.postgres.gen;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -53,7 +53,7 @@ public final class PostgresVacuumGenerator {
                 }
             }
         }
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("VACUUM cannot run inside a transaction block");
         errors.add("deadlock"); /*
                                  * "FULL" commented out due to https://www.postgresql.org/message-id/CA%2Bu7OA6pL%

--- a/src/sqlancer/postgres/gen/PostgresViewGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresViewGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.postgres.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -17,7 +15,7 @@ public final class PostgresViewGenerator {
     }
 
     public static Query create(PostgresGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder("CREATE");
         boolean materialized;
         boolean recursive = false;

--- a/src/sqlancer/sqlite3/SQLite3Errors.java
+++ b/src/sqlancer/sqlite3/SQLite3Errors.java
@@ -1,23 +1,22 @@
 package sqlancer.sqlite3;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+
+import sqlancer.ExpectedErrors;
 
 public final class SQLite3Errors {
 
     private SQLite3Errors() {
     }
 
-    public static void addDeleteErrors(List<String> errors) {
+    public static void addDeleteErrors(ExpectedErrors errors) {
         // DELETE trigger for a view/table to which colomns were added or deleted
         errors.add("columns but");
         // trigger with on conflict clause
         errors.add("ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint");
     }
 
-    public static void addExpectedExpressionErrors(Collection<String> errors) {
+    public static void addExpectedExpressionErrors(ExpectedErrors errors) {
         errors.add("FTS expression tree is too large");
         errors.add("String or BLOB exceeds size limit");
         errors.add("[SQLITE_ERROR] SQL error or missing database (integer overflow)");
@@ -64,7 +63,7 @@ public final class SQLite3Errors {
 
     }
 
-    public static void addMatchQueryErrors(Collection<String> errors) {
+    public static void addMatchQueryErrors(ExpectedErrors errors) {
         errors.add("unable to use function MATCH in the requested context");
         errors.add("malformed MATCH expression");
         errors.add("fts5: syntax error near");
@@ -75,18 +74,18 @@ public final class SQLite3Errors {
         errors.add("unterminated string");
     }
 
-    public static void addTableManipulationErrors(List<String> errors) {
+    public static void addTableManipulationErrors(ExpectedErrors errors) {
         errors.add("unsupported frame specification");
         errors.add("non-deterministic functions prohibited in CHECK constraints");
         errors.addAll(Arrays.asList("subqueries prohibited in CHECK constraints",
                 "generated columns cannot be part of the PRIMARY KEY", "must have at least one non-generated column"));
     }
 
-    public static void addQueryErrors(Set<String> errors) {
+    public static void addQueryErrors(ExpectedErrors errors) {
         errors.add("ON clause references tables to its right");
     }
 
-    public static void addInsertNowErrors(List<String> errors) {
+    public static void addInsertNowErrors(ExpectedErrors errors) {
         errors.add("non-deterministic use of strftime()");
         errors.add("non-deterministic use of time()");
         errors.add("non-deterministic use of datetime()");

--- a/src/sqlancer/sqlite3/SQLite3Provider.java
+++ b/src/sqlancer/sqlite3/SQLite3Provider.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import sqlancer.AbstractAction;
+import sqlancer.ExpectedErrors;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
 import sqlancer.ProviderAdapter;
@@ -154,7 +155,7 @@ public class SQLite3Provider extends ProviderAdapter<SQLite3GlobalState, SQLite3
                     sb.append(" noskipscan");
                 }
                 sb.append("')");
-                return new QueryAdapter(sb.toString(), Arrays.asList("no such table"));
+                return new QueryAdapter(sb.toString(), ExpectedErrors.from("no such table"));
             }
         });
 
@@ -296,7 +297,7 @@ public class SQLite3Provider extends ProviderAdapter<SQLite3GlobalState, SQLite3
     private void checkTablesForGeneratedColumnLoops(SQLite3GlobalState globalState) throws SQLException {
         for (SQLite3Table table : globalState.getSchema().getDatabaseTables()) {
             Query q = new QueryAdapter("SELECT * FROM " + table.getName(),
-                    Arrays.asList("needs an odd number of arguments", " requires an even number of arguments",
+                    ExpectedErrors.from("needs an odd number of arguments", " requires an even number of arguments",
                             "generated column loop", "integer overflow", "malformed JSON",
                             "JSON cannot hold BLOB values", "JSON path error", "labels must be TEXT"));
             if (!q.execute(globalState)) {

--- a/src/sqlancer/sqlite3/gen/SQLite3AnalyzeGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3AnalyzeGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.sqlite3.gen;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -37,7 +36,7 @@ public final class SQLite3AnalyzeGenerator {
                 throw new AssertionError();
             }
         }
-        return new QueryAdapter(sb.toString(), Arrays.asList("The database file is locked"));
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("The database file is locked"));
     }
 
 }

--- a/src/sqlancer/sqlite3/gen/SQLite3CreateVirtualRtreeTabelGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3CreateVirtualRtreeTabelGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.sqlite3.gen;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -17,7 +16,7 @@ public final class SQLite3CreateVirtualRtreeTabelGenerator {
     }
 
     public static Query createTableStatement(String rTreeTableName, SQLite3GlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         List<SQLite3Column> columns = new ArrayList<>();
         StringBuilder sb = new StringBuilder("CREATE VIRTUAL TABLE ");
         sb.append(rTreeTableName);

--- a/src/sqlancer/sqlite3/gen/SQLite3PragmaGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3PragmaGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.sqlite3.gen;
 
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Supplier;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
 import sqlancer.sqlite3.SQLite3Provider.SQLite3GlobalState;
@@ -60,7 +59,7 @@ public class SQLite3PragmaGenerator {
     }
 
     private final StringBuilder sb = new StringBuilder();
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
 
     public void createPragma(String pragmaName, Supplier<Object> supplier) {
         boolean setSchema = Randomly.getBoolean();

--- a/src/sqlancer/sqlite3/gen/SQLite3ReindexGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ReindexGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.sqlite3.gen;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -24,7 +22,7 @@ public final class SQLite3ReindexGenerator {
     public static Query executeReindex(SQLite3GlobalState globalState) {
         SQLite3Schema s = globalState.getSchema();
         StringBuilder sb = new StringBuilder("REINDEX");
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         Target t = Randomly.fromOptions(Target.values());
         if (Randomly.getBoolean()) {
             sb.append(" ");

--- a/src/sqlancer/sqlite3/gen/SQLite3TransactionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3TransactionGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.sqlite3.gen;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -18,8 +17,8 @@ public final class SQLite3TransactionGenerator {
         if (Randomly.getBoolean()) {
             sb.append(" TRANSACTION");
         }
-        return new QueryAdapter(sb.toString(), Arrays.asList("no transaction is active", "The database file is locked",
-                "FOREIGN KEY constraint failed"), true);
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("no transaction is active",
+                "The database file is locked", "FOREIGN KEY constraint failed"), true);
     }
 
     public static Query generateBeginTransaction(SQLite3GlobalState globalState) {
@@ -30,13 +29,13 @@ public final class SQLite3TransactionGenerator {
         }
         sb.append(" TRANSACTION;");
         return new QueryAdapter(sb.toString(),
-                Arrays.asList("cannot start a transaction within a transaction", "The database file is locked"));
+                ExpectedErrors.from("cannot start a transaction within a transaction", "The database file is locked"));
     }
 
     public static Query generateRollbackTransaction(SQLite3GlobalState globalState) {
         // TODO: could be extended by savepoint
         return new QueryAdapter("ROLLBACK TRANSACTION;",
-                Arrays.asList("no transaction is active", "The database file is locked"), true);
+                ExpectedErrors.from("no transaction is active", "The database file is locked"), true);
     }
 
 }

--- a/src/sqlancer/sqlite3/gen/SQLite3VacuumGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3VacuumGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.sqlite3.gen;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -21,8 +20,8 @@ public final class SQLite3VacuumGenerator {
             sb.append(" ");
             sb.append(Randomly.fromOptions("temp", "main"));
         }
-        return new QueryAdapter(sb.toString(),
-                Arrays.asList("cannot VACUUM from within a transaction", "cannot VACUUM - SQL statements in progress"));
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("cannot VACUUM from within a transaction",
+                "cannot VACUUM - SQL statements in progress"));
     }
 
 }

--- a/src/sqlancer/sqlite3/gen/SQLite3VirtualFTSTableCommandGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3VirtualFTSTableCommandGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.sqlite3.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -15,7 +13,7 @@ public class SQLite3VirtualFTSTableCommandGenerator {
     private final StringBuilder sb = new StringBuilder();
     private final SQLite3Schema s;
     private final Randomly r;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
 
     public static Query create(SQLite3GlobalState globalState) {
         return new SQLite3VirtualFTSTableCommandGenerator(globalState.getSchema(), globalState.getRandomly())

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3AlterTable.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3AlterTable.java
@@ -1,9 +1,8 @@
 package sqlancer.sqlite3.gen.ddl;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -33,7 +32,7 @@ public class SQLite3AlterTable {
     }
 
     private Query getQuery(SQLite3Schema s, SQLite3AlterTable alterTable) throws AssertionError {
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("error in view");
         errors.add("no such column"); // trigger
         errors.add("error in trigger"); // trigger

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3CreateTriggerGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3CreateTriggerGenerator.java
@@ -2,9 +2,9 @@ package sqlancer.sqlite3.gen.ddl;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -110,7 +110,7 @@ public final class SQLite3CreateTriggerGenerator {
         sb.append("END");
 
         return new QueryAdapter(sb.toString(),
-                Arrays.asList("parser stack overflow", "unsupported frame specification"));
+                ExpectedErrors.from("parser stack overflow", "unsupported frame specification"));
     }
 
     private static void appendTableNameAndWhen(SQLite3GlobalState globalState, StringBuilder sb, SQLite3Table table) {

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3CreateVirtualFTSTableGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3CreateVirtualFTSTableGenerator.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -45,8 +46,8 @@ public class SQLite3CreateVirtualFTSTableGenerator {
         } else {
             createFts5Table();
         }
-        return new QueryAdapter(sb.toString(), Arrays.asList("unrecognized parameter", "unknown tokenizer: ascii"),
-                true);
+        return new QueryAdapter(sb.toString(),
+                ExpectedErrors.from("unrecognized parameter", "unknown tokenizer: ascii"), true);
     }
 
     private void createFts4Table() {

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3DropIndexGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3DropIndexGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.sqlite3.gen.ddl;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -23,7 +22,7 @@ public final class SQLite3DropIndexGenerator {
         sb.append('"');
         sb.append(indexName);
         sb.append('"');
-        return new QueryAdapter(sb.toString(), Arrays.asList(
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from(
                 "[SQLITE_ERROR] SQL error or missing database (index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped)"),
                 true);
     }

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3DropTableGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3DropTableGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.sqlite3.gen.ddl;
 
-import java.util.Arrays;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -23,7 +22,7 @@ public final class SQLite3DropTableGenerator {
         }
         sb.append(globalState.getSchema().getRandomTableOrBailout(t -> !t.isView()).getName());
         return new QueryAdapter(sb.toString(),
-                Arrays.asList("[SQLITE_ERROR] SQL error or missing database (foreign key mismatch",
+                ExpectedErrors.from("[SQLITE_ERROR] SQL error or missing database (foreign key mismatch",
                         "Abort due to constraint violation (FOREIGN KEY constraint failed)",
                         "SQL error or missing database"),
                 true);

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3IndexGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3IndexGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.sqlite3.gen.ddl;
 
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -21,7 +20,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 // see https://www.sqlite.org/lang_createindex.html
 public class SQLite3IndexGenerator {
 
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private final SQLite3GlobalState globalState;
 
     public static Query insertIndex(SQLite3GlobalState globalState) throws SQLException {

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3TableGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3TableGenerator.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -47,7 +48,7 @@ public class SQLite3TableGenerator {
     public static Query createTableStatement(String tableName, SQLite3GlobalState globalState) {
         SQLite3TableGenerator sqLite3TableGenerator = new SQLite3TableGenerator(tableName, globalState);
         sqLite3TableGenerator.start();
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         SQLite3Errors.addTableManipulationErrors(errors);
         errors.add("second argument to likelihood() must be a constant between 0.0 and 1.0");
         errors.add("non-deterministic functions prohibited in generated columns");

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3ViewGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3ViewGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.sqlite3.gen.ddl;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -42,7 +41,7 @@ public final class SQLite3ViewGenerator {
             sb.append(" IF NOT EXISTS ");
         }
         sb.append(SQLite3Common.getFreeViewName(globalState.getSchema()));
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("is circularly defined");
         errors.add("unsupported frame specification");
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3DeleteGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3DeleteGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.sqlite3.gen.dml;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -32,7 +31,7 @@ public final class SQLite3DeleteGenerator {
             sb.append(SQLite3Visitor.asString(new SQLite3ExpressionGenerator(globalState)
                     .setColumns(tableName.getColumns()).generateExpression()));
         }
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         SQLite3Errors.addExpectedExpressionErrors(errors);
         errors.addAll(Arrays.asList("[SQLITE_ERROR] SQL error or missing database (foreign key mismatch",
                 "[SQLITE_CONSTRAINT]  Abort due to constraint violation ",

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3InsertGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3InsertGenerator.java
@@ -1,10 +1,10 @@
 package sqlancer.sqlite3.gen.dml;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -21,13 +21,13 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 public class SQLite3InsertGenerator {
 
     private final Randomly r;
-    private final List<String> errors;
+    private final ExpectedErrors errors;
     private final SQLite3GlobalState globalState;
 
     public SQLite3InsertGenerator(SQLite3GlobalState globalState, Randomly r) {
         this.globalState = globalState;
         this.r = r;
-        errors = new ArrayList<>();
+        errors = new ExpectedErrors();
     }
 
     public static Query insertRow(SQLite3GlobalState globalState) throws SQLException {

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
@@ -1,9 +1,9 @@
 package sqlancer.sqlite3.gen.dml;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -19,7 +19,7 @@ public class SQLite3UpdateGenerator {
 
     private final StringBuilder sb = new StringBuilder();
     private final Randomly r;
-    private final List<String> errors = new ArrayList<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private final SQLite3GlobalState globalState;
 
     public SQLite3UpdateGenerator(SQLite3GlobalState globalState, Randomly r) {

--- a/src/sqlancer/sqlite3/oracle/SQLite3PivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3PivotedQuerySynthesisOracle.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -53,7 +54,7 @@ public class SQLite3PivotedQuerySynthesisOracle implements TestOracle {
     private SQLite3StateToReproduce state;
     private SQLite3RowValue rw;
     private List<SQLite3Column> fetchColumns;
-    private final List<String> errors = new ArrayList<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private List<SQLite3Expression> colExpressions;
     private final SQLite3GlobalState globalState;
 
@@ -85,7 +86,7 @@ public class SQLite3PivotedQuerySynthesisOracle implements TestOracle {
         return new QueryAdapter(queryString, errors);
     }
 
-    public static void addExpectedErrors(List<String> errors) {
+    public static void addExpectedErrors(ExpectedErrors errors) {
         errors.add("no such index");
         errors.add("no query solution");
         errors.add(
@@ -239,12 +240,11 @@ public class SQLite3PivotedQuerySynthesisOracle implements TestOracle {
             createStatement.close();
             return isContainedIn;
         } catch (SQLException e) {
-            for (String exp : finalQuery.getExpectedErrors()) {
-                if (e.getMessage().contains(exp)) {
-                    return true;
-                }
+            if (finalQuery.getExpectedErrors().errorIsExpected(e.getMessage())) {
+                return true;
+            } else {
+                throw e;
             }
-            throw e;
         }
     }
 

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
@@ -1,11 +1,11 @@
 package sqlancer.sqlite3.oracle.tlp;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import sqlancer.ComparatorHelper;
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -31,7 +31,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
 public class SQLite3TLPAggregateOracle implements TestOracle {
 
     private final SQLite3GlobalState state;
-    private final List<String> errors = new ArrayList<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private SQLite3ExpressionGenerator gen;
 
     public SQLite3TLPAggregateOracle(SQLite3GlobalState state) {

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
@@ -3,10 +3,10 @@ package sqlancer.sqlite3.oracle.tlp;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import sqlancer.ComparatorHelper;
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.TestOracle;
@@ -32,7 +32,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
 public class SQLite3TLPHavingOracle implements TestOracle {
 
     private final SQLite3GlobalState state;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
 
     public SQLite3TLPHavingOracle(SQLite3GlobalState state) {
         this.state = state;

--- a/src/sqlancer/sqlite3/schema/SQLite3Schema.java
+++ b/src/sqlancer/sqlite3/schema/SQLite3Schema.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -347,7 +348,7 @@ public class SQLite3Schema {
 
     public static int getNrRows(SQLite3GlobalState globalState, String table) throws SQLException {
         String string = "SELECT COUNT(*) FROM " + table;
-        List<String> errors = new ArrayList<>();
+        ExpectedErrors errors = new ExpectedErrors();
         errors.add("ORDER BY term out of range");
         errors.addAll(Arrays.asList("second argument to nth_value must be a positive integer",
                 "ON clause references tables to its right", "no such table", "no query solution", "no such index",

--- a/src/sqlancer/tidb/TiDBErrors.java
+++ b/src/sqlancer/tidb/TiDBErrors.java
@@ -1,13 +1,13 @@
 package sqlancer.tidb;
 
-import java.util.Set;
+import sqlancer.ExpectedErrors;
 
 public final class TiDBErrors {
 
     private TiDBErrors() {
     }
 
-    public static void addExpressionErrors(Set<String> errors) {
+    public static void addExpressionErrors(ExpectedErrors errors) {
         errors.add("DECIMAL value is out of range");
         errors.add("error parsing regexp");
         errors.add("BIGINT UNSIGNED value is out of range");
@@ -46,12 +46,12 @@ public final class TiDBErrors {
         errors.add("Illegal mix of collations");
     }
 
-    public static void addExpressionHavingErrors(Set<String> errors) {
+    public static void addExpressionHavingErrors(ExpectedErrors errors) {
         errors.add("is not in GROUP BY clause and contains nonaggregated column");
         errors.add("Unknown column");
     }
 
-    public static void addInsertErrors(Set<String> errors) {
+    public static void addInsertErrors(ExpectedErrors errors) {
         errors.add("Duplicate entry");
         errors.add("cannot be null");
         errors.add("doesn't have a default value");

--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -4,13 +4,12 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import sqlancer.AbstractAction;
 import sqlancer.CompositeTestOracle;
+import sqlancer.ExpectedErrors;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
 import sqlancer.ProviderAdapter;
@@ -51,7 +50,7 @@ public class TiDBProvider extends ProviderAdapter<TiDBGlobalState, TiDBOptions> 
         VIEW_GENERATOR(TiDBViewGenerator::getQuery), //
         ALTER_TABLE(TiDBAlterTableGenerator::getQuery), //
         EXPLAIN((g) -> {
-            Set<String> errors = new HashSet<>();
+            ExpectedErrors errors = new ExpectedErrors();
             TiDBErrors.addExpressionErrors(errors);
             TiDBErrors.addExpressionHavingErrors(errors);
             return new QueryAdapter(

--- a/src/sqlancer/tidb/gen/TiDBAlterTableGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBAlterTableGenerator.java
@@ -1,9 +1,8 @@
 package sqlancer.tidb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -24,7 +23,7 @@ public final class TiDBAlterTableGenerator {
     }
 
     public static Query getQuery(TiDBGlobalState globalState) {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         StringBuilder sb = new StringBuilder("ALTER TABLE ");
         TiDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         TiDBColumn column = table.getRandomColumn();

--- a/src/sqlancer/tidb/gen/TiDBAnalyzeTableGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBAnalyzeTableGenerator.java
@@ -1,8 +1,8 @@
 package sqlancer.tidb.gen;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -32,7 +32,7 @@ public final class TiDBAnalyzeTableGenerator {
             sb.append(Randomly.getNotCachedInteger(1, 1024));
             sb.append(" BUCKETS");
         }
-        return new QueryAdapter(sb.toString(), Arrays.asList("https://github.com/pingcap/tidb/issues/15993",
+        return new QueryAdapter(sb.toString(), ExpectedErrors.from("https://github.com/pingcap/tidb/issues/15993",
                 /* https://github.com/pingcap/tidb/issues/15993 */ "doesn't have a default value" /*
                                                                                                    * https://github.
                                                                                                    * com/pingcap/tidb/

--- a/src/sqlancer/tidb/gen/TiDBDeleteGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBDeleteGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.tidb.gen;
 
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -20,7 +19,7 @@ public final class TiDBDeleteGenerator {
     }
 
     public static Query getQuery(TiDBGlobalState globalState) throws SQLException {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         TiDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         TiDBExpressionGenerator gen = new TiDBExpressionGenerator(globalState).setColumns(table.getColumns());
         StringBuilder sb = new StringBuilder("DELETE ");

--- a/src/sqlancer/tidb/gen/TiDBIndexGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBIndexGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.tidb.gen;
 
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -18,7 +17,7 @@ public final class TiDBIndexGenerator {
     }
 
     public static Query getQuery(TiDBGlobalState globalState) throws SQLException {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
 
         TiDBTable randomTable = globalState.getSchema().getRandomTable(t -> !t.isView());
         String indexName = globalState.getSchema().getFreeIndexName();

--- a/src/sqlancer/tidb/gen/TiDBInsertGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBInsertGenerator.java
@@ -1,11 +1,10 @@
 package sqlancer.tidb.gen;
 
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -19,7 +18,7 @@ import sqlancer.tidb.visitor.TiDBVisitor;
 public class TiDBInsertGenerator {
 
     private final TiDBGlobalState globalState;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
     private TiDBExpressionGenerator gen;
 
     public TiDBInsertGenerator(TiDBGlobalState globalState) {

--- a/src/sqlancer/tidb/gen/TiDBTableGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBTableGenerator.java
@@ -2,11 +2,10 @@ package sqlancer.tidb.gen;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.IgnoreMeException;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
@@ -25,7 +24,7 @@ public class TiDBTableGenerator {
     private boolean allowPrimaryKey;
     private final List<TiDBColumn> columns = new ArrayList<>();
     private boolean primaryKeyAsTableConstraints;
-    private final Set<String> errors = new HashSet<>();
+    private final ExpectedErrors errors = new ExpectedErrors();
 
     public Query getQuery(TiDBGlobalState globalState) throws SQLException {
         errors.add("Information schema is changed during the execution of the statement");

--- a/src/sqlancer/tidb/gen/TiDBUpdateGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBUpdateGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.tidb.gen;
 
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -21,7 +20,7 @@ public final class TiDBUpdateGenerator {
     }
 
     public static Query getQuery(TiDBGlobalState globalState) throws SQLException {
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         TiDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         TiDBExpressionGenerator gen = new TiDBExpressionGenerator(globalState).setColumns(table.getColumns());
         StringBuilder sb = new StringBuilder("UPDATE ");

--- a/src/sqlancer/tidb/gen/TiDBViewGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBViewGenerator.java
@@ -1,8 +1,6 @@
 package sqlancer.tidb.gen;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import sqlancer.ExpectedErrors;
 import sqlancer.Query;
 import sqlancer.QueryAdapter;
 import sqlancer.Randomly;
@@ -37,7 +35,7 @@ public final class TiDBViewGenerator {
         }
         sb.append(") AS ");
         sb.append(TiDBRandomQuerySynthesizer.generate(globalState, nrColumns).getQueryString());
-        Set<String> errors = new HashSet<>();
+        ExpectedErrors errors = new ExpectedErrors();
         TiDBErrors.addExpressionErrors(errors);
         errors.add(
                 "references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them");

--- a/test/sqlancer/TestExpectedErrors.java
+++ b/test/sqlancer/TestExpectedErrors.java
@@ -1,0 +1,38 @@
+package sqlancer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TestExpectedErrors {
+
+    @Test
+    public void testEmpty() {
+        ExpectedErrors errors = new ExpectedErrors();
+        assertFalse(errors.errorIsExpected("a"));
+    }
+
+    @Test
+    public void testSimple() {
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("a");
+        errors.add("b");
+        errors.add("c");
+        assertTrue(errors.errorIsExpected("a"));
+        assertTrue(errors.errorIsExpected("b"));
+        assertTrue(errors.errorIsExpected("c"));
+        assertTrue(errors.errorIsExpected("aa"));
+
+        assertFalse(errors.errorIsExpected("d"));
+    }
+
+    @Test
+    public void testRealistic() {
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("violated");
+        assertTrue(errors.errorIsExpected("UNIQUE constraint was violated!"));
+        assertTrue(errors.errorIsExpected("PRIMARY KEY constraint was violated!"));
+    }
+
+}


### PR DESCRIPTION
This class should introduce additional flexibility when dealing with expected errors. For example, future improvements could add support for regular expressions.

Partly addresses https://github.com/sqlancer/sqlancer/issues/32.