### PR TITLE
Update and fix the Citus CI step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
         run: mvn -B package -DskipTests=true
       - name: Set up Citus
         run: |
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list
           curl https://install.citusdata.com/community/deb.sh | sudo bash
           sudo apt-get -y install postgresql-13-citus-10.1
           sudo chown -R $USER:$USER /var/run/postgresql


### PR DESCRIPTION
This step started failing with an error "postgresql-13-citus-10.1 : Depends: postgresql-13 but it is not installable"