### PR TITLE
[ClickHouse] Set options for TLPHaving correct behavior

### DIFF
--- a/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPHavingOracle.java
+++ b/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPHavingOracle.java
@@ -62,6 +62,7 @@ public class ClickHouseTLPHavingOracle extends ClickHouseTLPBase {
                 ClickHouseUnaryPostfixOperation.ClickHouseUnaryPostfixOperator.IS_NULL, false));
         String thirdQueryString = ClickHouseVisitor.asString(select);
         String combinedString = firstQueryString + " UNION ALL " + secondQueryString + " UNION ALL " + thirdQueryString;
+        combinedString += " SETTINGS aggregate_functions_null_for_empty=1, enable_optimize_predicate_expression=0"; // https://github.com/ClickHouse/ClickHouse/issues/12264
         List<String> secondResultSet = ComparatorHelper.getResultSetFirstColumnAsString(combinedString, errors, state);
         if (state.getOptions().logEachSelect()) {
             state.getLogger().writeCurrent(originalQueryString);

--- a/test/sqlancer/dbms/TestClickHouse.java
+++ b/test/sqlancer/dbms/TestClickHouse.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.Test;
+
 import sqlancer.Main;
 
 public class TestClickHouse {
@@ -33,10 +34,9 @@ public class TestClickHouse {
         String clickHouseAvailable = System.getenv("CLICKHOUSE_AVAILABLE");
         boolean clickHouseIsAvailable = clickHouseAvailable != null && clickHouseAvailable.equalsIgnoreCase("true");
         assumeTrue(clickHouseIsAvailable);
-        assertEquals(0, Main.executeMain("--timeout-seconds", "60", "--num-queries", "0", "--num-threads", "5",
-                "--username", "default", "--password", "", "clickhouse", "--oracle", "TLPHaving")); // Disabled
-                                                                                                    // in CI
-                                                                                                    // https://github.com/ClickHouse/ClickHouse/issues/12264
+        assertEquals(0,
+                Main.executeMain("--timeout-seconds", "60", "--num-queries", TestConfig.NUM_QUERIES, "--num-threads",
+                        "5", "--username", "default", "--password", "", "clickhouse", "--oracle", "TLPHaving"));
     }
 
     @Test


### PR DESCRIPTION
Workaround for https://github.com/ClickHouse/ClickHouse/issues/12264

After this commit I'm going to enable red checks if there are problems in SQLancer CI run.