### PR TITLE
Add Citus 10.1 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Citus
         run: |
           curl https://install.citusdata.com/community/deb.sh | sudo bash
-          sudo apt-get -y install postgresql-13-citus-9.5
+          sudo apt-get -y install postgresql-13-citus-10.1
           sudo chown -R $USER:$USER /var/run/postgresql
           export PATH=/usr/lib/postgresql/13/bin:$PATH
           cd ~
@@ -68,8 +68,8 @@ jobs:
           psql -c "CREATE EXTENSION citus;" -p 9700 -U $USER -d test
           psql -c "CREATE EXTENSION citus;" -p 9701 -U $USER -d test
           psql -c "CREATE EXTENSION citus;" -p 9702 -U $USER -d test
-          psql -c "SELECT * from master_add_node('localhost', 9701);" -p 9700 -U $USER -d test
-          psql -c "SELECT * from master_add_node('localhost', 9702);" -p 9700 -U $USER -d test
+          psql -c "SELECT * from citus_add_node('localhost', 9701);" -p 9700 -U $USER -d test
+          psql -c "SELECT * from citus_add_node('localhost', 9702);" -p 9700 -U $USER -d test
       - name: Run Tests
         run: CITUS_AVAILABLE=true mvn -Dtest=TestCitus test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,8 +130,8 @@ matrix:
         - psql -c "CREATE EXTENSION citus;" -p 9700 -U $USER -d test
         - psql -c "CREATE EXTENSION citus;" -p 9701 -U $USER -d test
         - psql -c "CREATE EXTENSION citus;" -p 9702 -U $USER -d test
-        - psql -c "SELECT * from master_add_node('localhost', 9701);" -p 9700 -U $USER -d test
-        - psql -c "SELECT * from master_add_node('localhost', 9702);" -p 9700 -U $USER -d test
+        - psql -c "SELECT * from citus_add_node('localhost', 9701);" -p 9700 -U $USER -d test
+        - psql -c "SELECT * from citus_add_node('localhost', 9702);" -p 9700 -U $USER -d test
       script:
         - CITUS_AVAILABLE=true mvn -Dtest=TestCitus test
     - name: ClickHouse

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -312,10 +312,10 @@ public class CitusProvider extends PostgresProvider {
 
     private List<CitusWorkerNode> readCitusWorkerNodes(PostgresGlobalState globalState, SQLConnection con)
             throws SQLException {
-        globalState.getState().logStatement("SELECT * FROM master_get_active_worker_nodes()");
+        globalState.getState().logStatement("SELECT * FROM citus_get_active_worker_nodes()");
         List<CitusWorkerNode> citusWorkerNodes = new ArrayList<>();
         try (Statement s = con.createStatement()) {
-            ResultSet rs = s.executeQuery("SELECT * FROM master_get_active_worker_nodes();");
+            ResultSet rs = s.executeQuery("SELECT * FROM citus_get_active_worker_nodes();");
             while (rs.next()) {
                 String nodeHost = rs.getString("node_name");
                 int nodePort = rs.getInt("node_port");
@@ -374,7 +374,7 @@ public class CitusProvider extends PostgresProvider {
     private void addCitusWorkerNodes(PostgresGlobalState globalState, SQLConnection con,
             List<CitusWorkerNode> citusWorkerNodes) throws SQLException {
         for (CitusWorkerNode w : citusWorkerNodes) {
-            String addWorkers = "SELECT * from master_add_node('" + w.getHost() + "', " + w.getPort() + ");";
+            String addWorkers = "SELECT * from citus_add_node('" + w.getHost() + "', " + w.getPort() + ");";
             globalState.getState().logStatement(addWorkers);
             try (Statement s = con.createStatement()) {
                 s.execute(addWorkers);

--- a/src/sqlancer/citus/CitusSchema.java
+++ b/src/sqlancer/citus/CitusSchema.java
@@ -65,6 +65,10 @@ public class CitusSchema extends PostgresSchema {
                         "SELECT table_name, column_to_column_name(logicalrelid, partkey) AS dist_col_name, colocationid FROM information_schema.tables LEFT OUTER JOIN pg_dist_partition ON logicalrelid=table_name::regclass WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%';")) {
                     while (rs.next()) {
                         String tableName = rs.getString("table_name");
+                        /* citus_tables is a helper view, we don't need to test with it so we let's ignore it */
+                        if (tableName.equals("citus_tables")) {
+                            continue;
+                        }
                         String distributionColumnName = rs.getString("dist_col_name");
                         Integer colocationId = rs.getInt("colocationid");
                         if (rs.wasNull()) {

--- a/src/sqlancer/postgres/PostgresSchema.java
+++ b/src/sqlancer/postgres/PostgresSchema.java
@@ -124,6 +124,7 @@ public class PostgresSchema extends AbstractSchema<PostgresGlobalState, Postgres
         case "character":
         case "character varying":
         case "name":
+        case "regclass":
             return PostgresDataType.TEXT;
         case "numeric":
             return PostgresDataType.DECIMAL;


### PR DESCRIPTION
This PR updates the Citus version from 9.5 to 10.1
The PR also renames the function names that start with `master_` to `citus_` and handles  the new `citus_tables` view to be compatible with Citus 10.1