### PR TITLE
Update CockroachDB to v20.2.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,11 +110,11 @@ jobs:
         run: mvn -B package -DskipTests=true
       - name: Set up CockroachDB
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v20.1.2.linux-amd64.tgz | tar  xvz
-          cd cockroach-v20.1.2.linux-amd64/ && ./cockroach start-single-node --insecure &
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v20.2.6.linux-amd64.tgz | tar  xvz
+          cd cockroach-v20.2.6.linux-amd64/ && ./cockroach start-single-node --insecure &
           sleep 10
       - name: Create SQLancer user
-        run: cd cockroach-v20.1.2.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
+        run: cd cockroach-v20.2.6.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
       - name: Run Tests
         run: COCKROACHDB_AVAILABLE=true mvn -Dtest=TestCockroachDB test
 

--- a/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
@@ -26,7 +26,7 @@ public class CockroachDBIndexGenerator extends CockroachDBGenerator {
         errors.add("already contains column");
         errors.add("violates unique constraint");
         errors.add("schema change statement cannot follow a statement that has written in the same transaction");
-        errors.add("https://github.com/cockroachdb/cockroach/issues/35730"); // some array types are not indexable
+        errors.add("and thus is not indexable"); // array types are not indexable
         errors.add("cannot determine type of empty array. Consider annotating with the desired type");
         errors.add("incompatible IF expression"); // TODO: investigate; seems to be a bug
         CockroachDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());

--- a/src/sqlancer/cockroachdb/gen/CockroachDBSetClusterSettingGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBSetClusterSettingGenerator.java
@@ -15,18 +15,16 @@ public final class CockroachDBSetClusterSettingGenerator {
 
     // https://www.cockroachlabs.com/docs/stable/set-vars.html
     private enum CockroachDBClusterSetting {
-        COMPATOR_ENABLED("compactor.enabled", CockroachDBSetSessionGenerator::onOff), //
-        BUFFER_INCREMENT("kv.bulk_ingest.buffer_increment", (g) -> "'" + Randomly.getUncachedDouble() + "'"), //
+        COMPATOR_ENABLED("compactor.enabled", CockroachDBSetSessionGenerator::onOff),
+        BUFFER_INCREMENT("kv.bulk_ingest.buffer_increment", (g) -> "'" + Randomly.getUncachedDouble() + "'"),
         BACKPRESSURE_RANGE_SIZE_MULTIPLIER(" kv.range.backpressure_range_size_multiplier",
-                (g) -> Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)), //
-        RANGE_DESCRIPTOR_CACHE_SIZE("kv.range_descriptor_cache.size", (g) -> Randomly.getNonCachedInteger()), //
+                (g) -> Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)),
+        RANGE_DESCRIPTOR_CACHE_SIZE("kv.range_descriptor_cache.size", (g) -> Randomly.getNonCachedInteger()),
         SQL_DEFAULTS_VECTORIZE_ROW_COUNT_THRESHOLD("sql.defaults.vectorize_row_count_threshold",
                 (g) -> Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)),
         // SQL_DEFAULTS_EXPERIMENTAL_OPTIMIZER_FOREIGN_KEYS_ENABLED("sql.defaults.experimental_optimizer_foreign_keys.enabled",
         // CockroachDBSetSessionGenerator::onOff),
-        MERGE_JOINS_ENABLED("sql.distsql.merge_joins.enabled", CockroachDBSetSessionGenerator::onOff), //
-        PARALLEL_SCANS_ENABLED("sql.parallel_scans.enabled", CockroachDBSetSessionGenerator::onOff), //
-        SQL_QUERY_CACHE_ENABLED("sql.query_cache.enabled", CockroachDBSetSessionGenerator::onOff), //
+        SQL_QUERY_CACHE_ENABLED("sql.query_cache.enabled", CockroachDBSetSessionGenerator::onOff),
         SQL_STATS_HISTOGRAM_COLLECTION_ENABLED("sql.stats.histogram_collection.enabled",
                 CockroachDBSetSessionGenerator::onOff);
 

--- a/src/sqlancer/cockroachdb/gen/CockroachDBSetSessionGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBSetSessionGenerator.java
@@ -19,23 +19,25 @@ public final class CockroachDBSetSessionGenerator {
 
     // https://www.cockroachlabs.com/docs/stable/set-vars.html
     private enum CockroachDBSetting {
-        BYTEA_OUTPUT((g) -> Randomly.fromOptions("hex", "escape", "base64")), //
-        DEFAULT_INT_SIZE((g) -> Randomly.fromOptions(4, 8)), //
-        DISTSQL((g) -> Randomly.fromOptions("on", "off", "auto", "always")), //
-        ENABLE_IMPLICIT_SELECT_FOR_UPDATE(CockroachDBSetSessionGenerator::onOff), //
-        ENABLE_INSERT_FAST_PATH(CockroachDBSetSessionGenerator::onOff), //
+        BYTEA_OUTPUT((g) -> Randomly.fromOptions("hex", "escape", "base64")),
+        DEFAULT_INT_SIZE((g) -> Randomly.fromOptions(4, 8)),
+        DISTSQL((g) -> Randomly.fromOptions("on", "off", "auto", "always")),
+        ENABLE_IMPLICIT_SELECT_FOR_UPDATE(CockroachDBSetSessionGenerator::onOff),
+        ENABLE_INSERT_FAST_PATH(CockroachDBSetSessionGenerator::onOff),
         ENABLE_ZIGZAG_JOIN(CockroachDBSetSessionGenerator::onOff),
         // EXPERIMENTAL_ENABLE_HASH_SHARDED_INDEXES(CockroachDBSetSessionGenerator::onOff),
-        EXPERIMENTAL_SERIAL_NORMALIZATION((g) -> Randomly.fromOptions("'rowid'", "'virtual_sequence'")), //
-        EXTRA_FLOAT_DIGITS((g) -> g.getRandomly().getInteger(-15, 3)), //
+        SERIAL_NORMALIZATION((g) -> Randomly.fromOptions("'rowid'", "'virtual_sequence'")),
+        EXTRA_FLOAT_DIGITS((g) -> g.getRandomly().getInteger(-15, 3)),
         REORDER_JOINS_LIMIT((g) -> g.getRandomly().getInteger(0, Integer.MAX_VALUE)), //
-        SQL_SAFE_UPDATES(CockroachDBSetSessionGenerator::onOff),
+        SQL_SAFE_UPDATES((g) -> "off"),
         // TRACING(CockroachDBSetSessionGenerator::onOff)
-        VECTORIZE((g) -> Randomly.fromOptions("auto", "on",
-                "off")); /*
-                          * see https://github.com/cockroachdb/cockroach/issues/44133,
-                          * https://github.com/cockroachdb/cockroach/issues/44207
-                          */
+        /*
+         * CockroachDB enables vectorized (column-oriented) execution by default. Row-oriented execution can be enforced
+         * by setting vectorized to "off". Some examples of bugs found in the vectorized execution engine are:
+         * https://github.com/cockroachdb/cockroach/issues/44133 https://github.com/cockroachdb/cockroach/issues/44207
+         *
+         */
+        VECTORIZE((g) -> Randomly.fromOptions("on", "off"));
 
         private Function<CockroachDBGlobalState, Object> f;
 

--- a/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
@@ -34,7 +34,7 @@ public class CockroachDBTableGenerator extends CockroachDBGenerator {
 
     @Override
     public void buildStatement() {
-        errors.add("https://github.com/cockroachdb/cockroach/issues/35730"); // not indexable array types
+        errors.add("and thus is not indexable"); // array types are not indexable
         if (globalState.getDmbsSpecificOptions().testTempTables) {
             errors.add("constraints on temporary tables may reference only temporary tables");
             errors.add("constraints on permanent tables may reference only permanent tables");
@@ -75,6 +75,7 @@ public class CockroachDBTableGenerator extends CockroachDBGenerator {
                 sb.append(CockroachDBVisitor.asString(gen.generateExpression(cockroachDBColumn.getType())));
                 sb.append(") STORED");
                 errors.add("computed columns cannot reference other computed columns");
+                errors.add("context-dependent operators are not allowed in computed column");
                 errors.add("has type unknown");
             }
             if (Randomly.getBooleanWithRatherLowProbability()) {


### PR DESCRIPTION
This commit updates the version of CockroachDB to v20.2.6. Cluster and
session settings for the CockroachDB adapter have also been updated so
that they are compatible with the new version. Specifically:

  - Cluster setting `sql.distsql.merge_joins.enabled` was removed in
    20.2.
  - Cluster setting `sql.parallel_scans.enabled` was removed in 20.2.
  - Session setting `experimental_serial_normalization` was renamed to
    `serial_normalization` in 20.2.
  - Session setting `vectorize` no longer accepts `auto` as of 20.2.

Additionally, this commit sets the session setting `sql_safe_updates` to
`off` for every generated session. When this is on, mutations without
`WHERE` clauses caused errors. I don't think there is any reason to
keep this setting enabled in the context of SQLancer.
