### PR TITLE
Add config tests for ArangoDB

### DIFF
--- a/src/sqlancer/arangodb/ArangoDBOptions.java
+++ b/src/sqlancer/arangodb/ArangoDBOptions.java
@@ -25,6 +25,10 @@ public class ArangoDBOptions implements DBMSSpecificOptions<ArangoDBOptions.Aran
     @Parameter(names = "--max-number-indexes", description = "The maximum number of indexes used.", arity = 1)
     public int maxNumberIndexes = 15;
 
+    @Parameter(names = "--with-optimizer-rule-tests", description = "Adds an additional query, where a random set"
+            + "of optimizer rules are disabled.", arity = 1)
+    public boolean withOptimizerRuleTests;
+
     @Override
     public List<ArangoDBOracleFactory> getTestOracleFactory() {
         return oracles;
@@ -39,6 +43,5 @@ public class ArangoDBOptions implements DBMSSpecificOptions<ArangoDBOptions.Aran
                 return new CompositeTestOracle(oracles, globalState);
             }
         }
-
     }
 }

--- a/src/sqlancer/arangodb/query/ArangoDBOptimizerRules.java
+++ b/src/sqlancer/arangodb/query/ArangoDBOptimizerRules.java
@@ -1,0 +1,57 @@
+package sqlancer.arangodb.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+
+public class ArangoDBOptimizerRules {
+
+    private final List<String> allRules = new ArrayList<>();
+
+    public ArangoDBOptimizerRules() {
+        // SRC:
+        // https://www.arangodb.com/docs/stable/aql/execution-and-performance-optimizer.html#list-of-optimizer-rules
+        // Filtered out irrelevant ones
+        allRules.add("-fuse-filters");
+        // allRules.add("-geo-index-optimizer");
+        // allRules.add("-handle-arangosearch-views");
+        // allRules.add("-inline-subqueries");
+        allRules.add("-interchange-adjacent-enumerations");
+        allRules.add("-late-document-materialization");
+        // allRules.add("-late-document-materialization-arangosearch");
+        allRules.add("-move-calculations-down");
+        allRules.add("-move-calculations-up");
+        allRules.add("-move-filters-into-enumerate");
+        allRules.add("-move-filters-up");
+        // allRules.add("-optimize-count");
+        // allRules.add("-optimize-subqueries");
+        // allRules.add("-optimize-traversals");
+        // allRules.add("-patch-update-statements");
+        allRules.add("-propagate-constant-attributes");
+        allRules.add("-reduce-extraction-to-projection");
+        // allRules.add("-remove-collect-variables");
+        // allRules.add("-remove-data-modification-out-variables");
+        allRules.add("-remove-filter-covered-by-index");
+        // allRules.add("-remove-filter-covered-by-traversal");
+        allRules.add("-remove-redundant-calculations");
+        allRules.add("-remove-redundant-or");
+        // allRules.add("-remove-redundant-path-var");
+        // allRules.add("-remove-redundant-sorts");
+        // allRules.add("-remove-sort-rand");
+        allRules.add("-remove-unnecessary-calculations");
+        allRules.add("-remove-unnecessary-filters");
+        // allRules.add("-replace-function-with-index");
+        allRules.add("-replace-or-with-in");
+        allRules.add("-simplify-conditions");
+        // allRules.add("-sort-in-values");
+        // allRules.add("-sort-limit");
+        // allRules.add("-splice-subqueries");
+        // allRules.add("-use-index-for-sort");
+        allRules.add("-use-indexes");
+    }
+
+    public List<String> getRandomRules() {
+        return Randomly.subset(allRules);
+    }
+}

--- a/src/sqlancer/arangodb/test/ArangoDBQueryPartitioningWhereTester.java
+++ b/src/sqlancer/arangodb/test/ArangoDBQueryPartitioningWhereTester.java
@@ -32,7 +32,15 @@ public class ArangoDBQueryPartitioningWhereTester extends ArangoDBQueryPartition
         query = ArangoDBVisitor.asSelectQuery(select);
         List<BaseDocument> thirdResultSet = getResultSetAsDocumentList(query, state);
 
-        secondResultSet.addAll(thirdResultSet);
-        assumeResultSetsAreEqual(firstResultSet, secondResultSet, query);
+        thirdResultSet.addAll(secondResultSet);
+        assumeResultSetsAreEqual(firstResultSet, thirdResultSet, query);
+
+        if (state.getDmbsSpecificOptions().withOptimizerRuleTests) {
+            select.setFilterClause(predicate);
+            query = ArangoDBVisitor.asSelectQuery(select);
+            query.excludeRandomOptRules();
+            List<BaseDocument> forthResultSet = getResultSetAsDocumentList(query, state);
+            assumeResultSetsAreEqual(secondResultSet, forthResultSet, query);
+        }
     }
 }


### PR DESCRIPTION
With the configuration "withOptimizerRuleTests" it is now possible to test ArangoDB queries further. A randomly generated query is executed with all optimizer flags enabled and with a random number of optimizer flags disabled.