### PR TITLE
Add support for access methods

### DIFF
--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -21,8 +21,10 @@ import sqlancer.citus.gen.CitusDeleteGenerator;
 import sqlancer.citus.gen.CitusIndexGenerator;
 import sqlancer.citus.gen.CitusInsertGenerator;
 import sqlancer.citus.gen.CitusSetGenerator;
+import sqlancer.citus.gen.CitusTableGenerator;
 import sqlancer.citus.gen.CitusUpdateGenerator;
 import sqlancer.citus.gen.CitusViewGenerator;
+import sqlancer.common.DBMSCommon;
 import sqlancer.common.oracle.CompositeTestOracle;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.common.query.ExpectedErrors;
@@ -269,6 +271,20 @@ public class CitusProvider extends PostgresProvider {
             }
         }
         distributeTable(columns, tableName, globalState);
+    }
+
+    @Override
+    protected void createTables(PostgresGlobalState globalState, int numTables) throws Exception {
+        while (globalState.getSchema().getDatabaseTables().size() < numTables) {
+            try {
+                String tableName = DBMSCommon.createTableName(globalState.getSchema().getDatabaseTables().size());
+                SQLQueryAdapter createTable = CitusTableGenerator.generate(tableName, globalState.getSchema(),
+                        generateOnlyKnown, globalState);
+                globalState.executeStatement(createTable);
+            } catch (IgnoreMeException e) {
+
+            }
+        }
     }
 
     @Override

--- a/src/sqlancer/citus/gen/CitusCommon.java
+++ b/src/sqlancer/citus/gen/CitusCommon.java
@@ -47,6 +47,9 @@ public final class CitusCommon {
         errors.add("cannot pushdown the subquery");
         // see https://github.com/sqlancer/sqlancer/issues/215
         errors.add("direct joins between distributed and local tables are not supported");
+        errors.add("unlogged columnar tables are not supported");
+        errors.add("UPDATE and CTID scans not supported for ColumnarScan");
+        errors.add("indexes not supported for columnar tables");
 
         // current errors in Citus (to be removed once fixed)
         if (CitusBugs.bug3957) {

--- a/src/sqlancer/citus/gen/CitusTableGenerator.java
+++ b/src/sqlancer/citus/gen/CitusTableGenerator.java
@@ -1,5 +1,6 @@
 package sqlancer.citus.gen;
 
+import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema;
 import sqlancer.postgres.gen.PostgresTableGenerator;
@@ -10,6 +11,11 @@ public class CitusTableGenerator extends PostgresTableGenerator {
             PostgresGlobalState globalState) {
         super(tableName, newSchema, generateOnlyKnown, globalState);
         CitusCommon.addCitusErrors(errors);
+    }
+
+    public static SQLQueryAdapter generate(String tableName, PostgresSchema newSchema, boolean generateOnlyKnown,
+            PostgresGlobalState globalState) {
+        return new CitusTableGenerator(tableName, newSchema, generateOnlyKnown, globalState).generate();
     }
 
 }

--- a/src/sqlancer/postgres/gen/PostgresTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableGenerator.java
@@ -23,6 +23,7 @@ public class PostgresTableGenerator {
     private boolean columnHasPrimaryKey;
     private final StringBuilder sb = new StringBuilder();
     private boolean isTemporaryTable;
+    private boolean isPartitionedTable;
     private final PostgresSchema newSchema;
     private final List<PostgresColumn> columnsToBeAdded = new ArrayList<>();
     protected final ExpectedErrors errors = new ExpectedErrors();
@@ -63,7 +64,7 @@ public class PostgresTableGenerator {
         return new PostgresTableGenerator(tableName, newSchema, generateOnlyKnown, globalState).generate();
     }
 
-    private SQLQueryAdapter generate() {
+    protected SQLQueryAdapter generate() {
         columnCanHavePrimaryKey = true;
         sb.append("CREATE");
         if (Randomly.getBoolean()) {
@@ -111,6 +112,7 @@ public class PostgresTableGenerator {
         sb.append(")");
         generateInherits();
         generatePartitionBy();
+        generateUsing();
         PostgresCommon.generateWith(sb, globalState, errors);
         if (Randomly.getBoolean() && isTemporaryTable) {
             sb.append(" ON COMMIT ");
@@ -152,8 +154,10 @@ public class PostgresTableGenerator {
 
     private void generatePartitionBy() {
         if (Randomly.getBoolean()) {
+            isPartitionedTable = false;
             return;
         }
+        isPartitionedTable = true;
         sb.append(" PARTITION BY ");
         // TODO "RANGE",
         String partitionOption = Randomly.fromOptions("RANGE", "LIST", "HASH");
@@ -183,6 +187,21 @@ public class PostgresTableGenerator {
             }
         }
         sb.append(")");
+    }
+
+    private void generateUsing() {
+        /*
+         * Postgres does not allow specifying USING clause for partitioned tables since they don't have any storage
+         * associated with them
+         */
+        if (isPartitionedTable) {
+            return;
+        }
+        if (Randomly.getBoolean()) {
+            return;
+        }
+        sb.append(" USING ");
+        sb.append(globalState.getRandomTableAccessMethod());
     }
 
     private void generateInherits() {


### PR DESCRIPTION
This PR adds support for table access methods in Postgres.
A `SELECT` query finds the existing table access methods in the Postgres database and the tables are randomly created as one of those access methods with the `USING` syntax.