### PR TITLE
Create a source JAR for IDEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,19 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.2.0</version>
         <configuration>


### PR DESCRIPTION
This fixes a "Missing: no sources jar found in folder '/com/sqlancer/sqlancer/1.0'" error on https://oss.sonatype.org/.