### PR TITLE
Update `DuckDB` SQLancer implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
     <dependency>
       <groupId>org.duckdb</groupId>
       <artifactId>duckdb_jdbc</artifactId>
-      <version>0.2.5</version>
+      <version>0.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/sqlancer/duckdb/DuckDBErrors.java
+++ b/src/sqlancer/duckdb/DuckDBErrors.java
@@ -23,7 +23,7 @@ public final class DuckDBErrors {
         errors.add("invalid UTF-8"); // TODO
         errors.add("String value is not valid UTF8");
 
-        errors.add("Conversion: Invalid TypeId "); // TODO
+        errors.add("Invalid TypeId "); // TODO
 
         errors.add("GROUP BY clause cannot contain aggregates!"); // investigate
 
@@ -33,7 +33,7 @@ public final class DuckDBErrors {
 
         errors.add("Overflow in multiplication");
         errors.add("Out of Range");
-        errors.add("Conversion: Date out of range");
+        errors.add("Date out of range");
 
         // collate
         errors.add("Cannot combine types with different collation!");
@@ -42,6 +42,7 @@ public final class DuckDBErrors {
         // // https://github.com/cwida/duckdb/issues/532
         errors.add("Not implemented type: DATE");
         errors.add("Not implemented type: TIMESTAMP");
+        errors.add("Like pattern must not end with escape character!"); // LIKE
 
         errors.add("does not have a column named \"rowid\""); // TODO: this can be removed if we can query whether a
                                                               // table supports rowids
@@ -50,7 +51,6 @@ public final class DuckDBErrors {
                                                     // removed column
         errors.add("Contents of view were altered: types don't match!");
         errors.add("Not implemented: ROUND(DECIMAL, INTEGER) with non-constant precision is not supported");
-        errors.add("Could not convert string"); // Could not convert string '1.7976931348623157E308' to DOUBLE
     }
 
     private static void addRegexErrors(ExpectedErrors errors) {
@@ -66,32 +66,44 @@ public final class DuckDBErrors {
     }
 
     private static void addFunctionErrors(ExpectedErrors errors) {
-        errors.add("SUBSTRING cannot handle negative offsets");
+        errors.add("SUBSTRING cannot handle negative lengths");
         errors.add("is undefined outside [-1,1]"); // ACOS etc
         errors.add("invalid type specifier"); // PRINTF
         errors.add("argument index out of range"); // PRINTF
         errors.add("invalid format string"); // PRINTF
         errors.add("number is too big"); // PRINTF
+        errors.add("Like pattern must not end with escape character!"); // LIKE
         errors.add("Could not choose a best candidate function for the function call \"date_part"); // date_part
         errors.add("extract specifier"); // date_part
+        errors.add("not recognized"); // date_part
+        errors.add("not supported"); // date_part
+        errors.add("Failed to cast");
+        errors.add("Conversion Error");
+        errors.add("Could not cast value");
         errors.add("Insufficient padding in RPAD"); // RPAD
         errors.add("Could not choose a best candidate function for the function call"); // monthname
+        errors.add("expected a numeric precision field"); // ROUND
+        errors.add("with non-constant precision is not supported"); // ROUND
     }
 
     public static void addInsertErrors(ExpectedErrors errors) {
+        addRegexErrors(errors);
+        addFunctionErrors(errors);
+
         errors.add("NOT NULL constraint failed");
         errors.add("PRIMARY KEY or UNIQUE constraint violated");
-        errors.add("duplicate key value violates primary key or unique constraint");
+        errors.add("duplicate key");
         errors.add("can't be cast because the value is out of range for the destination type");
         errors.add("Could not convert string");
-        errors.add("timestamp field value out of range");
         errors.add("Unimplemented type for cast");
-        errors.add("date/time field value out of range");
+        errors.add("field value out of range");
         errors.add("CHECK constraint failed");
         errors.add("Cannot explicitly insert values into rowid column"); // TODO: don't insert into rowid
         errors.add(" Column with name rowid does not exist!"); // currently, there doesn't seem to way to determine if
                                                                // the table has a primary key
-        errors.add("Out of Range: Could not cast value");
+        errors.add("Could not cast value");
+        errors.add("create unique index, table contains duplicate data");
+        errors.add("Failed to cast");
     }
 
     public static void addGroupByErrors(ExpectedErrors errors) {

--- a/src/sqlancer/duckdb/DuckDBProvider.java
+++ b/src/sqlancer/duckdb/DuckDBProvider.java
@@ -2,6 +2,9 @@ package sqlancer.duckdb;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.io.File;
 
 import com.google.auto.service.AutoService;
 
@@ -118,11 +121,34 @@ public class DuckDBProvider extends SQLProviderAdapter<DuckDBGlobalState, DuckDB
         se.executeStatements();
     }
 
+    public void tryDeleteFile(String fname) {
+        try {
+            File f = new File(fname);
+            f.delete();
+        } catch(Exception e) {
+        }
+    }
+
+    public void tryDeleteDatabase(String dbpath) {
+        if (dbpath.equals("") || dbpath.equals(":memory:")) {
+            return;
+        }
+        tryDeleteFile(dbpath);
+        tryDeleteFile(dbpath + ".wal");
+    }
+
     @Override
     public SQLConnection createDatabase(DuckDBGlobalState globalState) throws SQLException {
-        String url = "jdbc:duckdb:";
-        return new SQLConnection(DriverManager.getConnection(url, globalState.getOptions().getUserName(),
-                globalState.getOptions().getPassword()));
+        String database_file = System.getProperty("duckdb.database.file", "");
+        String url = "jdbc:duckdb:" + database_file;
+        tryDeleteDatabase(database_file);
+
+        Connection conn = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
+                globalState.getOptions().getPassword());
+        Statement stmt = conn.createStatement();
+        stmt.execute("PRAGMA checkpoint_threshold='1 byte';");
+        stmt.close();
+        return new SQLConnection(conn);
     }
 
     @Override

--- a/src/sqlancer/duckdb/DuckDBProvider.java
+++ b/src/sqlancer/duckdb/DuckDBProvider.java
@@ -1,10 +1,10 @@
 package sqlancer.duckdb;
 
+import java.io.File;
+import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.sql.Connection;
 import java.sql.Statement;
-import java.io.File;
 
 import com.google.auto.service.AutoService;
 
@@ -125,7 +125,7 @@ public class DuckDBProvider extends SQLProviderAdapter<DuckDBGlobalState, DuckDB
         try {
             File f = new File(fname);
             f.delete();
-        } catch(Exception e) {
+        } catch (Exception e) {
         }
     }
 
@@ -139,9 +139,9 @@ public class DuckDBProvider extends SQLProviderAdapter<DuckDBGlobalState, DuckDB
 
     @Override
     public SQLConnection createDatabase(DuckDBGlobalState globalState) throws SQLException {
-        String database_file = System.getProperty("duckdb.database.file", "");
-        String url = "jdbc:duckdb:" + database_file;
-        tryDeleteDatabase(database_file);
+        String databaseFile = System.getProperty("duckdb.database.file", "");
+        String url = "jdbc:duckdb:" + databaseFile;
+        tryDeleteDatabase(databaseFile);
 
         Connection conn = DriverManager.getConnection(url, globalState.getOptions().getUserName(),
                 globalState.getOptions().getPassword());

--- a/src/sqlancer/duckdb/DuckDBSchema.java
+++ b/src/sqlancer/duckdb/DuckDBSchema.java
@@ -237,7 +237,7 @@ public class DuckDBSchema extends AbstractSchema<DuckDBGlobalState, DuckDBTable>
     private static List<String> getTableNames(SQLConnection con) throws SQLException {
         List<String> tableNames = new ArrayList<>();
         try (Statement s = con.createStatement()) {
-            try (ResultSet rs = s.executeQuery("SELECT * FROM sqlite_master()")) {
+            try (ResultSet rs = s.executeQuery("SELECT * FROM sqlite_master WHERE type='table' or type='view'")) {
                 while (rs.next()) {
                     tableNames.add(rs.getString("name"));
                 }

--- a/src/sqlancer/duckdb/DuckDBSchema.java
+++ b/src/sqlancer/duckdb/DuckDBSchema.java
@@ -25,8 +25,12 @@ public class DuckDBSchema extends AbstractSchema<DuckDBGlobalState, DuckDBTable>
 
         INT, VARCHAR, BOOLEAN, FLOAT, DATE, TIMESTAMP, NULL;
 
-        public static DuckDBDataType getRandom() {
-            return Randomly.fromOptions(values());
+        public static DuckDBDataType getRandomWithoutNull() {
+            DuckDBDataType dt;
+            do {
+                dt = Randomly.fromOptions(values());
+            } while (dt == DuckDBDataType.NULL);
+            return dt;
         }
 
     }
@@ -53,8 +57,8 @@ public class DuckDBSchema extends AbstractSchema<DuckDBGlobalState, DuckDBTable>
             return size;
         }
 
-        public static DuckDBCompositeDataType getRandom() {
-            DuckDBDataType type = DuckDBDataType.getRandom();
+        public static DuckDBCompositeDataType getRandomWithoutNull() {
+            DuckDBDataType type = DuckDBDataType.getRandomWithoutNull();
             int size = -1;
             switch (type) {
             case INT:

--- a/src/sqlancer/duckdb/DuckDBSchema.java
+++ b/src/sqlancer/duckdb/DuckDBSchema.java
@@ -23,7 +23,7 @@ public class DuckDBSchema extends AbstractSchema<DuckDBGlobalState, DuckDBTable>
 
     public enum DuckDBDataType {
 
-        INT, VARCHAR, BOOLEAN, FLOAT, DATE, TIMESTAMP;
+        INT, VARCHAR, BOOLEAN, FLOAT, DATE, TIMESTAMP, NULL;
 
         public static DuckDBDataType getRandom() {
             return Randomly.fromOptions(values());
@@ -109,6 +109,8 @@ public class DuckDBSchema extends AbstractSchema<DuckDBGlobalState, DuckDBTable>
                 return Randomly.fromOptions("TIMESTAMP", "DATETIME");
             case DATE:
                 return Randomly.fromOptions("DATE");
+            case NULL:
+                return Randomly.fromOptions("NULL");
             default:
                 throw new AssertionError(getPrimitiveDataType());
             }
@@ -196,6 +198,9 @@ public class DuckDBSchema extends AbstractSchema<DuckDBGlobalState, DuckDBTable>
             break;
         case "TIMESTAMP":
             primitiveType = DuckDBDataType.TIMESTAMP;
+            break;
+        case "NULL":
+            primitiveType = DuckDBDataType.NULL;
             break;
         case "INTERVAL":
             throw new IgnoreMeException();

--- a/src/sqlancer/duckdb/gen/DuckDBAlterTableGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBAlterTableGenerator.java
@@ -34,13 +34,13 @@ public final class DuckDBAlterTableGenerator {
             String columnName = table.getFreeColumnName();
             sb.append(columnName);
             sb.append(" ");
-            sb.append(DuckDBCompositeDataType.getRandom().toString());
+            sb.append(DuckDBCompositeDataType.getRandomWithoutNull().toString());
             break;
         case ALTER_COLUMN:
             sb.append("ALTER COLUMN ");
             sb.append(table.getRandomColumn().getName());
             sb.append(" SET DATA TYPE ");
-            sb.append(DuckDBCompositeDataType.getRandom().toString());
+            sb.append(DuckDBCompositeDataType.getRandomWithoutNull().toString());
             if (Randomly.getBoolean()) {
                 sb.append(" USING ");
                 DuckDBErrors.addExpressionErrors(errors);

--- a/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
@@ -243,6 +243,7 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
         DEGREES(1), //
         RADIANS(1), //
         MOD(2), //
+        XOR(2), //
         // string functions
         LENGTH(1), //
         LOWER(1), //
@@ -379,8 +380,7 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
     }
 
     public enum DuckDBBinaryArithmeticOperator implements Operator {
-        CONCAT("||"), ADD("+"), SUB("-"), MULT("*"), DIV("/"), MOD("%"), AND("&"), OR("|"), XOR("#"), LSHIFT("<<"),
-        RSHIFT(">>");
+        CONCAT("||"), ADD("+"), SUB("-"), MULT("*"), DIV("/"), MOD("%"), AND("&"), OR("|"), LSHIFT("<<"), RSHIFT(">>");
 
         private String textRepr;
 
@@ -400,7 +400,6 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
     }
 
     public enum DuckDBBinaryComparisonOperator implements Operator {
-
         EQUALS("="), GREATER(">"), GREATER_EQUALS(">="), SMALLER("<"), SMALLER_EQUALS("<="), NOT_EQUALS("!="),
         LIKE("LIKE"), NOT_LIKE("NOT LIKE"), SIMILAR_TO("SIMILAR TO"), NOT_SIMILAR_TO("NOT SIMILAR TO"),
         REGEX_POSIX("~"), REGEX_POSIT_NOT("!~");

--- a/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
@@ -98,7 +98,8 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
             return new NewBinaryOperatorNode<DuckDBExpression>(generateExpression(depth + 1),
                     generateExpression(depth + 1), DuckDBBinaryArithmeticOperator.getRandom());
         case CAST:
-            return new DuckDBCastOperation(generateExpression(depth + 1), DuckDBCompositeDataType.getRandom());
+            return new DuckDBCastOperation(generateExpression(depth + 1),
+                    DuckDBCompositeDataType.getRandomWithoutNull());
         case FUNC:
             DBFunction func = DBFunction.getRandom();
             return new NewFunctionNode<DuckDBExpression, DBFunction>(generateExpressions(func.getNrArgs()), func);
@@ -132,7 +133,7 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
         if (Randomly.getBooleanWithSmallProbability()) {
             return DuckDBConstant.createNullConstant();
         }
-        DuckDBDataType type = DuckDBDataType.getRandom();
+        DuckDBDataType type = DuckDBDataType.getRandomWithoutNull();
         switch (type) {
         case INT:
             if (!globalState.getDbmsSpecificOptions().testIntConstants) {

--- a/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
@@ -80,7 +80,7 @@ public class DuckDBTableGenerator {
         List<DuckDBColumn> columns = new ArrayList<>();
         for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
             String columnName = String.format("c%d", i);
-            DuckDBCompositeDataType columnType = DuckDBCompositeDataType.getRandom();
+            DuckDBCompositeDataType columnType = DuckDBCompositeDataType.getRandomWithoutNull();
             columns.add(new DuckDBColumn(columnName, columnType, false, false));
         }
         return columns;

--- a/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
@@ -58,7 +58,6 @@ public class DuckDBTableGenerator {
             if (Randomly.getBoolean() && globalState.getDbmsSpecificOptions().testDefaultValues) {
                 sb.append(" DEFAULT(");
                 sb.append(DuckDBToStringVisitor.asString(gen.generateConstant()));
-                DuckDBErrors.addExpressionErrors(errors);
                 sb.append(")");
             }
         }

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
@@ -3,6 +3,7 @@ package sqlancer.duckdb.test;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
@@ -34,6 +35,15 @@ public class DuckDBQueryPartitioningBase
     public DuckDBQueryPartitioningBase(DuckDBGlobalState state) {
         super(state);
         DuckDBErrors.addExpressionErrors(errors);
+    }
+
+    public static String canonicalizeResultValue(String value) {
+        // Rule: -0.0 should be canonicalized to 0.0
+        if (Objects.equals(value, "-0.0")) {
+            return "0.0";
+        }
+
+        return value;
     }
 
     @Override

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningDistinctTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningDistinctTester.java
@@ -38,7 +38,7 @@ public class DuckDBQueryPartitioningDistinctTester extends DuckDBQueryPartitioni
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state);
+                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
     }
 
 }

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningGroupByTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningGroupByTester.java
@@ -41,7 +41,7 @@ public class DuckDBQueryPartitioningGroupByTester extends DuckDBQueryPartitionin
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state);
+                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
@@ -46,7 +46,7 @@ public class DuckDBQueryPartitioningHavingTester extends DuckDBQueryPartitioning
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state);
+                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningWhereTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningWhereTester.java
@@ -39,7 +39,7 @@ public class DuckDBQueryPartitioningWhereTester extends DuckDBQueryPartitioningB
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state);
+                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
     }
 
 }

--- a/test/sqlancer/dbms/TestDuckDB.java
+++ b/test/sqlancer/dbms/TestDuckDB.java
@@ -11,8 +11,10 @@ public class TestDuckDB {
     @Test
     public void testDuckDB() {
         // run with one thread due to multithreading issues, see https://github.com/sqlancer/sqlancer/pull/45
-        assertEquals(0, Main.executeMain(new String[] { "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
-                "--num-threads", "1", "--num-queries", "0", "duckdb", "--oracle", "QUERY_PARTITIONING" }));
+        assertEquals(0,
+                Main.executeMain(new String[] { "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
+                        "--num-threads", "1", "--num-queries", TestConfig.NUM_QUERIES, "duckdb", "--oracle",
+                        "QUERY_PARTITIONING" }));
     }
 
 }


### PR DESCRIPTION
Simple PR that bumps DuckDB to its latest version 0.3.3, and updates the implementation based on the SQLancer fork used by the DuckDB team (specifically, the `persistent` branch which is used in their CI).

Also enables in SQLancer CI tests for DuckDB again (specifically, with the query partitioning oracle which is DuckDB's default oracle)