### PR TITLE
Fix ClickHouse testing after 0.3.1 ClickHouse JDBC breaking changes

### DIFF
--- a/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
@@ -49,7 +49,9 @@ public class ClickHouseTableGenerator {
         if (Randomly.getBoolean()) {
             sb.append("IF NOT EXISTS ");
         }
-        sb.append(tableName);
+        sb.append(this.globalState.getDatabaseName());
+        sb.append(".");
+        sb.append(this.tableName);
         sb.append(" (");
         int nrColumns = 1 + Randomly.smallNumber();
         for (int i = 0; i < nrColumns; i++) {

--- a/test/sqlancer/clickhouse/ast/ClickHouseBinaryComparisonOperationTest.java
+++ b/test/sqlancer/clickhouse/ast/ClickHouseBinaryComparisonOperationTest.java
@@ -1,10 +1,11 @@
 package sqlancer.clickhouse.ast;
 
 import org.junit.jupiter.api.Test;
-import ru.yandex.clickhouse.domain.ClickHouseDataType;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
+
+import ru.yandex.clickhouse.domain.ClickHouseDataType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
Database name is no longer set in query by default. Use explicit DB name to create table.