### PR TITLE
Fix#95: support host and port arguments configuration for different DBMSs in SQLancer

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -453,7 +453,7 @@ public final class Main {
                         .testConnection();
             } catch (Exception e) {
                 System.err.println(
-                        "SQLancer failed creating a test database, indicating that SQLancer might have failed connecting to the DBMS. In order to change the username and password, you can use the --username and --password options. Currently, SQLancer does not yet support passing a host and port (see https://github.com/sqlancer/sqlancer/issues/95).\n\n");
+                        "SQLancer failed creating a test database, indicating that SQLancer might have failed connecting to the DBMS. In order to change the username, password, host and port, you can use the --username, --password, --host and --port options.\n\n");
                 e.printStackTrace();
                 return options.getErrorExitCode();
             }

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -55,7 +55,6 @@ public class MainOptions {
     @Parameter(names = "--port", description = "The port used to log into the DBMS")
     private String port = "sqlancer"; // NOPMD
 
-
     @Parameter(names = "--print-progress-information", description = "Whether to print progress information such as the number of databases generated or queries issued", arity = 1)
     private boolean printProgressInformation = true; // NOPMD
 
@@ -158,11 +157,11 @@ public class MainOptions {
         return password;
     }
 
-    public String getHost(){
+    public String getHost() {
         return host;
     }
 
-    public String getPort(){
+    public String getPort() {
         return port;
     }
 

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -49,6 +49,13 @@ public class MainOptions {
     @Parameter(names = "--password", description = "The password used to log into the DBMS")
     private String password = "sqlancer"; // NOPMD
 
+    @Parameter(names = "--host", description = "The host used to log into the DBMS")
+    private String host = "sqlancer"; // NOPMD
+
+    @Parameter(names = "--port", description = "The port used to log into the DBMS")
+    private String port = "sqlancer"; // NOPMD
+
+
     @Parameter(names = "--print-progress-information", description = "Whether to print progress information such as the number of databases generated or queries issued", arity = 1)
     private boolean printProgressInformation = true; // NOPMD
 
@@ -149,6 +156,14 @@ public class MainOptions {
 
     public String getPassword() {
         return password;
+    }
+
+    public String getHost(){
+        return host;
+    }
+
+    public String getPort(){
+        return port;
     }
 
     public boolean printProgressInformation() {

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -104,19 +104,19 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
 
     @Override
     public SQLConnection createDatabase(ClickHouseGlobalState globalState) throws SQLException {
-	host = globalState.getOptions().getHost();
-	port = globalState.getOptions().getPort();
-	if("sqlancer".equals(host)){
-	    host = "localhost";
-	}
-	if("sqlancer".equals(port)){
-	    port = "8123";
-	}
+        host = globalState.getOptions().getHost();
+        port = globalState.getOptions().getPort();
+        if ("sqlancer".equals(host)) {
+            host = "localhost";
+        }
+        if ("sqlancer".equals(port)) {
+            port = "8123";
+        }
 
         ClickHouseOptions clickHouseOptions = globalState.getDmbsSpecificOptions();
         globalState.setClickHouseOptions(clickHouseOptions);
-        //String url = "jdbc:clickhouse://localhost:8123/default";
-	String url = "jdbc:clickhouse://" + host + ":" + port + "/defult";
+        // String url = "jdbc:clickhouse://localhost:8123/default";
+        String url = "jdbc:clickhouse://" + host + ":" + port + "/defult";
         String databaseName = globalState.getDatabaseName();
         Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -21,6 +21,8 @@ import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLQueryProvider;
 
 public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState, ClickHouseOptions> {
+    protected String host;
+    protected String port;
 
     public ClickHouseProvider() {
         super(ClickHouseGlobalState.class, ClickHouseOptions.class);
@@ -102,9 +104,19 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
 
     @Override
     public SQLConnection createDatabase(ClickHouseGlobalState globalState) throws SQLException {
+	host = globalState.getOptions().getHost();
+	port = globalState.getOptions().getPort();
+	if("sqlancer".equals(host)){
+	    host = "localhost";
+	}
+	if("sqlancer".equals(port)){
+	    port = "8123";
+	}
+
         ClickHouseOptions clickHouseOptions = globalState.getDmbsSpecificOptions();
         globalState.setClickHouseOptions(clickHouseOptions);
-        String url = "jdbc:clickhouse://localhost:8123/default";
+        //String url = "jdbc:clickhouse://localhost:8123/default";
+	String url = "jdbc:clickhouse://" + host + ":" + port + "/defult";
         String databaseName = globalState.getDatabaseName();
         Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());

--- a/src/sqlancer/cockroachdb/CockroachDBProvider.java
+++ b/src/sqlancer/cockroachdb/CockroachDBProvider.java
@@ -250,17 +250,17 @@ public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalSta
 
     @Override
     public SQLConnection createDatabase(CockroachDBGlobalState globalState) throws SQLException {
-	host = globalState.getOptions().getHost();
-	port = globalState.getOptions().getPort();
-	if("sqlancer".equals(host)){
-	    host = "localhost";
-	}
-	if("sqlancer".equals(port)){
-	    port = "26257";
-	}
+        host = globalState.getOptions().getHost();
+        port = globalState.getOptions().getPort();
+        if ("sqlancer".equals(host)) {
+            host = "localhost";
+        }
+        if ("sqlancer".equals(port)) {
+            port = "26257";
+        }
         String databaseName = globalState.getDatabaseName();
-        //String url = "jdbc:postgresql://localhost:26257/test";
-	String url = "jdbc:postgresql://" + host + ":" + port + "/test";
+        // String url = "jdbc:postgresql://localhost:26257/test";
+        String url = "jdbc:postgresql://" + host + ":" + port + "/test";
         Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());
         globalState.getState().logStatement("USE test");

--- a/src/sqlancer/cockroachdb/CockroachDBProvider.java
+++ b/src/sqlancer/cockroachdb/CockroachDBProvider.java
@@ -35,6 +35,8 @@ import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLQueryProvider;
 
 public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalState, CockroachDBOptions> {
+    protected String host;
+    protected String port;
 
     public CockroachDBProvider() {
         super(CockroachDBGlobalState.class, CockroachDBOptions.class);
@@ -248,8 +250,17 @@ public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalSta
 
     @Override
     public SQLConnection createDatabase(CockroachDBGlobalState globalState) throws SQLException {
+	host = globalState.getOptions().getHost();
+	port = globalState.getOptions().getPort();
+	if("sqlancer".equals(host)){
+	    host = "localhost";
+	}
+	if("sqlancer".equals(port)){
+	    port = "26257";
+	}
         String databaseName = globalState.getDatabaseName();
-        String url = "jdbc:postgresql://localhost:26257/test";
+        //String url = "jdbc:postgresql://localhost:26257/test";
+	String url = "jdbc:postgresql://" + host + ":" + port + "/test";
         Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());
         globalState.getState().logStatement("USE test");

--- a/src/sqlancer/mariadb/MariaDBProvider.java
+++ b/src/sqlancer/mariadb/MariaDBProvider.java
@@ -27,6 +27,10 @@ import sqlancer.mariadb.gen.MariaDBUpdateGenerator;
 public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, MariaDBOptions> {
 
     public static final int MAX_EXPRESSION_DEPTH = 3;
+    protected String username;
+    protected String password;
+    protected String host;
+    protected String port; 
 
     public MariaDBProvider() {
         super(MariaDBGlobalState.class, MariaDBOptions.class);
@@ -168,9 +172,19 @@ public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, Mari
         globalState.getState().logStatement("CREATE DATABASE " + globalState.getDatabaseName());
         globalState.getState().logStatement("USE " + globalState.getDatabaseName());
         // /?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
-        String url = "jdbc:mariadb://localhost:3306";
-        Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
-                globalState.getOptions().getPassword());
+        // String url = "jdbc:mariadb://localhost:3306";
+	username = globalState.getOptions().getUserName();
+	password = globalState.getOptions().getPassword();
+	host = globalState.getOptions().getHost();
+	port = globalState.getOptions().getPort();
+	if("sqlancer".equals(host)){
+	    host = "localhost";
+	}
+	if("sqlancer".equals(port)){
+	    port = "3306";
+	}
+	String url = "jdbc:mariadb://" + host + ":" + port;
+        Connection con = DriverManager.getConnection(url, username, password);
         try (Statement s = con.createStatement()) {
             s.execute("DROP DATABASE IF EXISTS " + globalState.getDatabaseName());
         }

--- a/src/sqlancer/mariadb/MariaDBProvider.java
+++ b/src/sqlancer/mariadb/MariaDBProvider.java
@@ -30,7 +30,7 @@ public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, Mari
     protected String username;
     protected String password;
     protected String host;
-    protected String port; 
+    protected String port;
 
     public MariaDBProvider() {
         super(MariaDBGlobalState.class, MariaDBOptions.class);
@@ -173,17 +173,17 @@ public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, Mari
         globalState.getState().logStatement("USE " + globalState.getDatabaseName());
         // /?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
         // String url = "jdbc:mariadb://localhost:3306";
-	username = globalState.getOptions().getUserName();
-	password = globalState.getOptions().getPassword();
-	host = globalState.getOptions().getHost();
-	port = globalState.getOptions().getPort();
-	if("sqlancer".equals(host)){
-	    host = "localhost";
-	}
-	if("sqlancer".equals(port)){
-	    port = "3306";
-	}
-	String url = "jdbc:mariadb://" + host + ":" + port;
+        username = globalState.getOptions().getUserName();
+        password = globalState.getOptions().getPassword();
+        host = globalState.getOptions().getHost();
+        port = globalState.getOptions().getPort();
+        if ("sqlancer".equals(host)) {
+            host = "localhost";
+        }
+        if ("sqlancer".equals(port)) {
+            port = "3306";
+        }
+        String url = "jdbc:mariadb://" + host + ":" + port;
         Connection con = DriverManager.getConnection(url, username, password);
         try (Statement s = con.createStatement()) {
             s.execute("DROP DATABASE IF EXISTS " + globalState.getDatabaseName());

--- a/src/sqlancer/mysql/MySQLProvider.java
+++ b/src/sqlancer/mysql/MySQLProvider.java
@@ -153,22 +153,23 @@ public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOpt
 
     @Override
     public SQLConnection createDatabase(MySQLGlobalState globalState) throws SQLException {
-	username = globalState.getOptions().getUserName();
-	password = globalState.getOptions().getPassword();
-	host = globalState.getOptions().getHost();
-	port = globalState.getOptions().getPort();
-	if("sqlancer".equals(host)){
-	    host = "localhost";
-	}
-	if("sqlancer".equals(port)){
-	    port = "3306";
-	}
+        username = globalState.getOptions().getUserName();
+        password = globalState.getOptions().getPassword();
+        host = globalState.getOptions().getHost();
+        port = globalState.getOptions().getPort();
+        if ("sqlancer".equals(host)) {
+            host = "localhost";
+        }
+        if ("sqlancer".equals(port)) {
+            port = "3306";
+        }
         String databaseName = globalState.getDatabaseName();
         globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
         globalState.getState().logStatement("CREATE DATABASE " + databaseName);
         globalState.getState().logStatement("USE " + databaseName);
-        String url = "jdbc:mysql://" + host + ":" + port + "?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true";
-	Connection con = DriverManager.getConnection(url, username, password);
+        String url = "jdbc:mysql://" + host + ":" + port
+                + "?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true";
+        Connection con = DriverManager.getConnection(url, username, password);
         try (Statement s = con.createStatement()) {
             s.execute("DROP DATABASE IF EXISTS " + databaseName);
         }

--- a/src/sqlancer/mysql/MySQLProvider.java
+++ b/src/sqlancer/mysql/MySQLProvider.java
@@ -31,6 +31,10 @@ import sqlancer.mysql.gen.tblmaintenance.MySQLOptimize;
 import sqlancer.mysql.gen.tblmaintenance.MySQLRepair;
 
 public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOptions> {
+    protected String username;
+    protected String password;
+    protected String host;
+    protected String port;
 
     public MySQLProvider() {
         super(MySQLGlobalState.class, MySQLOptions.class);
@@ -149,12 +153,21 @@ public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOpt
 
     @Override
     public SQLConnection createDatabase(MySQLGlobalState globalState) throws SQLException {
+	host = globalState.getOptions().getHost();
+	port = globalState.getOptions().getPort();
+	if("sqlancer".equals(host)){
+	    host = "localhost";
+	}
+	if("sqlancer".equals(port)){
+	    port = "3306";
+	}
         String databaseName = globalState.getDatabaseName();
         globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
         globalState.getState().logStatement("CREATE DATABASE " + databaseName);
         globalState.getState().logStatement("USE " + databaseName);
-        String url = "jdbc:mysql://localhost:3306/?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true";
-        Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
+        String url = "jdbc:mysql://" + host + ":" + port + "?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true";
+	System.out.println("url: "+ url);
+	Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());
         try (Statement s = con.createStatement()) {
             s.execute("DROP DATABASE IF EXISTS " + databaseName);

--- a/src/sqlancer/mysql/MySQLProvider.java
+++ b/src/sqlancer/mysql/MySQLProvider.java
@@ -153,6 +153,8 @@ public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOpt
 
     @Override
     public SQLConnection createDatabase(MySQLGlobalState globalState) throws SQLException {
+	username = globalState.getOptions().getUserName();
+	password = globalState.getOptions().getPassword();
 	host = globalState.getOptions().getHost();
 	port = globalState.getOptions().getPort();
 	if("sqlancer".equals(host)){
@@ -166,9 +168,7 @@ public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOpt
         globalState.getState().logStatement("CREATE DATABASE " + databaseName);
         globalState.getState().logStatement("USE " + databaseName);
         String url = "jdbc:mysql://" + host + ":" + port + "?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true";
-	System.out.println("url: "+ url);
-	Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
-                globalState.getOptions().getPassword());
+	Connection con = DriverManager.getConnection(url, username, password);
         try (Statement s = con.createStatement()) {
             s.execute("DROP DATABASE IF EXISTS " + databaseName);
         }

--- a/src/sqlancer/postgres/PostgresOptions.java
+++ b/src/sqlancer/postgres/PostgresOptions.java
@@ -32,7 +32,7 @@ public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactor
     public boolean testCollations = true;
 
     @Parameter(names = "--connection-url", description = "Specifies the URL for connecting to the PostgreSQL server", arity = 1)
-    public String connectionURL = "postgresql://localhost:5432/test";
+    public String connectionURL = "postgresql://localhost:5432/template1";
 
     public enum PostgresOracleFactory implements OracleFactory<PostgresGlobalState> {
         NOREC {

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -55,7 +55,6 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
     protected String entryPath;
     protected String host;
     protected String port;
-    protected String Scheme;
     protected String testURL;
     protected String databaseName;
     protected String createDatabaseCommand;

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -203,14 +203,14 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         username = globalState.getOptions().getUserName();
         password = globalState.getOptions().getPassword();
         host = globalState.getOptions().getHost();
-	port = globalState.getOptions().getPort();
+        port = globalState.getOptions().getPort();
         entryPath = "/test";
         entryURL = globalState.getDmbsSpecificOptions().connectionURL;
         // trim URL to exclude "jdbc:"
         if (entryURL.startsWith("jdbc:")) {
             entryURL = entryURL.substring(5);
         }
-	String entryDatabaseName = entryPath.substring(1);
+        String entryDatabaseName = entryPath.substring(1);
         databaseName = globalState.getDatabaseName();
 
         try {
@@ -235,12 +235,12 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
             if (pathURI != null) {
                 entryPath = pathURI;
             }
-	    if ("sqlancer".equals(host)){
-	        host = uri.getHost();
-	    }
-	    if("sqlancer".equals(port)){
-	        port = Integer.toString(uri.getPort());
-	    }
+            if ("sqlancer".equals(host)) {
+                host = uri.getHost();
+            }
+            if ("sqlancer".equals(port)) {
+                port = Integer.toString(uri.getPort());
+            }
             entryURL = uri.getScheme() + "://" + host + ":" + port + "/" + entryDatabaseName;
         } catch (URISyntaxException e) {
             throw new AssertionError(e);
@@ -262,7 +262,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         String postDatabaseName = entryURL.substring(databaseIndex + entryDatabaseName.length());
         testURL = preDatabaseName + databaseName + postDatabaseName;
         globalState.getState().logStatement(String.format("\\c %s;", databaseName));
-	
+
         con = DriverManager.getConnection("jdbc:" + testURL, username, password);
         return new SQLConnection(con);
     }

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -203,19 +203,19 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         password = globalState.getOptions().getPassword();
         host = globalState.getOptions().getHost();
         port = globalState.getOptions().getPort();
-        entryPath = "/test";
         entryURL = globalState.getDmbsSpecificOptions().connectionURL;
         // trim URL to exclude "jdbc:"
         if (entryURL.startsWith("jdbc:")) {
             entryURL = entryURL.substring(5);
         }
-        String entryDatabaseName = entryPath.substring(1);
+        String entryDatabaseName = null;
         databaseName = globalState.getDatabaseName();
 
         try {
             URI uri = new URI(entryURL);
             String userInfoURI = uri.getUserInfo();
             String pathURI = uri.getPath();
+	    entryDatabaseName = pathURI.substring(1);
             if (userInfoURI != null) {
                 // username and password specified in URL take precedence
                 if (userInfoURI.contains(":")) {

--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -134,18 +134,18 @@ public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOption
 
     @Override
     public SQLConnection createDatabase(TiDBGlobalState globalState) throws SQLException {
-	host = globalState.getOptions().getHost();
-	port = globalState.getOptions().getPort();
-	if("sqlancer".equals(host)){
-	    host = "127.0.0.1";
-	}
-	if("sqlancer".equals(port)){
-	    port = "4000";
-	}
+        host = globalState.getOptions().getHost();
+        port = globalState.getOptions().getPort();
+        if ("sqlancer".equals(host)) {
+            host = "127.0.0.1";
+        }
+        if ("sqlancer".equals(port)) {
+            port = "4000";
+        }
 
         String databaseName = globalState.getDatabaseName();
-        //String url = "jdbc:mysql://127.0.0.1:4000/";
-	String url = "jdbc:mysql://" + host + ":" + port + "/";
+        // String url = "jdbc:mysql://127.0.0.1:4000/";
+        String url = "jdbc:mysql://" + host + ":" + port + "/";
         Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());
         globalState.getState().logStatement("USE test");

--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -28,6 +28,8 @@ import sqlancer.tidb.gen.TiDBUpdateGenerator;
 import sqlancer.tidb.gen.TiDBViewGenerator;
 
 public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOptions> {
+    protected String host;
+    protected String port;
 
     public TiDBProvider() {
         super(TiDBGlobalState.class, TiDBOptions.class);
@@ -132,8 +134,18 @@ public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOption
 
     @Override
     public SQLConnection createDatabase(TiDBGlobalState globalState) throws SQLException {
+	host = globalState.getOptions().getHost();
+	port = globalState.getOptions().getPort();
+	if("sqlancer".equals(host)){
+	    host = "127.0.0.1";
+	}
+	if("sqlancer".equals(port)){
+	    port = "4000";
+	}
+
         String databaseName = globalState.getDatabaseName();
-        String url = "jdbc:mysql://127.0.0.1:4000/";
+        //String url = "jdbc:mysql://127.0.0.1:4000/";
+	String url = "jdbc:mysql://" + host + ":" + port + "/";
         Connection con = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());
         globalState.getState().logStatement("USE test");

--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -137,7 +137,7 @@ public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOption
         host = globalState.getOptions().getHost();
         port = globalState.getOptions().getPort();
         if ("sqlancer".equals(host)) {
-            host = "127.0.0.1";
+            host = "localhost";
         }
         if ("sqlancer".equals(port)) {
             port = "4000";


### PR DESCRIPTION
# What problem does this PR solve?
Issue Number: #95

# Summary
Supporting host/port arguments for the follow databases:

- [x] PostgreSQL
- [x] MySQL
- [x] MariaDB
- [x] Clickhouse
- [x] CockRoachDB
- [x] TiDB 

# Release note
No release note.