### PR TITLE
disable EXTRA_FLOAT_DIGITS

### DIFF
--- a/src/sqlancer/cockroachdb/gen/CockroachDBSetSessionGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBSetSessionGenerator.java
@@ -27,7 +27,7 @@ public final class CockroachDBSetSessionGenerator {
         ENABLE_ZIGZAG_JOIN(CockroachDBSetSessionGenerator::onOff),
         // EXPERIMENTAL_ENABLE_HASH_SHARDED_INDEXES(CockroachDBSetSessionGenerator::onOff),
         SERIAL_NORMALIZATION((g) -> Randomly.fromOptions("'rowid'", "'virtual_sequence'")),
-        EXTRA_FLOAT_DIGITS((g) -> g.getRandomly().getInteger(-15, 3)),
+        // EXTRA_FLOAT_DIGITS((g) -> g.getRandomly().getInteger(-15, 3)),
         REORDER_JOINS_LIMIT((g) -> g.getRandomly().getInteger(0, Integer.MAX_VALUE)), //
         SQL_SAFE_UPDATES((g) -> "off"),
         // TRACING(CockroachDBSetSessionGenerator::onOff)


### PR DESCRIPTION
We disable the EXTRA_FLOAT_DIGITS to avoid the false positive as follows:
 
```sql
CREATE TABLE t1 (c0 BOOL);
SET SESSION EXTRA_FLOAT_DIGITS=-15;
UPSERT INTO t1 (c0) VALUES(false);

SELECT SUM(0.57 :::FLOAT); -- 0.6
SELECT SUM(0.57 :::FLOAT)::DECIMAL; -- 0.57000000000000000000
```