### PR TITLE
Use a ServiceLoader to pick up database testing implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
       <version>1.82</version>

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -21,23 +22,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.JCommander.Builder;
 
-import sqlancer.arangodb.ArangoDBProvider;
-import sqlancer.citus.CitusProvider;
-import sqlancer.clickhouse.ClickHouseProvider;
-import sqlancer.cockroachdb.CockroachDBProvider;
 import sqlancer.common.log.Loggable;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLancerResultSet;
-import sqlancer.cosmos.CosmosProvider;
-import sqlancer.duckdb.DuckDBProvider;
-import sqlancer.h2.H2Provider;
-import sqlancer.mariadb.MariaDBProvider;
-import sqlancer.mongodb.MongoDBProvider;
-import sqlancer.mysql.MySQLProvider;
-import sqlancer.oceanbase.OceanBaseProvider;
-import sqlancer.postgres.PostgresProvider;
-import sqlancer.sqlite3.SQLite3Provider;
-import sqlancer.tidb.TiDBProvider;
 
 public final class Main {
 
@@ -543,22 +530,21 @@ public final class Main {
         return threadsShutdown == 0 ? 0 : options.getErrorExitCode();
     }
 
+    /**
+     * To register a new provider, it is necessary to implement the DatabaseProvider interface and add an additional
+     * configuration file, see https://docs.oracle.com/javase/9/docs/api/java/util/ServiceLoader.html. Currently, we use
+     * an @AutoService annotation to create the configuration file automatically. This allows SQLancer to pick up
+     * providers in other JARs on the classpath.
+     *
+     * @return The list of service providers on the classpath
+     */
     static List<DatabaseProvider<?, ?, ?>> getDBMSProviders() {
         List<DatabaseProvider<?, ?, ?>> providers = new ArrayList<>();
-        providers.add(new SQLite3Provider());
-        providers.add(new CockroachDBProvider());
-        providers.add(new MySQLProvider());
-        providers.add(new MariaDBProvider());
-        providers.add(new TiDBProvider());
-        providers.add(new PostgresProvider());
-        providers.add(new CitusProvider());
-        providers.add(new ClickHouseProvider());
-        providers.add(new DuckDBProvider());
-        providers.add(new H2Provider());
-        providers.add(new MongoDBProvider());
-        providers.add(new CosmosProvider());
-        providers.add(new ArangoDBProvider());
-        providers.add(new OceanBaseProvider());
+        @SuppressWarnings("rawtypes")
+        ServiceLoader<DatabaseProvider> loader = ServiceLoader.load(DatabaseProvider.class);
+        for (DatabaseProvider<?, ?, ?> provider : loader) {
+            providers.add(provider);
+        }
         return providers;
     }
 

--- a/src/sqlancer/arangodb/ArangoDBProvider.java
+++ b/src/sqlancer/arangodb/ArangoDBProvider.java
@@ -5,8 +5,10 @@ import java.util.List;
 
 import com.arangodb.ArangoDB;
 import com.arangodb.ArangoDatabase;
+import com.google.auto.service.AutoService;
 
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.ExecutionTimer;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
@@ -19,6 +21,7 @@ import sqlancer.arangodb.gen.ArangoDBTableGenerator;
 import sqlancer.common.log.LoggableFactory;
 import sqlancer.common.query.Query;
 
+@AutoService(DatabaseProvider.class)
 public class ArangoDBProvider
         extends ProviderAdapter<ArangoDBProvider.ArangoDBGlobalState, ArangoDBOptions, ArangoDBConnection> {
 

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -10,7 +10,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.SQLConnection;
@@ -51,6 +54,7 @@ import sqlancer.postgres.gen.PostgresTransactionGenerator;
 import sqlancer.postgres.gen.PostgresTruncateGenerator;
 import sqlancer.postgres.gen.PostgresVacuumGenerator;
 
+@AutoService(DatabaseProvider.class)
 public class CitusProvider extends PostgresProvider {
 
     @SuppressWarnings("unchecked")

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -6,7 +6,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.stream.Collectors;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.MainOptions;
 import sqlancer.Randomly;
@@ -21,6 +24,7 @@ import sqlancer.clickhouse.gen.ClickHouseTableGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLQueryProvider;
 
+@AutoService(DatabaseProvider.class)
 public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState, ClickHouseOptions> {
 
     public ClickHouseProvider() {

--- a/src/sqlancer/cockroachdb/CockroachDBProvider.java
+++ b/src/sqlancer/cockroachdb/CockroachDBProvider.java
@@ -8,6 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.auto.service.AutoService;
+
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.Main.QueryManager;
 import sqlancer.MainOptions;
@@ -34,6 +37,7 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLQueryProvider;
 
+@AutoService(DatabaseProvider.class)
 public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalState, CockroachDBOptions> {
 
     public CockroachDBProvider() {

--- a/src/sqlancer/cosmos/CosmosProvider.java
+++ b/src/sqlancer/cosmos/CosmosProvider.java
@@ -1,11 +1,13 @@
 package sqlancer.cosmos;
 
+import com.google.auto.service.AutoService;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.ProviderAdapter;
 import sqlancer.Randomly;
@@ -17,6 +19,7 @@ import sqlancer.mongodb.MongoDBOptions;
 import sqlancer.mongodb.MongoDBQueryAdapter;
 import sqlancer.mongodb.gen.MongoDBTableGenerator;
 
+@AutoService(DatabaseProvider.class)
 public class CosmosProvider extends
         ProviderAdapter<sqlancer.mongodb.MongoDBProvider.MongoDBGlobalState, MongoDBOptions, MongoDBConnection> {
 

--- a/src/sqlancer/duckdb/DuckDBProvider.java
+++ b/src/sqlancer/duckdb/DuckDBProvider.java
@@ -3,7 +3,10 @@ package sqlancer.duckdb;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.SQLConnection;
@@ -22,6 +25,7 @@ import sqlancer.duckdb.gen.DuckDBTableGenerator;
 import sqlancer.duckdb.gen.DuckDBUpdateGenerator;
 import sqlancer.duckdb.gen.DuckDBViewGenerator;
 
+@AutoService(DatabaseProvider.class)
 public class DuckDBProvider extends SQLProviderAdapter<DuckDBGlobalState, DuckDBOptions> {
 
     public DuckDBProvider() {

--- a/src/sqlancer/h2/H2Provider.java
+++ b/src/sqlancer/h2/H2Provider.java
@@ -4,7 +4,10 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.SQLConnection;
@@ -15,6 +18,7 @@ import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLQueryProvider;
 import sqlancer.h2.H2Provider.H2GlobalState;
 
+@AutoService(DatabaseProvider.class)
 public class H2Provider extends SQLProviderAdapter<H2GlobalState, H2Options> {
 
     public H2Provider() {

--- a/src/sqlancer/mariadb/MariaDBProvider.java
+++ b/src/sqlancer/mariadb/MariaDBProvider.java
@@ -7,6 +7,9 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.auto.service.AutoService;
+
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.MainOptions;
 import sqlancer.Randomly;
@@ -24,6 +27,7 @@ import sqlancer.mariadb.gen.MariaDBTableGenerator;
 import sqlancer.mariadb.gen.MariaDBTruncateGenerator;
 import sqlancer.mariadb.gen.MariaDBUpdateGenerator;
 
+@AutoService(DatabaseProvider.class)
 public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, MariaDBOptions> {
 
     public static final int MAX_EXPRESSION_DEPTH = 3;

--- a/src/sqlancer/mongodb/MongoDBProvider.java
+++ b/src/sqlancer/mongodb/MongoDBProvider.java
@@ -3,11 +3,13 @@ package sqlancer.mongodb;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.auto.service.AutoService;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.ExecutionTimer;
 import sqlancer.GlobalState;
 import sqlancer.IgnoreMeException;
@@ -21,6 +23,7 @@ import sqlancer.mongodb.gen.MongoDBIndexGenerator;
 import sqlancer.mongodb.gen.MongoDBInsertGenerator;
 import sqlancer.mongodb.gen.MongoDBTableGenerator;
 
+@AutoService(DatabaseProvider.class)
 public class MongoDBProvider
         extends ProviderAdapter<MongoDBProvider.MongoDBGlobalState, MongoDBOptions, MongoDBConnection> {
 

--- a/src/sqlancer/mysql/MySQLProvider.java
+++ b/src/sqlancer/mysql/MySQLProvider.java
@@ -5,7 +5,10 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.MainOptions;
 import sqlancer.Randomly;
@@ -31,6 +34,7 @@ import sqlancer.mysql.gen.tblmaintenance.MySQLChecksum;
 import sqlancer.mysql.gen.tblmaintenance.MySQLOptimize;
 import sqlancer.mysql.gen.tblmaintenance.MySQLRepair;
 
+@AutoService(DatabaseProvider.class)
 public class MySQLProvider extends SQLProviderAdapter<MySQLGlobalState, MySQLOptions> {
 
     public MySQLProvider() {

--- a/src/sqlancer/oceanbase/OceanBaseProvider.java
+++ b/src/sqlancer/oceanbase/OceanBaseProvider.java
@@ -5,7 +5,10 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.MainOptions;
 import sqlancer.Randomly;
@@ -24,6 +27,7 @@ import sqlancer.oceanbase.gen.OceanBaseTruncateTableGenerator;
 import sqlancer.oceanbase.gen.OceanBaseUpdateGenerator;
 import sqlancer.oceanbase.gen.datadef.OceanBaseIndexGenerator;
 
+@AutoService(DatabaseProvider.class)
 public class OceanBaseProvider extends SQLProviderAdapter<OceanBaseGlobalState, OceanBaseOptions> {
 
     public OceanBaseProvider() {

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -8,7 +8,10 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.MainOptions;
 import sqlancer.Randomly;
@@ -43,6 +46,7 @@ import sqlancer.postgres.gen.PostgresViewGenerator;
 
 // EXISTS
 // IN
+@AutoService(DatabaseProvider.class)
 public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, PostgresOptions> {
 
     /**

--- a/src/sqlancer/sqlite3/SQLite3Provider.java
+++ b/src/sqlancer/sqlite3/SQLite3Provider.java
@@ -7,7 +7,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.SQLConnection;
@@ -40,6 +43,7 @@ import sqlancer.sqlite3.gen.dml.SQLite3StatTableGenerator;
 import sqlancer.sqlite3.gen.dml.SQLite3UpdateGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
+@AutoService(DatabaseProvider.class)
 public class SQLite3Provider extends SQLProviderAdapter<SQLite3GlobalState, SQLite3Options> {
 
     public static boolean allowFloatingPointFp = true;

--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -5,7 +5,10 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import com.google.auto.service.AutoService;
+
 import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
 import sqlancer.IgnoreMeException;
 import sqlancer.MainOptions;
 import sqlancer.Randomly;
@@ -28,6 +31,7 @@ import sqlancer.tidb.gen.TiDBTableGenerator;
 import sqlancer.tidb.gen.TiDBUpdateGenerator;
 import sqlancer.tidb.gen.TiDBViewGenerator;
 
+@AutoService(DatabaseProvider.class)
 public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOptions> {
 
     public TiDBProvider() {


### PR DESCRIPTION
This change allows SQLancer to pick up database providers in other JARs than the SQLancer JAR, if they are on the classpath.