### PR TITLE
Bootstrap automatic test case reduction.

### DIFF
--- a/src/sqlancer/DatabaseProvider.java
+++ b/src/sqlancer/DatabaseProvider.java
@@ -30,6 +30,21 @@ public interface DatabaseProvider<G extends GlobalState<O, ?, C>, O extends DBMS
      */
     void generateAndTestDatabase(G globalState) throws Exception;
 
+    /**
+     * Reduce a state which triggers an error in a test oracle.
+     *
+     * @param e
+     *          the exception carrying on the error.
+     * @param stateToReduce
+     *          the state to be reduced.
+     * @param newGlobalState
+     *          a copy state where to apply reduction.
+     *          At the end of the reduction it contains a possibly reduced list of statements.
+     * @throws Exception
+     *          if creating the reduced database fails.
+     */
+    void reduceDatabase(FoundBugException e, G stateToReduce, G newGlobalState) throws Exception;
+
     C createDatabase(G globalState) throws Exception;
 
     /**

--- a/src/sqlancer/FoundBugException.java
+++ b/src/sqlancer/FoundBugException.java
@@ -1,0 +1,27 @@
+package sqlancer;
+
+import sqlancer.common.schema.AbstractSchema;
+
+public class FoundBugException extends RuntimeException {
+
+    public interface Reproducer<G extends SQLGlobalState<O, ? extends AbstractSchema<G , ?>>, O extends DBMSSpecificOptions<?>> {
+        public abstract boolean bugStillTriggers(G globalState);
+
+        public default void outputHook(G globalState) {
+
+        }
+    }
+
+    private static final long serialVersionUID = 1L;
+    private final Reproducer reproducer;
+
+    public FoundBugException(String string, Reproducer reproducer) {
+        super(string);
+        this.reproducer = reproducer;
+    }
+
+    public Reproducer getReproducer() {
+        return reproducer;
+    }
+
+}

--- a/src/sqlancer/ProviderAdapter.java
+++ b/src/sqlancer/ProviderAdapter.java
@@ -60,6 +60,10 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
         }
     }
 
+    public void reduceDatabase(FoundBugException e, G stateToReduce, G newGlobalState) throws Exception {
+        // Used only in SQLProviderAdapter.
+    }
+
     protected abstract void checkViewsAreValid(G globalState);
 
     protected TestOracle getTestOracle(G globalState) throws Exception {

--- a/src/sqlancer/SQLProviderAdapter.java
+++ b/src/sqlancer/SQLProviderAdapter.java
@@ -1,15 +1,21 @@
 package sqlancer;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import sqlancer.common.log.LoggableFactory;
 import sqlancer.common.log.SQLLoggableFactory;
+import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.schema.AbstractSchema;
 import sqlancer.common.schema.AbstractTable;
 
 public abstract class SQLProviderAdapter<G extends SQLGlobalState<O, ? extends AbstractSchema<G, ?>>, O extends DBMSSpecificOptions<? extends OracleFactory<G>>>
         extends ProviderAdapter<G, O, SQLConnection> {
+
+    private boolean observedChange = false;
+
     public SQLProviderAdapter(Class<G> globalClass, Class<O> optionClass) {
         super(globalClass, optionClass);
     }
@@ -30,5 +36,84 @@ public abstract class SQLProviderAdapter<G extends SQLGlobalState<O, ? extends A
                 throw new IgnoreMeException();
             }
         }
+    }
+
+    @Override
+    public void reduceDatabase(FoundBugException e, G stateToReduce, G newGlobalState) throws Exception {
+
+        FoundBugException.Reproducer<G, O> reproducer = e.getReproducer();
+
+        List<SQLQueryAdapter> knownToReproduceBugStatements = new ArrayList<>();
+        for (Query<?> stat : stateToReduce.getState().getStatements()) {
+            knownToReproduceBugStatements.add((SQLQueryAdapter) stat);
+        }
+        // Iterate until fixpoint.
+        do {
+            observedChange = false;
+            System.out.println(observedChange);
+            knownToReproduceBugStatements = tryReduction(reproducer, newGlobalState,
+                    knownToReproduceBugStatements, (candidateStatements, i) -> {
+                        candidateStatements.remove((int) i);
+                        return true;
+                    });
+        } while (observedChange);
+
+        for (String s : new String[] { "OR IGNORE", "OR ABORT", "OR ROLLBACK", "OR FAIL", "TEMP",
+                "TEMPORARY", "UNIQUE", "NOT NULL", "COLLATE BINARY", "COLLATE NOCASE", "COLLATE RTRIM",
+                "INT", "REAL", "TEXT", "IF NOT EXISTS", "UNINDEXED" }) {
+            knownToReproduceBugStatements = tryReplaceToken(reproducer, newGlobalState,
+                    knownToReproduceBugStatements, " " + s, "");
+        }
+    }
+
+    private List<SQLQueryAdapter> tryReplaceToken(FoundBugException.Reproducer<G, O> reproducer, G newGlobalState,
+                                           List<SQLQueryAdapter> knownToReproduceBugStatements, String target, String replaceBy) throws Exception {
+        do {
+            observedChange = false;
+            knownToReproduceBugStatements = tryReduction(reproducer, newGlobalState,
+                    knownToReproduceBugStatements, (candidateStatements, i) -> {
+                        SQLQueryAdapter statement = candidateStatements.get(i);
+                        if (statement.getQueryString().contains(target)) {
+                            candidateStatements.set(i, new SQLQueryAdapter(
+                                    statement.getQueryString().replace(target, replaceBy), true));
+                            return true;
+                        }
+                        return false;
+                    }
+            );
+        } while (observedChange);
+        return knownToReproduceBugStatements;
+    }
+
+    private List<SQLQueryAdapter> tryReduction(FoundBugException.Reproducer<G, O> reproducer, G newGlobalState,
+                                        List<SQLQueryAdapter> knownToReproduceBugStatements,
+                                        BiFunction<List<SQLQueryAdapter>, Integer, Boolean> reductionOperation) throws Exception {
+        for (int i = 0; i < knownToReproduceBugStatements.size(); i++) {
+            try (SQLConnection con2 = this.createDatabase(newGlobalState)) {
+                newGlobalState.setConnection(con2);
+                List<SQLQueryAdapter> candidateStatements = new ArrayList<>(knownToReproduceBugStatements);
+                if (!reductionOperation.apply(candidateStatements, i)) {
+                    continue;
+                }
+                newGlobalState.getState().setStatements(new ArrayList<>(candidateStatements));
+                for (SQLQueryAdapter s : candidateStatements) {
+                    try {
+                        s.execute(newGlobalState);
+                    } catch (Throwable ignoredException) {
+                        // ignore
+                    }
+                }
+                try {
+                    if (reproducer.bugStillTriggers(newGlobalState)) {
+                        observedChange = true;
+                        knownToReproduceBugStatements = candidateStatements;
+                        reproducer.outputHook(newGlobalState);
+                    }
+                } catch (Throwable ignoredException) {
+
+                }
+            }
+        }
+        return knownToReproduceBugStatements;
     }
 }

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -9,7 +9,7 @@ import sqlancer.common.query.Query;
 
 public class StateToReproduce {
 
-    private final List<Query<?>> statements = new ArrayList<>();
+    private List<Query<?>> statements = new ArrayList<>();
 
     private final String databaseName;
 
@@ -126,6 +126,10 @@ public class StateToReproduce {
 
     public OracleRunReproductionState createLocalState() {
         return new OracleRunReproductionState();
+    }
+
+    public void setStatements(List<Query<?>> statements) {
+        this.statements = statements;
     }
 
 }

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3IndexGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3IndexGenerator.java
@@ -44,6 +44,7 @@ public class SQLite3IndexGenerator {
         errors.add("non-deterministic use of date() in an index");
         errors.add("non-deterministic use of datetime() in an index");
         errors.add("The database file is locked");
+        errors.add("Abort due to constraint violation");
         SQLite3Errors.addExpectedExpressionErrors(errors);
         if (!SQLite3Provider.mustKnowResult) {
             // can only happen when PRAGMA case_sensitive_like=ON;


### PR DESCRIPTION
Partially fix: https://github.com/sqlancer/sqlancer/issues/333

Using the reference implementation given [here](https://github.com/sqlancer/sqlancer/commit/66f57c69b40656ba36e96285ac57217b2606cfa3) I have created a generified first version for integrated test case reduction, as discussed offline with @mrigger. It is using the same fixpoint iteration as showed in the code linked.

Also, I have refactored (only partially) the code for `DuckDbNoRECOracle` to apply the reduction. Actually NoREC oracles can be refactored and I believe much more code reusability can be achieved.

This is only the starting point: I have tried to divide the actual reduction operation from logging, however I am not super happy as it is now, maybe we can improve also this part more in the future. The problem that I see is that the state is stored and passed from one method to the other. Modifying this whould require a great effort and it should be properly discussed I believe, so for now I just kept it this way, trying to separate filling the state object at runtime from actually writing the statements to file.