### PR TITLE
Upgrade CockroachDB to v21.1.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,11 +110,11 @@ jobs:
         run: mvn -B package -DskipTests=true
       - name: Set up CockroachDB
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v20.2.8.linux-amd64.tgz | tar  xvz
-          cd cockroach-v20.2.8.linux-amd64/ && ./cockroach start-single-node --insecure &
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v21.1.7.linux-amd64.tgz | tar  xvz
+          cd cockroach-v21.1.7.linux-amd64/ && ./cockroach start-single-node --insecure &
           sleep 10
       - name: Create SQLancer user
-        run: cd cockroach-v20.2.8.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
+        run: cd cockroach-v21.1.7.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
       - name: Run Tests
         run: COCKROACHDB_AVAILABLE=true mvn -Dtest=TestCockroachDB test
 

--- a/src/sqlancer/cockroachdb/CockroachDBProvider.java
+++ b/src/sqlancer/cockroachdb/CockroachDBProvider.java
@@ -54,12 +54,9 @@ public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalSta
         SHOW(CockroachDBShowGenerator::show), //
         TRANSACTION((g) -> {
             String s = Randomly.fromOptions("BEGIN", "ROLLBACK", "COMMIT");
-            return new SQLQueryAdapter(s,
-                    ExpectedErrors.from("there is no transaction in progress",
-                            "there is already a transaction in progress", "current transaction is aborted",
-                            "does not exist" /* interleaved indexes */));
-        }), //
-        EXPLAIN((g) -> {
+            return new SQLQueryAdapter(s, ExpectedErrors.from("there is no transaction in progress",
+                    "there is already a transaction in progress", "current transaction is aborted"));
+        }), EXPLAIN((g) -> {
             StringBuilder sb = new StringBuilder("EXPLAIN ");
             ExpectedErrors errors = new ExpectedErrors();
             if (Randomly.getBoolean()) {
@@ -267,12 +264,6 @@ public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalSta
         globalState.getState().logStatement("USE " + databaseName);
         try (Statement s = con.createStatement()) {
             s.execute("DROP DATABASE IF EXISTS " + databaseName);
-        } catch (SQLException e) {
-            if (e.getMessage().contains("ERROR: invalid interleave backreference")) {
-                throw new IgnoreMeException(); // TODO: investigate
-            } else {
-                throw e;
-            }
         }
         try (Statement s = con.createStatement()) {
             s.execute(createDatabaseCommand);

--- a/src/sqlancer/cockroachdb/gen/CockroachDBGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBGenerator.java
@@ -1,12 +1,10 @@
 package sqlancer.cockroachdb.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
 import sqlancer.cockroachdb.CockroachDBProvider.CockroachDBGlobalState;
 import sqlancer.cockroachdb.CockroachDBSchema.CockroachDBColumn;
-import sqlancer.cockroachdb.CockroachDBSchema.CockroachDBTable;
 import sqlancer.common.gen.AbstractGenerator;
 
 public abstract class CockroachDBGenerator extends AbstractGenerator {
@@ -30,23 +28,6 @@ public abstract class CockroachDBGenerator extends AbstractGenerator {
             }
         }
         sb.append(")");
-    }
-
-    void generateInterleave() {
-        // TODO make this more likely to succeed
-        CockroachDBTable parentTable = globalState.getSchema().getRandomTable(t -> !t.isView());
-        List<CockroachDBColumn> parentColumns = parentTable.getRandomNonEmptyColumnSubset();
-        sb.append(" INTERLEAVE IN PARENT ");
-        sb.append(parentTable.getName());
-        sb.append("(");
-        sb.append(parentColumns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
-        errors.add("must refer to a prefix of the primary key column names being interleaved");
-        errors.add("must refer to a prefix of the index column names being interleaved");
-        errors.add("must match the parent's primary index");
-        errors.add("must match type and sort direction of the parent's primary index");
-        errors.add("must be a prefix of the index columns being interleaved");
-        errors.add("must be a prefix of the primary key columns being interleaved");
     }
 
 }

--- a/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
@@ -27,6 +27,7 @@ public class CockroachDBIndexGenerator extends CockroachDBGenerator {
         errors.add("violates unique constraint");
         errors.add("schema change statement cannot follow a statement that has written in the same transaction");
         errors.add("and thus is not indexable"); // array types are not indexable
+        errors.add("the following columns are not indexable due to their type"); // array types are not indexable
         errors.add("cannot determine type of empty array. Consider annotating with the desired type");
         errors.add("incompatible IF expression"); // TODO: investigate; seems to be a bug
         CockroachDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());

--- a/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
@@ -53,9 +53,6 @@ public class CockroachDBIndexGenerator extends CockroachDBGenerator {
             sb.append(" ");
             addColumns(sb, table.getRandomNonEmptyColumnSubset(), false);
         }
-        if (!hashSharded /* interleaved indexes cannot also be hash sharded */ && Randomly.getBoolean()) {
-            generateInterleave();
-        }
     }
 
 }

--- a/src/sqlancer/cockroachdb/gen/CockroachDBSetClusterSettingGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBSetClusterSettingGenerator.java
@@ -15,7 +15,6 @@ public final class CockroachDBSetClusterSettingGenerator {
 
     // https://www.cockroachlabs.com/docs/stable/set-vars.html
     private enum CockroachDBClusterSetting {
-        COMPATOR_ENABLED("compactor.enabled", CockroachDBSetSessionGenerator::onOff),
         BUFFER_INCREMENT("kv.bulk_ingest.buffer_increment", (g) -> "'" + Randomly.getUncachedDouble() + "'"),
         BACKPRESSURE_RANGE_SIZE_MULTIPLIER(" kv.range.backpressure_range_size_multiplier",
                 (g) -> Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)),

--- a/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
@@ -167,9 +167,6 @@ public class CockroachDBTableGenerator extends CockroachDBGenerator {
             errors.add("there is no unique constraint matching given keys for referenced table");
         }
         sb.append(")");
-        if (Randomly.getBooleanWithRatherLowProbability() && !globalState.getSchema().getDatabaseTables().isEmpty()) {
-            generateInterleave();
-        }
         errors.add("collatedstring");
         CockroachDBErrors.addExpressionErrors(errors);
     }

--- a/src/sqlancer/cockroachdb/gen/CockroachDBTruncateGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBTruncateGenerator.java
@@ -13,7 +13,6 @@ public final class CockroachDBTruncateGenerator {
     // https://www.cockroachlabs.com/docs/v19.2/truncate.html
     public static SQLQueryAdapter truncate(CockroachDBGlobalState globalState) {
         ExpectedErrors errors = new ExpectedErrors();
-        errors.add("is interleaved by table");
         errors.add("is referenced by foreign key");
 
         // https://github.com/cockroachdb/cockroach/issues/47030


### PR DESCRIPTION
#### Update CockroachDB to v21.1.7


#### Remove interleaved tables and indexes for CockroachDB

Interleaved tables are disabled by default in CockroachDB v21.1, and
will be permanently removed in a future release. This commit removes
generation of interleaved tables and indexes.
