### PR TITLE
Add known Citus error 'cannot modify views over distributed tables'

### DIFF
--- a/src/sqlancer/citus/gen/CitusCommon.java
+++ b/src/sqlancer/citus/gen/CitusCommon.java
@@ -36,6 +36,7 @@ public final class CitusCommon {
         errors.add("cannot create foreign key constraint"); // SET NULL or SET DEFAULT is not supported in ON DELETE
                                                             // operation when distribution key is included in the
                                                             // foreign key constraint
+        errors.add("cannot modify views over distributed tables");
 
         // not supported by Citus (restrictions on SELECT queries)
         errors.add(


### PR DESCRIPTION
Adds known and expected Citus error message 'cannot modify views over distributed tables'.
Citus does not support the modification of views that are created over distributed tables.

We have used SQLancer again during our release process and found some interesting bugs thanks to it.