### PR TITLE
Update CockroachDB to v20.2.8 and enable tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,11 +110,13 @@ jobs:
         run: mvn -B package -DskipTests=true
       - name: Set up CockroachDB
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v20.2.6.linux-amd64.tgz | tar  xvz
-          cd cockroach-v20.2.6.linux-amd64/ && ./cockroach start-single-node --insecure &
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v20.2.8.linux-amd64.tgz | tar  xvz
+          cd cockroach-v20.2.8.linux-amd64/ && ./cockroach start-single-node --insecure &
           sleep 10
       - name: Create SQLancer user
-        run: cd cockroach-v20.2.6.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
+        run: cd cockroach-v20.2.8.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
+      - name: Run Tests
+        run: COCKROACHDB_AVAILABLE=true mvn -Dtest=TestCockroachDB test
 
   duckdb:
     name: DBMS Tests (DuckDB)


### PR DESCRIPTION
CockroachDB tests were disabled after they revealed a bug in v20.2.6,
https://github.com/cockroachdb/cockroach/issues/62281. This bug was
fixed and v20.2.8. This commit updates the CockroachDB version and
enables the tests.