### PR TITLE
Change the JAR name from SQLancer-* to sqlancer-*

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,7 @@ jobs:
       - name: Build
         run: mvn -B package -DskipTests=true
       - name: Shortly run DuckDB
-        run: java -jar target/SQLancer-*.jar --num-threads 4 --timeout-seconds 30 duckdb
+        run: java -jar target/sqlancer-*.jar --num-threads 4 --timeout-seconds 30 duckdb
 
   java13:
     name: Java 13 Compatibility (DuckDB)
@@ -312,7 +312,7 @@ jobs:
       - name: Build
         run: mvn -B package -DskipTests=true
       - name: Shortly run DuckDB
-        run: java -jar target/SQLancer-*.jar --num-threads 4 --timeout-seconds 30 duckdb
+        run: java -jar target/sqlancer-*.jar --num-threads 4 --timeout-seconds 30 duckdb
 
   java15:
     name: Java 15 EA Compatibility (DuckDB)
@@ -329,4 +329,4 @@ jobs:
       - name: Build
         run: mvn -B package -DskipTests=true
       - name: Shortly run DuckDB
-        run: java -jar target/SQLancer-*.jar --num-threads 4 --timeout-seconds 30 duckdb
+        run: java -jar target/sqlancer-*.jar --num-threads 4 --timeout-seconds 30 duckdb

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git clone https://github.com/sqlancer/sqlancer
 cd sqlancer
 mvn package -DskipTests
 cd target
-java -jar SQLancer-0.0.1-SNAPSHOT.jar --num-threads 4 sqlite3 --oracle NoREC
+java -jar sqlancer-*.jar --num-threads 4 sqlite3 --oracle NoREC
 ```
 
 If the execution prints progress information every five seconds, then the tool works as expected. Note that SQLancer might find bugs in SQLite. Before reporting these, be sure to check that they can still be reproduced when using the latest development version. The shortcut CTRL+C can be used to terminate SQLancer manually. If SQLancer does not find any bugs, it executes infinitely. The option `--num-tries` can be used to control after how many bugs SQLancer terminates. Alternatively, the option `--timeout-seconds` can be used to specify the maximum duration that SQLancer is allowed to run.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sqlancer</groupId>
-  <artifactId>SQLancer</artifactId>
+  <artifactId>sqlancer</artifactId>
   <version>1.0</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This commit changes the JAR naming format from `SQLancer-*.jar` to `sqlancer-*.jar` to follow the typical naming conventions (see https://maven.apache.org/guides/mini/guide-naming-conventions.html). This is in preparation for creating proper releases (see https://github.com/sqlancer/sqlancer/issues/280).

@qoega @hannesmuehleisen @thanodnl @jordanlewis I will wait for a day or two before merging - please let me know if I should wait longer, in case this change might affect your CI.