### PR TITLE
Refactor Logging to remove SQL Dependency, keeping same Functionality

### DIFF
--- a/src/sqlancer/DatabaseProvider.java
+++ b/src/sqlancer/DatabaseProvider.java
@@ -3,6 +3,8 @@ package sqlancer;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import sqlancer.common.log.LoggableFactory;
+
 public interface DatabaseProvider<G extends GlobalState<O, ?>, O extends DBMSSpecificOptions<?>> {
 
     /**
@@ -36,6 +38,8 @@ public interface DatabaseProvider<G extends GlobalState<O, ?>, O extends DBMSSpe
      * @return the DBMS' name
      */
     String getDBMSName();
+
+    LoggableFactory getLoggableFactory();
 
     StateToReproduce getStateToReproduce(String databaseName);
 

--- a/src/sqlancer/ProviderAdapter.java
+++ b/src/sqlancer/ProviderAdapter.java
@@ -23,7 +23,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ?>, O extends DBM
 
     @Override
     public StateToReproduce getStateToReproduce(String databaseName) {
-        return new StateToReproduce(databaseName);
+        return new StateToReproduce(databaseName, this);
     }
 
     @Override

--- a/src/sqlancer/SQLProviderAdapter.java
+++ b/src/sqlancer/SQLProviderAdapter.java
@@ -1,0 +1,16 @@
+package sqlancer;
+
+import sqlancer.common.log.LoggableFactory;
+import sqlancer.common.log.SQLLoggableFactory;
+
+public abstract class SQLProviderAdapter<G extends GlobalState<O, ?>, O extends DBMSSpecificOptions<? extends OracleFactory<G>>>
+        extends ProviderAdapter<G, O> {
+    public SQLProviderAdapter(Class<G> globalClass, Class<O> optionClass) {
+        super(globalClass, optionClass);
+    }
+
+    @Override
+    public LoggableFactory getLoggableFactory() {
+        return new SQLLoggableFactory();
+    }
+}

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -6,13 +6,14 @@ import java.util.Collections;
 import java.util.List;
 
 import sqlancer.common.query.Query;
-import sqlancer.common.query.QueryAdapter;
 
 public class StateToReproduce {
 
     private final List<Query> statements = new ArrayList<>();
 
     private final String databaseName;
+
+    private final DatabaseProvider<?, ?> databaseProvider;
 
     public String databaseVersion;
 
@@ -22,8 +23,9 @@ public class StateToReproduce {
 
     public OracleRunReproductionState localState;
 
-    public StateToReproduce(String databaseName) {
+    public StateToReproduce(String databaseName, DatabaseProvider<?, ?> databaseProvider) {
         this.databaseName = databaseName;
+        this.databaseProvider = databaseProvider;
     }
 
     public String getException() {
@@ -48,7 +50,7 @@ public class StateToReproduce {
         if (queryString == null) {
             throw new IllegalArgumentException();
         }
-        logStatement(new QueryAdapter(queryString));
+        logStatement(databaseProvider.getLoggableFactory().getQueryForStateToReproduce(queryString));
     }
 
     /**
@@ -68,12 +70,12 @@ public class StateToReproduce {
         return Collections.unmodifiableList(statements);
     }
 
+    @Deprecated
     public void commentStatements() {
         for (int i = 0; i < statements.size(); i++) {
             Query statement = statements.get(i);
-            String queryString = statement.getQueryString();
-            String newQueryString = "-- " + queryString;
-            statements.set(i, new QueryAdapter(newQueryString));
+            Query newQuery = databaseProvider.getLoggableFactory().commentOutQuery(statement);
+            statements.set(i, newQuery);
         }
     }
 
@@ -109,7 +111,7 @@ public class StateToReproduce {
         }
 
         public void log(String s) {
-            statements.add(new QueryAdapter(s));
+            statements.add(databaseProvider.getLoggableFactory().getQueryForStateToReproduce(s));
         }
 
         @Override

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -9,8 +9,8 @@ import java.util.stream.Collectors;
 import sqlancer.AbstractAction;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.StatementExecutor;
 import sqlancer.clickhouse.ClickHouseProvider.ClickHouseGlobalState;
 import sqlancer.clickhouse.gen.ClickHouseCommon;
@@ -19,7 +19,7 @@ import sqlancer.clickhouse.gen.ClickHouseTableGenerator;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.QueryProvider;
 
-public class ClickHouseProvider extends ProviderAdapter<ClickHouseGlobalState, ClickHouseOptions> {
+public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState, ClickHouseOptions> {
 
     public ClickHouseProvider() {
         super(ClickHouseGlobalState.class, ClickHouseOptions.class);

--- a/src/sqlancer/cockroachdb/CockroachDBProvider.java
+++ b/src/sqlancer/cockroachdb/CockroachDBProvider.java
@@ -12,8 +12,8 @@ import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
 import sqlancer.Main.QueryManager;
 import sqlancer.MainOptions;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.cockroachdb.CockroachDBProvider.CockroachDBGlobalState;
 import sqlancer.cockroachdb.CockroachDBSchema.CockroachDBTable;
 import sqlancer.cockroachdb.gen.CockroachDBCommentOnGenerator;
@@ -34,7 +34,7 @@ import sqlancer.common.query.Query;
 import sqlancer.common.query.QueryAdapter;
 import sqlancer.common.query.QueryProvider;
 
-public class CockroachDBProvider extends ProviderAdapter<CockroachDBGlobalState, CockroachDBOptions> {
+public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalState, CockroachDBOptions> {
 
     public CockroachDBProvider() {
         super(CockroachDBGlobalState.class, CockroachDBOptions.class);

--- a/src/sqlancer/common/log/Loggable.java
+++ b/src/sqlancer/common/log/Loggable.java
@@ -1,0 +1,5 @@
+package sqlancer.common.log;
+
+public interface Loggable {
+    String getLogString();
+}

--- a/src/sqlancer/common/log/LoggableFactory.java
+++ b/src/sqlancer/common/log/LoggableFactory.java
@@ -1,0 +1,37 @@
+package sqlancer.common.log;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import sqlancer.common.query.Query;
+
+public abstract class LoggableFactory {
+
+    public Loggable createLoggableWithNoLinebreak(String input) {
+        return createLoggable(input, "");
+    }
+
+    public Loggable createLoggable(String input) {
+        return createLoggable(input, "\n");
+    }
+
+    protected abstract Loggable createLoggable(String input, String suffix);
+
+    public abstract Query getQueryForStateToReproduce(String queryString);
+
+    @Deprecated
+    public abstract Query commentOutQuery(Query query);
+
+    public Loggable getInfo(String databaseName, String databaseVersion, long seedValue) {
+        Date date = new Date();
+        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+        return infoToLoggable(dateFormat.format(date), databaseName, databaseVersion, seedValue);
+    }
+
+    protected abstract Loggable infoToLoggable(String time, String databaseName, String databaseVersion,
+            long seedValue);
+
+    public abstract Loggable convertStacktraceToLoggable(Throwable throwable);
+
+}

--- a/src/sqlancer/common/log/LoggedString.java
+++ b/src/sqlancer/common/log/LoggedString.java
@@ -1,0 +1,15 @@
+package sqlancer.common.log;
+
+public class LoggedString implements Loggable {
+
+    private final String loggedString;
+
+    public LoggedString(String loggedString) {
+        this.loggedString = loggedString;
+    }
+
+    @Override
+    public String getLogString() {
+        return this.loggedString;
+    }
+}

--- a/src/sqlancer/common/log/SQLLoggableFactory.java
+++ b/src/sqlancer/common/log/SQLLoggableFactory.java
@@ -1,0 +1,52 @@
+package sqlancer.common.log;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import sqlancer.common.query.Query;
+import sqlancer.common.query.QueryAdapter;
+
+public class SQLLoggableFactory extends LoggableFactory {
+
+    @Override
+    protected Loggable createLoggable(String input, String suffix) {
+        String completeString = input;
+        if (!input.endsWith(";")) {
+            completeString += ";";
+        }
+        if (suffix != null && suffix.length() != 0) {
+            completeString += suffix;
+        }
+        return new LoggedString(completeString);
+    }
+
+    @Override
+    public Query getQueryForStateToReproduce(String queryString) {
+        return new QueryAdapter(queryString);
+    }
+
+    @Override
+    public Query commentOutQuery(Query query) {
+        String queryString = query.getLogString();
+        String newQueryString = "-- " + queryString;
+        return new QueryAdapter(newQueryString);
+    }
+
+    @Override
+    protected Loggable infoToLoggable(String time, String databaseName, String databaseVersion, long seedValue) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("-- Time: " + time + "\n");
+        sb.append("-- Database: " + databaseName + "\n");
+        sb.append("-- Database version: " + databaseVersion + "\n");
+        sb.append("-- seed value: " + seedValue + "\n");
+        return new LoggedString(sb.toString());
+    }
+
+    @Override
+    public Loggable convertStacktraceToLoggable(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        throwable.printStackTrace(pw);
+        return new LoggedString("--" + sw.toString().replace("\n", "\n--"));
+    }
+}

--- a/src/sqlancer/common/query/Query.java
+++ b/src/sqlancer/common/query/Query.java
@@ -3,8 +3,9 @@ package sqlancer.common.query;
 import java.sql.SQLException;
 
 import sqlancer.GlobalState;
+import sqlancer.common.log.Loggable;
 
-public abstract class Query {
+public abstract class Query implements Loggable {
 
     /**
      * Gets the query string, which is guaranteed to be terminated with a semicolon.

--- a/src/sqlancer/common/query/QueryAdapter.java
+++ b/src/sqlancer/common/query/QueryAdapter.java
@@ -140,4 +140,8 @@ public class QueryAdapter extends Query {
         return expectedErrors;
     }
 
+    @Override
+    public String getLogString() {
+        return getQueryString();
+    }
 }

--- a/src/sqlancer/duckdb/DuckDBProvider.java
+++ b/src/sqlancer/duckdb/DuckDBProvider.java
@@ -7,8 +7,8 @@ import java.sql.SQLException;
 import sqlancer.AbstractAction;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.StatementExecutor;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.Query;
@@ -23,7 +23,7 @@ import sqlancer.duckdb.gen.DuckDBTableGenerator;
 import sqlancer.duckdb.gen.DuckDBUpdateGenerator;
 import sqlancer.duckdb.gen.DuckDBViewGenerator;
 
-public class DuckDBProvider extends ProviderAdapter<DuckDBGlobalState, DuckDBOptions> {
+public class DuckDBProvider extends SQLProviderAdapter<DuckDBGlobalState, DuckDBOptions> {
 
     public DuckDBProvider() {
         super(DuckDBGlobalState.class, DuckDBOptions.class);

--- a/src/sqlancer/h2/H2Provider.java
+++ b/src/sqlancer/h2/H2Provider.java
@@ -7,15 +7,15 @@ import java.sql.SQLException;
 import sqlancer.AbstractAction;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.StatementExecutor;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.QueryAdapter;
 import sqlancer.common.query.QueryProvider;
 import sqlancer.h2.H2Provider.H2GlobalState;
 
-public class H2Provider extends ProviderAdapter<H2GlobalState, H2Options> {
+public class H2Provider extends SQLProviderAdapter<H2GlobalState, H2Options> {
 
     public H2Provider() {
         super(H2GlobalState.class, H2Options.class);

--- a/src/sqlancer/mariadb/MariaDBProvider.java
+++ b/src/sqlancer/mariadb/MariaDBProvider.java
@@ -10,8 +10,8 @@ import java.util.List;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
 import sqlancer.MainOptions;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.common.query.Query;
 import sqlancer.mariadb.MariaDBProvider.MariaDBGlobalState;
 import sqlancer.mariadb.gen.MariaDBIndexGenerator;
@@ -23,7 +23,7 @@ import sqlancer.mariadb.gen.MariaDBTruncateGenerator;
 import sqlancer.mariadb.gen.MariaDBUpdateGenerator;
 import sqlancer.sqlite3.gen.SQLite3Common;
 
-public class MariaDBProvider extends ProviderAdapter<MariaDBGlobalState, MariaDBOptions> {
+public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, MariaDBOptions> {
 
     public static final int MAX_EXPRESSION_DEPTH = 3;
 

--- a/src/sqlancer/mysql/MySQLProvider.java
+++ b/src/sqlancer/mysql/MySQLProvider.java
@@ -7,8 +7,8 @@ import java.sql.Statement;
 
 import sqlancer.AbstractAction;
 import sqlancer.IgnoreMeException;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.StatementExecutor;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.QueryAdapter;
@@ -30,7 +30,7 @@ import sqlancer.mysql.gen.tblmaintenance.MySQLOptimize;
 import sqlancer.mysql.gen.tblmaintenance.MySQLRepair;
 import sqlancer.sqlite3.gen.SQLite3Common;
 
-public class MySQLProvider extends ProviderAdapter<MySQLGlobalState, MySQLOptions> {
+public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOptions> {
 
     public MySQLProvider() {
         super(MySQLGlobalState.class, MySQLOptions.class);

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -10,8 +10,8 @@ import java.util.Arrays;
 
 import sqlancer.AbstractAction;
 import sqlancer.IgnoreMeException;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.StatementExecutor;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.QueryAdapter;
@@ -43,7 +43,7 @@ import sqlancer.sqlite3.gen.SQLite3Common;
 
 // EXISTS
 // IN
-public class PostgresProvider extends ProviderAdapter<PostgresGlobalState, PostgresOptions> {
+public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, PostgresOptions> {
 
     /**
      * Generate only data types and expressions that are understood by PQS.

--- a/src/sqlancer/sqlite3/SQLite3Provider.java
+++ b/src/sqlancer/sqlite3/SQLite3Provider.java
@@ -11,8 +11,8 @@ import java.util.List;
 import sqlancer.AbstractAction;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.StatementExecutor;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.Query;
@@ -44,7 +44,7 @@ import sqlancer.sqlite3.gen.dml.SQLite3UpdateGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
-public class SQLite3Provider extends ProviderAdapter<SQLite3GlobalState, SQLite3Options> {
+public class SQLite3Provider extends SQLProviderAdapter<SQLite3GlobalState, SQLite3Options> {
 
     public static boolean allowFloatingPointFp = true;
     public static boolean mustKnowResult;
@@ -300,5 +300,4 @@ public class SQLite3Provider extends ProviderAdapter<SQLite3GlobalState, SQLite3
     public String getDBMSName() {
         return "sqlite3";
     }
-
 }

--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -8,8 +8,8 @@ import java.sql.Statement;
 import sqlancer.AbstractAction;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
-import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
+import sqlancer.SQLProviderAdapter;
 import sqlancer.StatementExecutor;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.Query;
@@ -27,7 +27,7 @@ import sqlancer.tidb.gen.TiDBTableGenerator;
 import sqlancer.tidb.gen.TiDBUpdateGenerator;
 import sqlancer.tidb.gen.TiDBViewGenerator;
 
-public class TiDBProvider extends ProviderAdapter<TiDBGlobalState, TiDBOptions> {
+public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOptions> {
 
     public TiDBProvider() {
         super(TiDBGlobalState.class, TiDBOptions.class);


### PR DESCRIPTION
As of this commit the classes StateLogger and StateToReproduce are no longer dependent on SQL strings. The functionality is now supported by a LoggableFactory, specifically for all current DBMSs the SQLLoggableFactory. Parts of the functionality may be removed later, for example commentStatements is now marked depricated.