### PR TITLE
Added wrapped exceptions support

### DIFF
--- a/src/sqlancer/common/query/SQLQueryAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryAdapter.java
@@ -98,17 +98,15 @@ public class SQLQueryAdapter extends Query<SQLConnection> {
     public void checkException(Exception e) throws AssertionError {
         Throwable ex = e;
 
-        while (true) {
+        while (ex != null) {
             if (expectedErrors.errorIsExpected(ex.getMessage())) {
                 return;
-            } else if (ex.getCause() != null) {
-                ex = ex.getCause();
             } else {
-                break;
+                ex = ex.getCause();
             }
         }
 
-        throw new AssertionError(query, ex);
+        throw new AssertionError(query, e);
     }
 
     @Override

--- a/src/sqlancer/common/query/SQLQueryAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryAdapter.java
@@ -96,9 +96,19 @@ public class SQLQueryAdapter extends Query<SQLConnection> {
     }
 
     public void checkException(Exception e) throws AssertionError {
-        if (!expectedErrors.errorIsExpected(e.getMessage())) {
-            throw new AssertionError(query, e);
+        Throwable ex = e;
+
+        while (true) {
+            if (expectedErrors.errorIsExpected(ex.getMessage())) {
+                return;
+            } else if (ex.getCause() != null) {
+                ex = ex.getCause();
+            } else {
+                break;
+            }
         }
+
+        throw new AssertionError(query, ex);
     }
 
     @Override


### PR DESCRIPTION
Some database drivers throws exceptions that may be wrapped by a high-level one. In this case exception text that is actually allowed will be treated as an error.

New code walks through all existing causes and search for the text there.