### PR TITLE
Refactor Exceptions to remove SQLDependency while keeping the same functionality

### DIFF
--- a/configs/pmd-rules.xml
+++ b/configs/pmd-rules.xml
@@ -71,6 +71,7 @@
 		<exclude name="SingularField" />
 		<exclude name="ExcessiveMethodLength" />
 		<exclude name="TooManyFields" />
+		<exclude name="SignatureDeclareThrowsException" />
 	</rule>
 	<rule ref="category/java/performance.xml">
 		<priority>2</priority>

--- a/src/sqlancer/AbstractAction.java
+++ b/src/sqlancer/AbstractAction.java
@@ -1,12 +1,10 @@
 package sqlancer;
 
-import java.sql.SQLException;
-
 import sqlancer.common.query.Query;
 
 public interface AbstractAction<G> {
 
-    Query getQuery(G globalState) throws SQLException;
+    Query getQuery(G globalState) throws Exception;
 
     /**
      * Specifies whether it makes sense to request a {@link Query}, when the previous call to {@link #getQuery(Object)}

--- a/src/sqlancer/DatabaseProvider.java
+++ b/src/sqlancer/DatabaseProvider.java
@@ -1,7 +1,6 @@
 package sqlancer;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
 import sqlancer.common.log.LoggableFactory;
 
@@ -28,9 +27,9 @@ public interface DatabaseProvider<G extends GlobalState<O, ?>, O extends DBMSSpe
      *            the state created and is valid for this method call.
      *
      */
-    void generateAndTestDatabase(G globalState) throws SQLException;
+    void generateAndTestDatabase(G globalState) throws Exception;
 
-    Connection createDatabase(G globalState) throws SQLException;
+    Connection createDatabase(G globalState) throws Exception;
 
     /**
      * The DBMS name is used to name the log directory and command to test the respective DBMS.

--- a/src/sqlancer/GlobalState.java
+++ b/src/sqlancer/GlobalState.java
@@ -1,7 +1,6 @@
 package sqlancer;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
 import sqlancer.Main.QueryManager;
 import sqlancer.Main.StateLogger;
@@ -95,7 +94,7 @@ public abstract class GlobalState<O extends DBMSSpecificOptions<?>, S extends Ab
         this.databaseName = databaseName;
     }
 
-    private ExecutionTimer executePrologue(Query q) throws SQLException {
+    private ExecutionTimer executePrologue(Query q) throws Exception {
         boolean logExecutionTime = getOptions().logExecutionTime();
         ExecutionTimer timer = null;
         if (logExecutionTime) {
@@ -114,7 +113,7 @@ public abstract class GlobalState<O extends DBMSSpecificOptions<?>, S extends Ab
         return timer;
     }
 
-    private void executeEpilogue(Query q, boolean success, ExecutionTimer timer) throws SQLException {
+    private void executeEpilogue(Query q, boolean success, ExecutionTimer timer) throws Exception {
         boolean logExecutionTime = getOptions().logExecutionTime();
         if (success && getOptions().printSucceedingStatements()) {
             System.out.println(q.getQueryString());
@@ -127,14 +126,14 @@ public abstract class GlobalState<O extends DBMSSpecificOptions<?>, S extends Ab
         }
     }
 
-    public boolean executeStatement(Query q, String... fills) throws SQLException {
+    public boolean executeStatement(Query q, String... fills) throws Exception {
         ExecutionTimer timer = executePrologue(q);
         boolean success = manager.execute(q, fills);
         executeEpilogue(q, success, timer);
         return success;
     }
 
-    public SQLancerResultSet executeStatementAndGet(Query q, String... fills) throws SQLException {
+    public SQLancerResultSet executeStatementAndGet(Query q, String... fills) throws Exception {
         ExecutionTimer timer = executePrologue(q);
         SQLancerResultSet result = manager.executeAndGet(q, fills);
         boolean success = result != null;
@@ -142,7 +141,7 @@ public abstract class GlobalState<O extends DBMSSpecificOptions<?>, S extends Ab
             result.registerEpilogue(() -> {
                 try {
                     executeEpilogue(q, success, timer);
-                } catch (SQLException e) {
+                } catch (Exception e) {
                     throw new AssertionError(e);
                 }
             });
@@ -154,7 +153,7 @@ public abstract class GlobalState<O extends DBMSSpecificOptions<?>, S extends Ab
         if (schema == null) {
             try {
                 updateSchema();
-            } catch (SQLException e) {
+            } catch (Exception e) {
                 throw new AssertionError();
             }
         }
@@ -165,13 +164,13 @@ public abstract class GlobalState<O extends DBMSSpecificOptions<?>, S extends Ab
         this.schema = schema;
     }
 
-    public void updateSchema() throws SQLException {
+    public void updateSchema() throws Exception {
         setSchema(readSchema());
         for (AbstractTable<?, ?> table : schema.getDatabaseTables()) {
             table.recomputeCount();
         }
     }
 
-    protected abstract S readSchema() throws SQLException;
+    protected abstract S readSchema() throws Exception;
 
 }

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.sql.Connection;
-import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -232,7 +231,7 @@ public final class Main {
             this.globalState = globalState;
         }
 
-        public boolean execute(Query q, String... fills) throws SQLException {
+        public boolean execute(Query q, String... fills) throws Exception {
             globalState.getState().logStatement(q);
             boolean success;
             success = q.execute(globalState, fills);
@@ -240,7 +239,7 @@ public final class Main {
             return success;
         }
 
-        public SQLancerResultSet executeAndGet(Query q, String... fills) throws SQLException {
+        public SQLancerResultSet executeAndGet(Query q, String... fills) throws Exception {
             globalState.getState().logStatement(q);
             SQLancerResultSet result;
             result = q.executeAndGet(globalState, fills);
@@ -293,14 +292,14 @@ public final class Main {
             return command;
         }
 
-        public void testConnection() throws SQLException {
+        public void testConnection() throws Exception {
             G state = getInitializedGlobalState(options.getRandomSeed());
             try (Connection con = provider.createDatabase(state)) {
                 return;
             }
         }
 
-        public void run() throws SQLException {
+        public void run() throws Exception {
             G state = createGlobalState();
             stateToRepro = provider.getStateToReproduce(databaseName);
             stateToRepro.seedValue = r.getSeed();
@@ -455,7 +454,7 @@ public final class Main {
             try {
                 executorFactory.getDBMSExecutor(options.getDatabasePrefix() + "connectiontest", new Randomly())
                         .testConnection();
-            } catch (SQLException e) {
+            } catch (Exception e) {
                 System.err.println(
                         "SQLancer failed creating a test database, indicating that SQLancer might have failed connecting to the DBMS. In order to change the username and password, you can use the --username and --password options. Currently, SQLancer does not yet support passing a host and port (see https://github.com/sqlancer/sqlancer/issues/95).\n\n");
                 e.printStackTrace();

--- a/src/sqlancer/OracleFactory.java
+++ b/src/sqlancer/OracleFactory.java
@@ -1,12 +1,10 @@
 package sqlancer;
 
-import java.sql.SQLException;
-
 import sqlancer.common.oracle.TestOracle;
 
 public interface OracleFactory<G extends GlobalState<?, ?>> {
 
-    TestOracle create(G globalState) throws SQLException;
+    TestOracle create(G globalState) throws Exception;
 
     /**
      * Indicates whether the test oracle requires that all tables (including views) contain at least one row.

--- a/src/sqlancer/ProviderAdapter.java
+++ b/src/sqlancer/ProviderAdapter.java
@@ -1,6 +1,5 @@
 package sqlancer;
 
-import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +36,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ?>, O extends DBM
     }
 
     @Override
-    public void generateAndTestDatabase(G globalState) throws SQLException {
+    public void generateAndTestDatabase(G globalState) throws Exception {
         try {
             generateDatabase(globalState);
             checkViewsAreValid(globalState);
@@ -74,7 +73,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ?>, O extends DBM
         }
     }
 
-    protected TestOracle getTestOracle(G globalState) throws SQLException {
+    protected TestOracle getTestOracle(G globalState) throws Exception {
         List<? extends OracleFactory<G>> testOracleFactory = globalState.getDmbsSpecificOptions()
                 .getTestOracleFactory();
         boolean testOracleRequiresMoreThanZeroRows = testOracleFactory.stream()
@@ -90,13 +89,13 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ?>, O extends DBM
             return new CompositeTestOracle(testOracleFactory.stream().map(o -> {
                 try {
                     return o.create(globalState);
-                } catch (SQLException e1) {
+                } catch (Exception e1) {
                     throw new AssertionError(e1);
                 }
             }).collect(Collectors.toList()), globalState);
         }
     }
 
-    public abstract void generateDatabase(G globalState) throws SQLException;
+    public abstract void generateDatabase(G globalState) throws Exception;
 
 }

--- a/src/sqlancer/StatementExecutor.java
+++ b/src/sqlancer/StatementExecutor.java
@@ -1,6 +1,5 @@
 package sqlancer;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +14,7 @@ public class StatementExecutor<G extends GlobalState<?, ?>, A extends AbstractAc
 
     @FunctionalInterface
     public interface AfterQueryAction {
-        void notify(Query q) throws SQLException;
+        void notify(Query q) throws Exception;
     }
 
     @FunctionalInterface
@@ -30,7 +29,7 @@ public class StatementExecutor<G extends GlobalState<?, ?>, A extends AbstractAc
         this.queryConsumer = queryConsumer;
     }
 
-    public void executeStatements() throws SQLException {
+    public void executeStatements() throws Exception {
         Randomly r = globalState.getRandomly();
         int[] nrRemaining = new int[actions.length];
         List<A> availableActions = new ArrayList<>();

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -113,7 +113,7 @@ public class CitusProvider extends PostgresProvider {
         }
 
         @Override
-        public Query getQuery(PostgresGlobalState state) throws SQLException {
+        public Query getQuery(PostgresGlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -200,7 +200,7 @@ public class CitusProvider extends PostgresProvider {
     }
 
     private static void distributeTable(List<PostgresColumn> columns, String tableName, CitusGlobalState globalState)
-            throws SQLException {
+            throws Exception {
         if (!columns.isEmpty()) {
             PostgresColumn columnToDistribute = Randomly.fromList(columns);
             String queryString = "SELECT create_distributed_table('" + tableName + "', '" + columnToDistribute.getName()
@@ -227,7 +227,7 @@ public class CitusProvider extends PostgresProvider {
         return constraints;
     }
 
-    private static void createDistributedTable(String tableName, CitusGlobalState globalState) throws SQLException {
+    private static void createDistributedTable(String tableName, CitusGlobalState globalState) throws Exception {
         List<PostgresColumn> columns = new ArrayList<>();
         List<String> tableConstraints = getTableConstraints(tableName, globalState);
         if (tableConstraints.isEmpty()) {
@@ -276,7 +276,7 @@ public class CitusProvider extends PostgresProvider {
     }
 
     @Override
-    public void generateDatabase(PostgresGlobalState globalState) throws SQLException {
+    public void generateDatabase(PostgresGlobalState globalState) throws Exception {
         readFunctions(globalState);
         createTables(globalState, Randomly.fromOptions(4, 5, 6));
         for (PostgresTable table : globalState.getSchema().getDatabaseTables()) {
@@ -307,7 +307,7 @@ public class CitusProvider extends PostgresProvider {
         List<TestOracle> oracles = ((CitusOptions) globalState.getDmbsSpecificOptions()).citusOracle.stream().map(o -> {
             try {
                 return o.create(globalState);
-            } catch (SQLException e1) {
+            } catch (Exception e1) {
                 throw new AssertionError(e1);
             }
         }).collect(Collectors.toList());
@@ -424,7 +424,7 @@ public class CitusProvider extends PostgresProvider {
     }
 
     @Override
-    protected void prepareTables(PostgresGlobalState globalState) throws SQLException {
+    protected void prepareTables(PostgresGlobalState globalState) throws Exception {
         StatementExecutor<PostgresGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
                 CitusProvider::mapActions, (q) -> {
                     if (globalState.getSchema().getDatabaseTables().isEmpty()) {

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -36,7 +36,7 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
         }
 
         @Override
-        public Query getQuery(ClickHouseGlobalState state) throws SQLException {
+        public Query getQuery(ClickHouseGlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -80,7 +80,7 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
     }
 
     @Override
-    public void generateDatabase(ClickHouseGlobalState globalState) throws SQLException {
+    public void generateDatabase(ClickHouseGlobalState globalState) throws Exception {
         for (int i = 0; i < Randomly.fromOptions(1); i++) {
             boolean success;
             do {

--- a/src/sqlancer/cockroachdb/CockroachDBProvider.java
+++ b/src/sqlancer/cockroachdb/CockroachDBProvider.java
@@ -105,7 +105,7 @@ public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalSta
             this.queryProvider = queryProvider;
         }
 
-        public Query getQuery(CockroachDBGlobalState state) throws SQLException {
+        public Query getQuery(CockroachDBGlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -120,7 +120,7 @@ public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalSta
     }
 
     @Override
-    public void generateDatabase(CockroachDBGlobalState globalState) throws SQLException {
+    public void generateDatabase(CockroachDBGlobalState globalState) throws Exception {
         QueryManager manager = globalState.getManager();
         MainOptions options = globalState.getOptions();
         List<String> standardSettings = new ArrayList<>();

--- a/src/sqlancer/common/oracle/CompositeTestOracle.java
+++ b/src/sqlancer/common/oracle/CompositeTestOracle.java
@@ -1,6 +1,5 @@
 package sqlancer.common.oracle;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import sqlancer.GlobalState;
@@ -17,7 +16,7 @@ public class CompositeTestOracle implements TestOracle {
     }
 
     @Override
-    public void check() throws SQLException {
+    public void check() throws Exception {
         try {
             oracles[i].check();
             boolean lastOracleIndex = i == oracles.length - 1;

--- a/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
+++ b/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
@@ -1,6 +1,5 @@
 package sqlancer.common.oracle;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +33,7 @@ public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?>, R e
     }
 
     @Override
-    public final void check() throws SQLException {
+    public final void check() throws Exception {
         rectifiedPredicates.clear();
         Query pivotRowQuery = getRectifiedQuery();
         if (globalState.getOptions().logEachSelect()) {
@@ -60,9 +59,9 @@ public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?>, R e
      *
      * @return true if at least one row is contained, false otherwise
      *
-     * @throws SQLException
+     * @throws Exception
      */
-    private boolean containsRows(Query query) throws SQLException {
+    private boolean containsRows(Query query) throws Exception {
         try (SQLancerResultSet result = query.executeAndGet(globalState)) {
             if (result == null) {
                 throw new IgnoreMeException();
@@ -107,9 +106,9 @@ public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?>, R e
      *
      * @return a query that checks whether the pivot row is contained in pivotRowQuery
      *
-     * @throws SQLException
+     * @throws Exception
      */
-    protected abstract Query getContainmentCheckQuery(Query pivotRowQuery) throws SQLException;
+    protected abstract Query getContainmentCheckQuery(Query pivotRowQuery) throws Exception;
 
     /**
      * Obtains a rectified query (i.e., a query that is guaranteed to fetch the pivot row. This corresponds to steps 2-5
@@ -117,9 +116,9 @@ public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?>, R e
      *
      * @return the rectified query
      *
-     * @throws SQLException
+     * @throws Exception
      */
-    protected abstract Query getRectifiedQuery() throws SQLException;
+    protected abstract Query getRectifiedQuery() throws Exception;
 
     /**
      * Prints the value to which the expression is expected to evaluate, and then recursively prints the subexpressions'

--- a/src/sqlancer/common/oracle/TestOracle.java
+++ b/src/sqlancer/common/oracle/TestOracle.java
@@ -1,9 +1,7 @@
 package sqlancer.common.oracle;
 
-import java.sql.SQLException;
-
 public interface TestOracle {
 
-    void check() throws SQLException;
+    void check() throws Exception;
 
 }

--- a/src/sqlancer/common/query/Query.java
+++ b/src/sqlancer/common/query/Query.java
@@ -1,7 +1,5 @@
 package sqlancer.common.query;
 
-import java.sql.SQLException;
-
 import sqlancer.GlobalState;
 import sqlancer.common.log.Loggable;
 
@@ -28,7 +26,7 @@ public abstract class Query implements Loggable {
      */
     public abstract boolean couldAffectSchema();
 
-    public abstract boolean execute(GlobalState<?, ?> globalState, String... fills) throws SQLException;
+    public abstract boolean execute(GlobalState<?, ?> globalState, String... fills) throws Exception;
 
     public abstract ExpectedErrors getExpectedErrors();
 
@@ -37,16 +35,16 @@ public abstract class Query implements Loggable {
         return getQueryString();
     }
 
-    public SQLancerResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws SQLException {
+    public SQLancerResultSet executeAndGet(GlobalState<?, ?> globalState, String... fills) throws Exception {
         throw new AssertionError();
     }
 
-    public boolean executeLogged(GlobalState<?, ?> globalState) throws SQLException {
+    public boolean executeLogged(GlobalState<?, ?> globalState) throws Exception {
         logQueryString(globalState);
         return execute(globalState);
     }
 
-    public SQLancerResultSet executeAndGetLogged(GlobalState<?, ?> globalState) throws SQLException {
+    public SQLancerResultSet executeAndGetLogged(GlobalState<?, ?> globalState) throws Exception {
         logQueryString(globalState);
         return executeAndGet(globalState);
     }

--- a/src/sqlancer/common/query/QueryProvider.java
+++ b/src/sqlancer/common/query/QueryProvider.java
@@ -1,8 +1,6 @@
 package sqlancer.common.query;
 
-import java.sql.SQLException;
-
 @FunctionalInterface
 public interface QueryProvider<S> {
-    Query getQuery(S globalState) throws SQLException;
+    Query getQuery(S globalState) throws Exception;
 }

--- a/src/sqlancer/duckdb/DuckDBProvider.java
+++ b/src/sqlancer/duckdb/DuckDBProvider.java
@@ -55,7 +55,7 @@ public class DuckDBProvider extends SQLProviderAdapter<DuckDBGlobalState, DuckDB
         }
 
         @Override
-        public Query getQuery(DuckDBGlobalState state) throws SQLException {
+        public Query getQuery(DuckDBGlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -95,7 +95,7 @@ public class DuckDBProvider extends SQLProviderAdapter<DuckDBGlobalState, DuckDB
     }
 
     @Override
-    public void generateDatabase(DuckDBGlobalState globalState) throws SQLException {
+    public void generateDatabase(DuckDBGlobalState globalState) throws Exception {
         for (int i = 0; i < Randomly.fromOptions(1, 2); i++) {
             boolean success = false;
             do {

--- a/src/sqlancer/h2/H2Provider.java
+++ b/src/sqlancer/h2/H2Provider.java
@@ -38,7 +38,7 @@ public class H2Provider extends SQLProviderAdapter<H2GlobalState, H2Options> {
         }
 
         @Override
-        public Query getQuery(H2GlobalState state) throws SQLException {
+        public Query getQuery(H2GlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -73,7 +73,7 @@ public class H2Provider extends SQLProviderAdapter<H2GlobalState, H2Options> {
     }
 
     @Override
-    public void generateDatabase(H2GlobalState globalState) throws SQLException {
+    public void generateDatabase(H2GlobalState globalState) throws Exception {
         if (Randomly.getBoolean()) {
             H2SetGenerator.getQuery(globalState).execute(globalState);
         }

--- a/src/sqlancer/mariadb/MariaDBProvider.java
+++ b/src/sqlancer/mariadb/MariaDBProvider.java
@@ -45,7 +45,7 @@ public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, Mari
     }
 
     @Override
-    public void generateDatabase(MariaDBGlobalState globalState) throws SQLException {
+    public void generateDatabase(MariaDBGlobalState globalState) throws Exception {
         MainOptions options = globalState.getOptions();
 
         while (globalState.getSchema().getDatabaseTables().size() < Randomly.smallNumber() + 1) {

--- a/src/sqlancer/mysql/MySQLProvider.java
+++ b/src/sqlancer/mysql/MySQLProvider.java
@@ -66,7 +66,7 @@ public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOpt
         }
 
         @Override
-        public Query getQuery(MySQLGlobalState globalState) throws SQLException {
+        public Query getQuery(MySQLGlobalState globalState) throws Exception {
             return queryProvider.getQuery(globalState);
         }
     }
@@ -131,7 +131,7 @@ public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOpt
     }
 
     @Override
-    public void generateDatabase(MySQLGlobalState globalState) throws SQLException {
+    public void generateDatabase(MySQLGlobalState globalState) throws Exception {
         while (globalState.getSchema().getDatabaseTables().size() < Randomly.smallNumber() + 1) {
             String tableName = SQLite3Common.createTableName(globalState.getSchema().getDatabaseTables().size());
             Query createTable = MySQLTableGenerator.generate(globalState, tableName);

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -121,7 +121,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         }
 
         @Override
-        public Query getQuery(PostgresGlobalState state) throws SQLException {
+        public Query getQuery(PostgresGlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -188,7 +188,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
     }
 
     @Override
-    public void generateDatabase(PostgresGlobalState globalState) throws SQLException {
+    public void generateDatabase(PostgresGlobalState globalState) throws Exception {
         readFunctions(globalState);
         createTables(globalState, Randomly.fromOptions(4, 5, 6));
         prepareTables(globalState);
@@ -268,7 +268,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         }
     }
 
-    protected void createTables(PostgresGlobalState globalState, int numTables) throws SQLException {
+    protected void createTables(PostgresGlobalState globalState, int numTables) throws Exception {
         while (globalState.getSchema().getDatabaseTables().size() < numTables) {
             try {
                 String tableName = SQLite3Common.createTableName(globalState.getSchema().getDatabaseTables().size());
@@ -281,7 +281,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         }
     }
 
-    protected void prepareTables(PostgresGlobalState globalState) throws SQLException {
+    protected void prepareTables(PostgresGlobalState globalState) throws Exception {
         StatementExecutor<PostgresGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
                 PostgresProvider::mapActions, (q) -> {
                     if (globalState.getSchema().getDatabaseTables().isEmpty()) {

--- a/src/sqlancer/sqlite3/SQLite3Provider.java
+++ b/src/sqlancer/sqlite3/SQLite3Provider.java
@@ -107,7 +107,7 @@ public class SQLite3Provider extends SQLProviderAdapter<SQLite3GlobalState, SQLi
         }
 
         @Override
-        public Query getQuery(SQLite3GlobalState state) throws SQLException {
+        public Query getQuery(SQLite3GlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -178,7 +178,7 @@ public class SQLite3Provider extends SQLProviderAdapter<SQLite3GlobalState, SQLi
     }
 
     @Override
-    public void generateDatabase(SQLite3GlobalState globalState) throws SQLException {
+    public void generateDatabase(SQLite3GlobalState globalState) throws Exception {
         Randomly r = new Randomly(SQLite3SpecialStringGenerator::generate);
         globalState.setRandomly(r);
         if (globalState.getDmbsSpecificOptions().generateDatabase) {
@@ -221,7 +221,7 @@ public class SQLite3Provider extends SQLProviderAdapter<SQLite3GlobalState, SQLi
         }
     }
 
-    private void checkTablesForGeneratedColumnLoops(SQLite3GlobalState globalState) throws SQLException {
+    private void checkTablesForGeneratedColumnLoops(SQLite3GlobalState globalState) throws Exception {
         for (SQLite3Table table : globalState.getSchema().getDatabaseTables()) {
             Query q = new QueryAdapter("SELECT * FROM " + table.getName(),
                     ExpectedErrors.from("needs an odd number of arguments", " requires an even number of arguments",
@@ -263,7 +263,7 @@ public class SQLite3Provider extends SQLProviderAdapter<SQLite3GlobalState, SQLi
         return tableQuery;
     }
 
-    private void addSensiblePragmaDefaults(SQLite3GlobalState globalState) throws SQLException {
+    private void addSensiblePragmaDefaults(SQLite3GlobalState globalState) throws Exception {
         List<String> pragmasToExecute = new ArrayList<>();
         if (!Randomly.getBooleanWithSmallProbability()) {
             pragmasToExecute.addAll(DEFAULT_PRAGMAS);

--- a/src/sqlancer/sqlite3/gen/SQLite3ExplainGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExplainGenerator.java
@@ -1,7 +1,5 @@
 package sqlancer.sqlite3.gen;
 
-import java.sql.SQLException;
-
 import sqlancer.Randomly;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.QueryAdapter;
@@ -14,7 +12,7 @@ public final class SQLite3ExplainGenerator {
     private SQLite3ExplainGenerator() {
     }
 
-    public static Query explain(SQLite3GlobalState globalState) throws SQLException {
+    public static Query explain(SQLite3GlobalState globalState) throws Exception {
         StringBuilder sb = new StringBuilder();
         sb.append("EXPLAIN ");
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/sqlite3/oracle/SQLite3Fuzzer.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3Fuzzer.java
@@ -1,7 +1,5 @@
 package sqlancer.sqlite3.oracle;
 
-import java.sql.SQLException;
-
 import sqlancer.Randomly;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.common.query.QueryAdapter;
@@ -18,7 +16,7 @@ public class SQLite3Fuzzer implements TestOracle {
     }
 
     @Override
-    public void check() throws SQLException {
+    public void check() throws Exception {
         String s = SQLite3Visitor
                 .asString(SQLite3RandomQuerySynthesizer.generate(globalState, Randomly.smallNumber() + 1)) + ";";
         try {

--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -61,7 +61,7 @@ public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOption
         }
 
         @Override
-        public Query getQuery(TiDBGlobalState state) throws SQLException {
+        public Query getQuery(TiDBGlobalState state) throws Exception {
             return queryProvider.getQuery(state);
         }
     }
@@ -103,7 +103,7 @@ public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOption
     }
 
     @Override
-    public void generateDatabase(TiDBGlobalState globalState) throws SQLException {
+    public void generateDatabase(TiDBGlobalState globalState) throws Exception {
         for (int i = 0; i < Randomly.fromOptions(1, 2); i++) {
             boolean success = false;
             do {


### PR DESCRIPTION
Multiple high-level classes such as DatabaseProvider carry already the semantics for non-SQL DBMS except for the fact that a lot of methods still throw SQLExceptions from the java.sql package. This commit exchanges SQLException with Exception in signatures to solve this.

Also changes the configuration of pmd to exclude the rule "SignatureDeclareThrowsException"