### PR TITLE
Fix a build issue introduced by the Javadoc changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,4 +320,24 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+  <profiles>
+    <profile>
+      <id>jdk-8-config</id>
+      <activation>
+        <jdk>[1.3,1.9)</jdk>
+      </activation>
+      <properties>
+        <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
+      </properties>
+    </profile>
+    <profile>
+      <id>jdk-11-config</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <properties>
+        <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Fix https://github.com/sqlancer/sqlancer/issues/288.
The fix was adopted from https://stackoverflow.com/questions/49472783/maven-is-unable-to-find-javadoc-command.