### PR TITLE
Add a new H2 expected error for foreign constraints

### DIFF
--- a/src/sqlancer/h2/H2TableGenerator.java
+++ b/src/sqlancer/h2/H2TableGenerator.java
@@ -102,6 +102,7 @@ public class H2TableGenerator {
             }
             errors.add("are not comparable");
             errors.add(" cannot be updatable by a referential constraint with"); // generated columns
+            errors.add("not found"); // Constraint "PRIMARY KEY | UNIQUE (C0)" not found;
         }
         sb.append(")");
         return new SQLQueryAdapter(sb.toString(), errors, true);


### PR DESCRIPTION
Consider the following test case:

```sql
CREATE TABLE t0(c0 INT);
CREATE TABLE t1(c0 INT, FOREIGN KEY(c0) REFERENCES t0(C0)); -- Constraint "PRIMARY KEY | UNIQUE (C0)" not found;
```

Due to a recent H2 change, the second `CREATE TABLE` statement now results in an error, while previously, it was executed successfully.