### PR TITLE
Add an expected error on usage of the chr() routine.

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresCommon.java
+++ b/src/sqlancer/postgres/gen/PostgresCommon.java
@@ -63,6 +63,7 @@ public final class PostgresCommon {
         errors.add("is of type boolean but expression is of type text");
         errors.add("a negative number raised to a non-integer power yields a complex result");
         errors.add("could not determine polymorphic type because input has type unknown");
+        errors.add("character number must be positive");
         addToCharFunctionErrors(errors);
         addBitStringOperationErrors(errors);
         addFunctionErrors(errors);


### PR DESCRIPTION
According to PG15 commit e9e63b7, chr() in next release will return an error
on negative input. Be prepared to that change.