### PR TITLE
Miscellaneous fixes to Citus & Postgres

### DIFF
--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -74,6 +74,15 @@ public class StateToReproduce {
         return Collections.unmodifiableList(statements);
     }
 
+    public void commentStatements() {
+        for (int i = 0; i < statements.size(); i ++) {
+            Query statement = statements.get(i);
+            String queryString = statement.getQueryString();
+            String newQueryString = "-- " + queryString;
+            statements.set(i, new QueryAdapter(newQueryString));
+        }
+    }
+
     public long getSeedValue() {
         return seedValue;
     }

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -75,7 +75,7 @@ public class StateToReproduce {
     }
 
     public void commentStatements() {
-        for (int i = 0; i < statements.size(); i ++) {
+        for (int i = 0; i < statements.size(); i++) {
             Query statement = statements.get(i);
             String queryString = statement.getQueryString();
             String newQueryString = "-- " + queryString;

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -271,14 +271,13 @@ public class CitusProvider extends PostgresProvider {
                     columns.add(c);
                 }
             }
-            // TODO: diffferent behavior for EXCLUDE constraint?
         }
         distributeTable(columns, tableName, globalState);
     }
 
     @Override
     public void generateDatabase(PostgresGlobalState globalState) throws SQLException {
-        // TODO: function reading? add to Postgres implementation?
+        readFunctions(globalState);
         createTables(globalState, Randomly.fromOptions(4, 5, 6));
         for (PostgresTable table : globalState.getSchema().getDatabaseTables()) {
             if (!(table.getTableType() == TableType.TEMPORARY || Randomly.getBooleanWithRatherLowProbability())) {
@@ -378,7 +377,6 @@ public class CitusProvider extends PostgresProvider {
     private void addCitusWorkerNodes(PostgresGlobalState globalState, Connection con,
             List<CitusWorkerNode> citusWorkerNodes) throws SQLException {
         for (CitusWorkerNode w : citusWorkerNodes) {
-            // TODO: protect from sql injection
             String addWorkers = "SELECT * from master_add_node('" + w.getHost() + "', " + w.getPort() + ");";
             globalState.getState().logStatement(addWorkers);
             try (Statement s = con.createStatement()) {

--- a/src/sqlancer/citus/CitusSchema.java
+++ b/src/sqlancer/citus/CitusSchema.java
@@ -14,7 +14,6 @@ import sqlancer.postgres.PostgresSchema;
 public class CitusSchema extends PostgresSchema {
 
     public CitusSchema(List<CitusTable> databaseTables, String databaseName) {
-        // FIXME: Will casting to PostgresTable lose CitusTable features?
         super(new ArrayList<>(databaseTables), databaseName);
     }
 
@@ -71,8 +70,6 @@ public class CitusSchema extends PostgresSchema {
                         if (rs.wasNull()) {
                             colocationId = null;
                         }
-                        // FIXME: Are the CitusTable-specific features I'm adding going to persist after the function
-                        // call?
                         PostgresTable t = schema.getDatabaseTable(tableName);
                         PostgresColumn distributionColumn = null;
                         if (t == null) {

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -188,6 +188,7 @@ public class PostgresProvider extends ProviderAdapter<PostgresGlobalState, Postg
 
     @Override
     public void generateDatabase(PostgresGlobalState globalState) throws SQLException {
+        readFunctions(globalState);
         createTables(globalState, Randomly.fromOptions(4, 5, 6));
         prepareTables(globalState);
     }

--- a/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
@@ -253,6 +253,7 @@ public class PostgresAlterTableGenerator {
                 sb.append("ADD ");
                 sb.append("CONSTRAINT " + r.getAlphabeticChar() + " ");
                 PostgresCommon.addTableConstraint(sb, randomTable, globalState, errors);
+                errors.add("already exists");
                 errors.add("multiple primary keys for table");
                 errors.add("could not create unique index");
                 errors.add("contains null values");
@@ -283,6 +284,7 @@ public class PostgresAlterTableGenerator {
                 sb.append("ADD ");
                 sb.append("CONSTRAINT " + r.getAlphabeticChar() + " ");
                 sb.append(Randomly.fromOptions("UNIQUE", "PRIMARY KEY"));
+                errors.add("already exists");
                 errors.add("not valid");
                 sb.append(" USING INDEX ");
                 sb.append(randomTable.getRandomIndex().getIndexName());


### PR DESCRIPTION
This PR:
1- Comments out the creation of the databases in Citus error logs as these are not reproduceable SQL commands (to reproduce, creating an empty Citus cluster with the appropriate workers and then running the file is possible with the new edit).
2- Fixes a bug that caused no functions to ever be used in the PostgresExpressionGenerator
3- Does a general clean-up of the Citus package source code
4. Adds expected error raised when multiple constraints with same name are trying to be added