### PR TITLE
Add '--extensions' option. Allow to perform a sqlancer test with an relocatable extension installed

### DIFF
--- a/src/sqlancer/postgres/PostgresOptions.java
+++ b/src/sqlancer/postgres/PostgresOptions.java
@@ -38,6 +38,9 @@ public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactor
     public String connectionURL = String.format("postgresql://%s:%d/test", PostgresOptions.DEFAULT_HOST,
             PostgresOptions.DEFAULT_PORT);
 
+    @Parameter(names = "--extensions", description = "Specifies a comma-separated list of extension names to be created in each test database", arity = 1)
+    public String extensions = "";
+
     public enum PostgresOracleFactory implements OracleFactory<PostgresGlobalState> {
         NOREC {
             @Override


### PR DESCRIPTION
As I know, people mostly use postgres with some essential extensions. For example, pg_stat_statements.
So it would be good option to allow sqlancer to test PostgreSQL installation with some set of extensions (relocatable, as for yet).
For example, if you try to test it in the way:
```
--oracle HAVING --extensions='pg_stat_statements'
```
you can see one cool bug with negative value of groups number estimation related to incorrect double -> long cast (I want to discuss it later in the hackers list).
So, I think, such option can be useful for the project.

P.S. For quick replay of the problem mentioned above, use simplistic patch below:
```
diff --git a/src/backend/optimizer/plan/createplan.c b/src/backend/optimizer/plan/createplan.c
index 5b7bf1cec6..04cfeb7953 100644
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2565,6 +2565,7 @@ create_setop_plan(PlannerInfo *root, SetOpPath *best_path, int flags)
 
 	/* Convert numGroups to long int --- but 'ware overflow! */
 	numGroups = (long) Min(best_path->numGroups, (double) LONG_MAX);
+	Assert(numGroups >= 0);
 
 	plan = make_setop(best_path->cmd,
 					  best_path->strategy,
@@ -2602,6 +2603,7 @@ create_recursiveunion_plan(PlannerInfo *root, RecursiveUnionPath *best_path)
 
 	/* Convert numGroups to long int --- but 'ware overflow! */
 	numGroups = (long) Min(best_path->numGroups, (double) LONG_MAX);
+	Assert(numGroups >= 0);
 
 	plan = make_recursive_union(tlist,
 								leftplan,
@@ -6302,6 +6304,7 @@ make_agg(List *tlist, List *qual,
 
 	/* Reduce to long, but 'ware overflow! */
 	numGroups = (long) Min(dNumGroups, (double) LONG_MAX);
+	Assert(numGroups >= 0);
 
 	node->aggstrategy = aggstrategy;
 	node->aggsplit = aggsplit;
```
