### PR TITLE
Add additional project information to the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,35 @@
   <groupId>com.sqlancer</groupId>
   <artifactId>sqlancer</artifactId>
   <version>1.0</version>
+  <name>SQLancer</name>
+  <url>http://www.sqlancer.com/</url>
+  <description>SQLancer finds logic bugs in Database Management Systems through automatic testing</description>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://github.com/sqlancer/sqlancer/blob/master/LICENSE.md</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>mrigger</id>
+      <name>Manuel Rigger</name>
+      <email>manuel.rigger@inf.ethz.ch</email>
+      <organization>ETH Zurich</organization>
+      <organizationUrl>https://ethz.ch/</organizationUrl>
+      <url>https://www.manuelrigger.at/</url>
+      <roles>
+        <role>architect</role>
+        <role>developer</role>
+      </roles>
+    </developer>
+  </developers>
+  <scm>
+    <url>git@github.com:sqlancer/sqlancer.git</url>
+    <connection>scm:git:git@github.com:sqlancer/sqlancer.git</connection>
+    <developerConnection>scm:git:git@github.com:sqlancer/sqlancer.git</developerConnection>
+  </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
This addresses the currently failing POM Validation at https://oss.sonatype.org/: "Invalid POM: /com/sqlancer/sqlancer/1.0/sqlancer-1.0.pom: Project name missing, Project description missing, Project URL missing, License information missing, SCM URL missing, Developer information missing"