### PR TITLE
Allow result set canonicalization before equality check

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import sqlancer.common.query.ExpectedErrors;
@@ -112,6 +113,18 @@ public final class ComparatorHelper {
                     firstQueryString, secondQueryString);
             throw new AssertionError(assertionMessage);
         }
+    }
+
+    public static void assumeResultSetsAreEqual(List<String> resultSet, List<String> secondResultSet,
+            String originalQueryString, List<String> combinedString, SQLGlobalState<?, ?> state,
+            UnaryOperator<String> canonicalizationRule) {
+        // Overloaded version of assumeResultSetsAreEqual that takes a canonicalization function which is applied to
+        // both result sets before their comparison.
+        List<String> canonicalizedResultSet = resultSet.stream().map(canonicalizationRule).collect(Collectors.toList());
+        List<String> canonicalizedSecondResultSet = secondResultSet.stream().map(canonicalizationRule)
+                .collect(Collectors.toList());
+        assumeResultSetsAreEqual(canonicalizedResultSet, canonicalizedSecondResultSet, originalQueryString,
+                combinedString, state);
     }
 
     public static List<String> getCombinedResultSet(String firstQueryString, String secondQueryString,

--- a/test/sqlancer/TestComparatorHelper.java
+++ b/test/sqlancer/TestComparatorHelper.java
@@ -1,0 +1,54 @@
+package sqlancer;
+
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class TestComparatorHelper {
+    // TODO: Implement tests for the other ComparatorHelper methods
+
+    @Test
+    public void testAssumeResultSetsAreEqualWithEqualSets() {
+        List<String> r1 = Arrays.asList("a", "b", "c");
+        List<String> r2 = Arrays.asList("a", "b", "c");
+        ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null);
+
+    }
+
+    @Test
+    public void testAssumeResultSetsAreEqualWithUnequalLengthSets() {
+        List<String> r1 = Arrays.asList("a", "b", "c");
+        List<String> r2 = Arrays.asList("a", "b", "c", "d", "g");
+        // NullPointerException is raised instead of AssertionError because state is null and the state.getState()...
+        // line occurs before AssertionError is thrown, but it's good enough as an indicator that one of the Exceptions
+        // is raised
+        assertThrowsExactly(NullPointerException.class, () -> {
+            ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null);
+        });
+    }
+
+    @Test
+    public void testAssumeResultSetsAreEqualWithUnequalValueSets() {
+        List<String> r1 = Arrays.asList("a", "b", "c");
+        List<String> r2 = Arrays.asList("a", "b", "d");
+        // NullPointerException is raised instead of AssertionError because state is null and the state.getState()...
+        // line occurs before AssertionError is thrown, but it's good enough as an indicator that one of the Exceptions
+        // is raised
+        assertThrowsExactly(NullPointerException.class, () -> {
+            ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null);
+        });
+    }
+
+    @Test
+    public void testAssumeResultSetsAreEqualWithCanonicalizationRule() {
+        List<String> r1 = Arrays.asList("a", "b", "c");
+        List<String> r2 = Arrays.asList("a", "b", "d");
+        ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null, (String s) -> {
+            return s.equals("d") ? "c" : s;
+        });
+    }
+
+}


### PR DESCRIPTION
Implements an overloaded version of `ComparatorHelper.assumeResultSetsAreEqual` that takes in an additional parameter, `canonicalizationRule`, which is a function that all elements of both result sets are mapped through before they are checked for equality.

Additionally, implements tests for the `assumeResultSetsAreEqual` function!

Inspired by the need for DuckDB-specific canonicalization noticed while implementing #497 