### PR TITLE
Swap parameters of Untyped generateExpressions to match Typed

### DIFF
--- a/src/sqlancer/arangodb/gen/ArangoDBComputedExpressionGenerator.java
+++ b/src/sqlancer/arangodb/gen/ArangoDBComputedExpressionGenerator.java
@@ -65,7 +65,7 @@ public class ArangoDBComputedExpressionGenerator
             return generateLeafNode();
         }
         ComputedFunction function = ComputedFunction.getRandom();
-        return new NewFunctionNode<>(generateExpressions(depth + 1, function.getNrArgs()), function);
+        return new NewFunctionNode<>(generateExpressions(function.getNrArgs(), depth + 1), function);
     }
 
     @Override

--- a/src/sqlancer/common/gen/UntypedExpressionGenerator.java
+++ b/src/sqlancer/common/gen/UntypedExpressionGenerator.java
@@ -42,7 +42,7 @@ public abstract class UntypedExpressionGenerator<E, C> implements ExpressionGene
         return expressions;
     }
 
-    public List<E> generateExpressions(int depth, int nr) {
+    public List<E> generateExpressions(int nr, int depth) {
         List<E> expressions = new ArrayList<>();
         for (int i = 0; i < nr; i++) {
             expressions.add(generateExpression(depth));

--- a/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBExpressionGenerator.java
@@ -48,7 +48,7 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
         if (allowAggregates && Randomly.getBoolean()) {
             DuckDBAggregateFunction aggregate = DuckDBAggregateFunction.getRandom();
             allowAggregates = false;
-            return new NewFunctionNode<>(generateExpressions(depth + 1, aggregate.getNrArgs()), aggregate);
+            return new NewFunctionNode<>(generateExpressions(aggregate.getNrArgs(), depth + 1), aggregate);
         }
         List<Expression> possibleOptions = new ArrayList<>(Arrays.asList(Expression.values()));
         if (!globalState.getDbmsSpecificOptions().testCollate) {
@@ -108,11 +108,11 @@ public final class DuckDBExpressionGenerator extends UntypedExpressionGenerator<
                     generateExpression(depth + 1), generateExpression(depth + 1), Randomly.getBoolean());
         case IN:
             return new NewInOperatorNode<DuckDBExpression>(generateExpression(depth + 1),
-                    generateExpressions(depth + 1, Randomly.smallNumber() + 1), Randomly.getBoolean());
+                    generateExpressions(Randomly.smallNumber() + 1, depth + 1), Randomly.getBoolean());
         case CASE:
             int nr = Randomly.smallNumber() + 1;
             return new NewCaseOperatorNode<DuckDBExpression>(generateExpression(depth + 1),
-                    generateExpressions(depth + 1, nr), generateExpressions(depth + 1, nr),
+                    generateExpressions(nr, depth + 1), generateExpressions(nr, depth + 1),
                     generateExpression(depth + 1));
         case LIKE_ESCAPE:
             return new NewTernaryNode<DuckDBExpression>(generateExpression(depth + 1), generateExpression(depth + 1),

--- a/src/sqlancer/h2/H2ExpressionGenerator.java
+++ b/src/sqlancer/h2/H2ExpressionGenerator.java
@@ -53,14 +53,14 @@ public class H2ExpressionGenerator extends UntypedExpressionGenerator<Node<H2Exp
                     H2UnaryPrefixOperator.getRandom());
         case IN:
             return new NewInOperatorNode<H2Expression>(generateExpression(depth + 1),
-                    generateExpressions(depth + 1, Randomly.smallNumber() + 1), Randomly.getBoolean());
+                    generateExpressions(Randomly.smallNumber() + 1, depth + 1), Randomly.getBoolean());
         case BETWEEN:
             return new NewBetweenOperatorNode<H2Expression>(generateExpression(depth + 1),
                     generateExpression(depth + 1), generateExpression(depth + 1), Randomly.getBoolean());
         case CASE:
             int nr = Randomly.smallNumber() + 1;
             return new NewCaseOperatorNode<H2Expression>(generateExpression(depth + 1),
-                    generateExpressions(depth + 1, nr), generateExpressions(depth + 1, nr),
+                    generateExpressions(nr, depth + 1), generateExpressions(nr, depth + 1),
                     generateExpression(depth + 1));
         case BINARY_ARITHMETIC:
             return new NewBinaryOperatorNode<H2Expression>(generateExpression(depth + 1), generateExpression(depth + 1),

--- a/src/sqlancer/mongodb/gen/MongoDBComputedExpressionGenerator.java
+++ b/src/sqlancer/mongodb/gen/MongoDBComputedExpressionGenerator.java
@@ -33,7 +33,7 @@ public class MongoDBComputedExpressionGenerator
             return generateLeafNode();
         }
         ComputedFunction func = ComputedFunction.getRandom();
-        return new NewFunctionNode<>(generateExpressions(depth + 1, func.getNrArgs()), func);
+        return new NewFunctionNode<>(generateExpressions(func.getNrArgs(), depth + 1), func);
     }
 
     public MongoDBComputedExpressionGenerator(MongoDBGlobalState globalState) {

--- a/src/sqlancer/tidb/TiDBExpressionGenerator.java
+++ b/src/sqlancer/tidb/TiDBExpressionGenerator.java
@@ -91,7 +91,7 @@ public class TiDBExpressionGenerator extends UntypedExpressionGenerator<TiDBExpr
                     Randomly.fromOptions("utf8mb4_bin", "latin1_bin", "binary", "ascii_bin", "utf8_bin"));
         case FUNCTION:
             TiDBFunction func = TiDBFunction.getRandom();
-            return new TiDBFunctionCall(func, generateExpressions(depth, func.getNrArgs()));
+            return new TiDBFunctionCall(func, generateExpressions(func.getNrArgs(), depth));
         case BINARY_BIT:
             return new TiDBBinaryBitOperation(generateExpression(depth + 1), generateExpression(depth + 1),
                     TiDBBinaryBitOperator.getRandom());
@@ -117,8 +117,8 @@ public class TiDBExpressionGenerator extends UntypedExpressionGenerator<TiDBExpr
                 throw new IgnoreMeException();
             }
             int nr = Randomly.fromOptions(1, 2);
-            return new TiDBCase(generateExpression(depth + 1), generateExpressions(depth + 1, nr),
-                    generateExpressions(depth + 1, nr), generateExpression(depth + 1));
+            return new TiDBCase(generateExpression(depth + 1), generateExpressions(nr, depth + 1),
+                    generateExpressions(nr, depth + 1), generateExpression(depth + 1));
         default:
             throw new AssertionError();
         }


### PR DESCRIPTION
Quick refactor of UntypedExpressionGenerator's `generateExpressions` method so that it's paramaters go `(int nr, int depth)` to keep it consistent with TypedExpressionGenerator which does `(T type, int nr, int depth)`