### PR TITLE
Ensure expressions with expected non-NULL values in Postgres when using PQS

### DIFF
--- a/src/sqlancer/postgres/ast/PostgresBinaryArithmeticOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresBinaryArithmeticOperation.java
@@ -48,12 +48,10 @@ public class PostgresBinaryArithmeticOperation extends BinaryOperatorNode<Postgr
 
             }
         },
-        // TODO no implementation
         EXPONENTIATION("^") {
             @Override
             public PostgresConstant apply(PostgresConstant left, PostgresConstant right) {
-                // return applyBitOperation(left, right, (l, r) -> (long) Math.pow(l, r));
-                throw new AssertionError();
+                return null;
             }
         };
 
@@ -97,6 +95,9 @@ public class PostgresBinaryArithmeticOperation extends BinaryOperatorNode<Postgr
     public PostgresConstant getExpectedValue() {
         PostgresConstant leftExpected = getLeft().getExpectedValue();
         PostgresConstant rightExpected = getRight().getExpectedValue();
+        if (leftExpected == null || rightExpected == null) {
+            return null;
+        }
         return getOp().apply(leftExpected, rightExpected);
     }
 

--- a/src/sqlancer/postgres/ast/PostgresBinaryComparisonOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresBinaryComparisonOperation.java
@@ -123,7 +123,12 @@ public class PostgresBinaryComparisonOperation
 
     @Override
     public PostgresConstant getExpectedValue() {
-        return getOp().getExpectedValue(getLeft().getExpectedValue(), getRight().getExpectedValue());
+        PostgresConstant leftExpectedValue = getLeft().getExpectedValue();
+        PostgresConstant rightExpectedValue = getRight().getExpectedValue();
+        if (leftExpectedValue == null || rightExpectedValue == null) {
+            return null;
+        }
+        return getOp().getExpectedValue(leftExpectedValue, rightExpectedValue);
     }
 
     @Override

--- a/src/sqlancer/postgres/ast/PostgresBinaryLogicalOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresBinaryLogicalOperation.java
@@ -77,7 +77,12 @@ public class PostgresBinaryLogicalOperation extends BinaryOperatorNode<PostgresE
 
     @Override
     public PostgresConstant getExpectedValue() {
-        return getOp().apply(getLeft().getExpectedValue(), getRight().getExpectedValue());
+        PostgresConstant leftExpectedValue = getLeft().getExpectedValue();
+        PostgresConstant rightExpectedValue = getRight().getExpectedValue();
+        if (leftExpectedValue == null || rightExpectedValue == null) {
+            return null;
+        }
+        return getOp().apply(leftExpectedValue, rightExpectedValue);
     }
 
 }

--- a/src/sqlancer/postgres/ast/PostgresCastOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresCastOperation.java
@@ -23,7 +23,11 @@ public class PostgresCastOperation implements PostgresExpression {
 
     @Override
     public PostgresConstant getExpectedValue() {
-        return expression.getExpectedValue().cast(type.getDataType());
+        PostgresConstant expectedValue = expression.getExpectedValue();
+        if (expectedValue == null) {
+            return null;
+        }
+        return expectedValue.cast(type.getDataType());
     }
 
     public PostgresExpression getExpression() {

--- a/src/sqlancer/postgres/ast/PostgresConcatOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresConcatOperation.java
@@ -16,11 +16,16 @@ public class PostgresConcatOperation extends BinaryNode<PostgresExpression> impl
 
     @Override
     public PostgresConstant getExpectedValue() {
-        if (getLeft().getExpectedValue().isNull() || getRight().getExpectedValue().isNull()) {
+        PostgresConstant leftExpectedValue = getLeft().getExpectedValue();
+        PostgresConstant rightExpectedValue = getRight().getExpectedValue();
+        if (leftExpectedValue == null || rightExpectedValue == null) {
+            return null;
+        }
+        if (leftExpectedValue.isNull() || rightExpectedValue.isNull()) {
             return PostgresConstant.createNullConstant();
         }
-        String leftStr = getLeft().getExpectedValue().cast(PostgresDataType.TEXT).getUnquotedTextRepresentation();
-        String rightStr = getRight().getExpectedValue().cast(PostgresDataType.TEXT).getUnquotedTextRepresentation();
+        String leftStr = leftExpectedValue.cast(PostgresDataType.TEXT).getUnquotedTextRepresentation();
+        String rightStr = rightExpectedValue.cast(PostgresDataType.TEXT).getUnquotedTextRepresentation();
         return PostgresConstant.createTextConstant(leftStr + rightStr);
     }
 

--- a/src/sqlancer/postgres/ast/PostgresConstant.java
+++ b/src/sqlancer/postgres/ast/PostgresConstant.java
@@ -75,7 +75,7 @@ public abstract class PostgresConstant implements PostgresExpression {
             case TEXT:
                 return PostgresConstant.createTextConstant(value ? "true" : "false");
             default:
-                throw new AssertionError();
+                return null;
             }
         }
 
@@ -212,7 +212,7 @@ public abstract class PostgresConstant implements PostgresExpression {
             case TEXT:
                 return this;
             default:
-                throw new AssertionError(this);
+                return null;
             }
         }
 
@@ -307,7 +307,7 @@ public abstract class PostgresConstant implements PostgresExpression {
             case TEXT:
                 return PostgresConstant.createTextConstant(String.valueOf(val));
             default:
-                throw new AssertionError(type);
+                return null;
             }
         }
 
@@ -406,8 +406,7 @@ public abstract class PostgresConstant implements PostgresExpression {
 
         @Override
         public PostgresConstant cast(PostgresDataType type) {
-            throw new AssertionError();
-
+            return null;
         }
     }
 

--- a/src/sqlancer/postgres/ast/PostgresExpression.java
+++ b/src/sqlancer/postgres/ast/PostgresExpression.java
@@ -5,10 +5,10 @@ import sqlancer.postgres.PostgresSchema.PostgresDataType;
 public interface PostgresExpression {
 
     default PostgresDataType getExpressionType() {
-        throw new AssertionError("operator does not support PQS evaluation!");
+        return null;
     }
 
     default PostgresConstant getExpectedValue() {
-        throw new AssertionError("operator does not support PQS evaluation!");
+        return null;
     }
 }

--- a/src/sqlancer/postgres/ast/PostgresFunction.java
+++ b/src/sqlancer/postgres/ast/PostgresFunction.java
@@ -286,10 +286,15 @@ public class PostgresFunction implements PostgresExpression {
 
     @Override
     public PostgresConstant getExpectedValue() {
-        assert functionWithKnownResult != null;
+        if (functionWithKnownResult == null) {
+            return null;
+        }
         PostgresConstant[] constants = new PostgresConstant[args.length];
         for (int i = 0; i < constants.length; i++) {
             constants[i] = args[i].getExpectedValue();
+            if (constants[i] == null) {
+                return null;
+            }
         }
         return functionWithKnownResult.apply(constants, args);
     }

--- a/src/sqlancer/postgres/ast/PostgresInOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresInOperation.java
@@ -26,15 +26,23 @@ public class PostgresInOperation implements PostgresExpression {
 
     @Override
     public PostgresConstant getExpectedValue() {
-        if (expr.getExpectedValue().isNull()) {
+        PostgresConstant leftValue = expr.getExpectedValue();
+        if (leftValue == null) {
+            return null;
+        }
+        if (leftValue.isNull()) {
             return PostgresConstant.createNullConstant();
         }
         boolean isNull = false;
         for (PostgresExpression expr : getListElements()) {
-            if (expr.getExpectedValue().isNull()) {
+            PostgresConstant rightExpectedValue = expr.getExpectedValue();
+            if (rightExpectedValue == null) {
+                return null;
+            }
+            if (rightExpectedValue.isNull()) {
                 isNull = true;
-            } else if (expr.getExpectedValue().isEquals(this.expr.getExpectedValue()).isBoolean()
-                    && expr.getExpectedValue().isEquals(this.expr.getExpectedValue()).asBoolean()) {
+            } else if (rightExpectedValue.isEquals(this.expr.getExpectedValue()).isBoolean()
+                    && rightExpectedValue.isEquals(this.expr.getExpectedValue()).asBoolean()) {
                 return PostgresConstant.createBooleanConstant(isTrue);
             }
         }

--- a/src/sqlancer/postgres/ast/PostgresLikeOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresLikeOperation.java
@@ -19,6 +19,9 @@ public class PostgresLikeOperation extends BinaryNode<PostgresExpression> implem
     public PostgresConstant getExpectedValue() {
         PostgresConstant leftVal = getLeft().getExpectedValue();
         PostgresConstant rightVal = getRight().getExpectedValue();
+        if (leftVal == null || rightVal == null) {
+            return null;
+        }
         if (leftVal.isNull() || rightVal.isNull()) {
             return PostgresConstant.createNullConstant();
         } else {

--- a/src/sqlancer/postgres/ast/PostgresPostfixOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresPostfixOperation.java
@@ -129,7 +129,11 @@ public class PostgresPostfixOperation implements PostgresExpression {
 
     @Override
     public PostgresConstant getExpectedValue() {
-        return op.apply(expr.getExpectedValue());
+        PostgresConstant expectedValue = expr.getExpectedValue();
+        if (expectedValue == null) {
+            return null;
+        }
+        return op.apply(expectedValue);
     }
 
     public String getOperatorTextRepresentation() {

--- a/src/sqlancer/postgres/ast/PostgresPrefixOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresPrefixOperation.java
@@ -51,7 +51,11 @@ public class PostgresPrefixOperation implements PostgresExpression {
                     // TODO
                     throw new IgnoreMeException();
                 }
-                return PostgresConstant.createIntConstant(-expectedValue.asInt());
+                try {
+                    return PostgresConstant.createIntConstant(-expectedValue.asInt());
+                } catch (UnsupportedOperationException e) {
+                    return null;
+                }
             }
 
         };
@@ -90,7 +94,11 @@ public class PostgresPrefixOperation implements PostgresExpression {
 
     @Override
     public PostgresConstant getExpectedValue() {
-        return op.getExpectedValue(expr.getExpectedValue());
+        PostgresConstant expectedValue = expr.getExpectedValue();
+        if (expectedValue == null) {
+            return null;
+        }
+        return op.getExpectedValue(expectedValue);
     }
 
     public PostgresDataType[] getInputDataTypes() {


### PR DESCRIPTION
See https://github.com/sqlancer/sqlancer/issues/161.