### PR TITLE
[ClickHouse] Apply setting to original query also

### DIFF
--- a/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPAggregateOracle.java
+++ b/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPAggregateOracle.java
@@ -48,6 +48,7 @@ public class ClickHouseTLPAggregateOracle extends ClickHouseTLPBase {
             select.setOrderByExpressions(gen.generateOrderBys());
         }
         String originalQuery = ClickHouseVisitor.asString(select);
+        originalQuery += " SETTINGS aggregate_functions_null_for_empty = 1";
 
         ClickHouseExpression whereClause = gen
                 .generateExpression(new ClickHouseSchema.ClickHouseLancerDataType(ClickHouseDataType.UInt8));


### PR DESCRIPTION
There are also Aggregations over 0 rows in original queries for TLP Aggregate.