### PR TITLE
Use NUMERIC as a string generation strategy for the MySQL tests

### DIFF
--- a/test/sqlancer/dbms/TestMySQL.java
+++ b/test/sqlancer/dbms/TestMySQL.java
@@ -16,8 +16,13 @@ public class TestMySQL {
     public void testPQS() {
         assumeTrue(mysqlIsAvailable);
         assertEquals(0,
+                /*
+                 * While the MySQL generation supports ALPHANUMERIC as string generation strategy, the Travis CI gate
+                 * seems to fail due to special characters that are not supposed to be generated, and which cannot be
+                 * reproduced locally.
+                 */
                 Main.executeMain(new String[] { "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
-                        "--num-threads", "4", "--random-string-generation", "ALPHANUMERIC", "--database-prefix",
+                        "--num-threads", "4", "--random-string-generation", "NUMERIC", "--database-prefix",
                         "pqsdb" /* Workaround for connections not being closed */, "--num-queries",
                         TestConfig.NUM_QUERIES, "mysql", "--oracle", "PQS" }));
     }

--- a/test/sqlancer/dbms/TestMySQL.java
+++ b/test/sqlancer/dbms/TestMySQL.java
@@ -28,7 +28,7 @@ public class TestMySQL {
         assertEquals(0,
                 Main.executeMain(new String[] { "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
                         "--max-expression-depth", "1", "--num-threads", "4", "--num-queries", TestConfig.NUM_QUERIES,
-                        "mysql" }));
+                        "mysql", "--oracle", "TLP_WHERE" }));
     }
 
 }


### PR DESCRIPTION
See https://github.com/sqlancer/sqlancer/issues/161.