### PR TITLE
Added Yugabyte API support

### DIFF
--- a/configs/spotbugs-exclude.xml
+++ b/configs/spotbugs-exclude.xml
@@ -11,5 +11,10 @@
 		<Class name="sqlancer.postgres.PostgresProvider" />
 		<Method name="createDatabase" />
 		<Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
-</Match>
+	</Match>
+	<Match>
+		<Class name="sqlancer.yugabyte.ysql.YSQLProvider" />
+		<Method name="createDatabase" />
+		<Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
+	</Match>
 </FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,16 @@
       <version>42.5.0</version>
     </dependency>
     <dependency>
+      <groupId>com.ing.data</groupId>
+      <artifactId>cassandra-jdbc-wrapper</artifactId>
+      <version>4.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yugabyte</groupId>
+      <artifactId>jdbc-yugabytedb</artifactId>
+      <version>42.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
       <version>3.36.0.3</version>

--- a/src/sqlancer/yugabyte/ycql/YCQLErrors.java
+++ b/src/sqlancer/yugabyte/ycql/YCQLErrors.java
@@ -1,0 +1,21 @@
+package sqlancer.yugabyte.ycql;
+
+import sqlancer.common.query.ExpectedErrors;
+
+public final class YCQLErrors {
+
+    private YCQLErrors() {
+    }
+
+    public static void addExpressionErrors(ExpectedErrors errors) {
+        errors.add("Signature mismatch in call to builtin function");
+        errors.add("Qualified name not allowed for column reference");
+        errors.add("Datatype Mismatch");
+        errors.add("Invalid Datatype");
+        errors.add("Invalid CQL Statement");
+        errors.add("Invalid SQL Statement");
+        errors.add("Order by clause contains invalid expression");
+        errors.add("Invalid Function Call");
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/YCQLOptions.java
+++ b/src/sqlancer/yugabyte/ycql/YCQLOptions.java
@@ -1,0 +1,47 @@
+package sqlancer.yugabyte.ycql;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import sqlancer.DBMSSpecificOptions;
+import sqlancer.OracleFactory;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.yugabyte.ycql.YCQLOptions.YCQLOracleFactory;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.test.YCQLFuzzer;
+
+@Parameters(commandDescription = "YCQL")
+public class YCQLOptions implements DBMSSpecificOptions<YCQLOracleFactory> {
+
+    @Parameter(names = "--max-num-deletes", description = "The maximum number of DELETE statements that are issued for a database", arity = 1)
+    public int maxNumDeletes = 1;
+
+    @Parameter(names = "--max-num-updates", description = "The maximum number of UPDATE statements that are issued for a database", arity = 1)
+    public int maxNumUpdates = 5;
+
+    @Parameter(names = "--datacenter", description = "YCQL datacenter, can be found in system.local table", arity = 1)
+    public String datacenter = "datacenter1";
+
+    @Parameter(names = "--oracle")
+    public List<YCQLOracleFactory> oracles = Arrays.asList(YCQLOracleFactory.FUZZER);
+
+    public enum YCQLOracleFactory implements OracleFactory<YCQLGlobalState> {
+        FUZZER {
+            @Override
+            public TestOracle create(YCQLGlobalState globalState) throws SQLException {
+                return new YCQLFuzzer(globalState);
+            }
+
+        }
+    }
+
+    @Override
+    public List<YCQLOracleFactory> getTestOracleFactory() {
+        return oracles;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/YCQLProvider.java
+++ b/src/sqlancer/yugabyte/ycql/YCQLProvider.java
@@ -1,0 +1,156 @@
+package sqlancer.yugabyte.ycql;
+
+import static sqlancer.yugabyte.ycql.YCQLSchema.getTableNames;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import com.google.auto.service.AutoService;
+
+import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.SQLGlobalState;
+import sqlancer.SQLProviderAdapter;
+import sqlancer.StatementExecutor;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLQueryProvider;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.gen.YCQLAlterTableGenerator;
+import sqlancer.yugabyte.ycql.gen.YCQLDeleteGenerator;
+import sqlancer.yugabyte.ycql.gen.YCQLIndexGenerator;
+import sqlancer.yugabyte.ycql.gen.YCQLInsertGenerator;
+import sqlancer.yugabyte.ycql.gen.YCQLRandomQuerySynthesizer;
+import sqlancer.yugabyte.ycql.gen.YCQLTableGenerator;
+import sqlancer.yugabyte.ycql.gen.YCQLUpdateGenerator;
+
+@AutoService(DatabaseProvider.class)
+public class YCQLProvider extends SQLProviderAdapter<YCQLGlobalState, YCQLOptions> {
+
+    public YCQLProvider() {
+        super(YCQLGlobalState.class, YCQLOptions.class);
+    }
+
+    public enum Action implements AbstractAction<YCQLGlobalState> {
+
+        ALTER(YCQLAlterTableGenerator::getQuery), //
+        INSERT(YCQLInsertGenerator::getQuery), //
+        CREATE_INDEX(YCQLIndexGenerator::getQuery), //
+        DELETE(YCQLDeleteGenerator::generate), //
+        UPDATE(YCQLUpdateGenerator::getQuery), //
+        EXPLAIN((g) -> {
+            ExpectedErrors errors = new ExpectedErrors();
+            YCQLErrors.addExpressionErrors(errors);
+            return new SQLQueryAdapter(
+                    "EXPLAIN " + YCQLToStringVisitor
+                            .asString(YCQLRandomQuerySynthesizer.generateSelect(g, Randomly.smallNumber() + 1)),
+                    errors);
+        });
+
+        private final SQLQueryProvider<YCQLGlobalState> sqlQueryProvider;
+
+        Action(SQLQueryProvider<YCQLGlobalState> sqlQueryProvider) {
+            this.sqlQueryProvider = sqlQueryProvider;
+        }
+
+        @Override
+        public SQLQueryAdapter getQuery(YCQLGlobalState state) throws Exception {
+            return sqlQueryProvider.getQuery(state);
+        }
+    }
+
+    private static int mapActions(YCQLGlobalState globalState, Action a) {
+        Randomly r = globalState.getRandomly();
+        switch (a) {
+        case ALTER:
+            return r.getInteger(0, 10);
+        case INSERT:
+            return r.getInteger(0, globalState.getOptions().getMaxNumberInserts());
+        case CREATE_INDEX:
+        case UPDATE:
+            return r.getInteger(0, globalState.getDbmsSpecificOptions().maxNumUpdates + 1);
+        case EXPLAIN:
+            return r.getInteger(0, 2);
+        case DELETE:
+            return r.getInteger(0, globalState.getDbmsSpecificOptions().maxNumDeletes + 1);
+        default:
+            throw new AssertionError(a);
+        }
+    }
+
+    public static class YCQLGlobalState extends SQLGlobalState<YCQLOptions, YCQLSchema> {
+
+        @Override
+        protected YCQLSchema readSchema() throws SQLException {
+            return YCQLSchema.fromConnection(getConnection(), getDatabaseName());
+        }
+
+    }
+
+    @Override
+    public void generateDatabase(YCQLGlobalState globalState) throws Exception {
+        for (int i = 0; i < Randomly.fromOptions(1, 2); i++) {
+            boolean success;
+            do {
+                SQLQueryAdapter qt = new YCQLTableGenerator().getQuery(globalState);
+                success = globalState.executeStatement(qt);
+            } while (!success);
+        }
+        if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+            throw new IgnoreMeException(); // TODO
+        }
+        StatementExecutor<YCQLGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
+                YCQLProvider::mapActions, (q) -> {
+                    if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+                        throw new IgnoreMeException();
+                    }
+                });
+        se.executeStatements();
+    }
+
+    @Override
+    public SQLConnection createDatabase(YCQLGlobalState globalState) throws SQLException {
+        try {
+            Class.forName("com.ing.data.cassandra.jdbc.CassandraDriver");
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        final String host = globalState.getOptions().getHost();
+        final String url = "jdbc:cassandra://%s:9042/%s?localdatacenter=%s";
+        final Connection connection = DriverManager.getConnection(
+                String.format(url, host, "system_schema", globalState.getDbmsSpecificOptions().datacenter));
+
+        try (Statement stmt = connection.createStatement()) {
+            try {
+                stmt.execute("DROP KEYSPACE IF EXISTS " + globalState.getDatabaseName());
+            } catch (Exception se) {
+                // try again
+                List<String> tableNames = getTableNames(
+                        new SQLConnection(DriverManager.getConnection(String.format(url, host,
+                                globalState.getDatabaseName(), globalState.getDbmsSpecificOptions().datacenter))),
+                        globalState.getDatabaseName());
+                for (String tableName : tableNames) {
+                    stmt.execute("DROP TABLE " + globalState.getDatabaseName() + "." + tableName);
+                }
+                stmt.execute("DROP KEYSPACE IF EXISTS " + globalState.getDatabaseName());
+            }
+
+            stmt.execute("CREATE KEYSPACE IF NOT EXISTS " + globalState.getDatabaseName());
+        }
+
+        return new SQLConnection(DriverManager.getConnection(String.format(url, host, globalState.getDatabaseName(),
+                globalState.getDbmsSpecificOptions().datacenter)));
+    }
+
+    @Override
+    public String getDBMSName() {
+        return "ycql";
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/YCQLSchema.java
+++ b/src/sqlancer/yugabyte/ycql/YCQLSchema.java
@@ -1,0 +1,267 @@
+package sqlancer.yugabyte.ycql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.schema.AbstractRelationalTable;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+import sqlancer.common.schema.TableIndex;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
+
+public class YCQLSchema extends AbstractSchema<YCQLGlobalState, YCQLTable> {
+
+    public enum YCQLDataType {
+
+        INT, VARCHAR, BOOLEAN, FLOAT, DATE, TIMESTAMP;
+
+        public static YCQLDataType getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+    }
+
+    public static class YCQLCompositeDataType {
+
+        private final YCQLDataType dataType;
+
+        private final int size;
+
+        public YCQLCompositeDataType(YCQLDataType dataType, int size) {
+            this.dataType = dataType;
+            this.size = size;
+        }
+
+        public YCQLDataType getPrimitiveDataType() {
+            return dataType;
+        }
+
+        public int getSize() {
+            if (size == -1) {
+                throw new AssertionError(this);
+            }
+            return size;
+        }
+
+        public static YCQLCompositeDataType getRandom() {
+            YCQLDataType type = YCQLDataType.getRandom();
+            int size = -1;
+            switch (type) {
+            case INT:
+                size = Randomly.fromOptions(1, 2, 4, 8);
+                break;
+            case FLOAT:
+                size = Randomly.fromOptions(4, 8);
+                break;
+            case BOOLEAN:
+            case VARCHAR:
+            case DATE:
+            case TIMESTAMP:
+                size = 0;
+                break;
+            default:
+                throw new AssertionError(type);
+            }
+
+            return new YCQLCompositeDataType(type, size);
+        }
+
+        @Override
+        public String toString() {
+            switch (getPrimitiveDataType()) {
+            case INT:
+                switch (size) {
+                case 8:
+                    return Randomly.fromOptions("BIGINT");
+                case 4:
+                    return Randomly.fromOptions("INTEGER", "INT");
+                case 2:
+                    return Randomly.fromOptions("SMALLINT");
+                case 1:
+                    return Randomly.fromOptions("TINYINT");
+                default:
+                    throw new AssertionError(size);
+                }
+            case VARCHAR:
+                return "VARCHAR";
+            case FLOAT:
+                switch (size) {
+                case 8:
+                    return Randomly.fromOptions("DOUBLE");
+                case 4:
+                    return Randomly.fromOptions("FLOAT");
+                default:
+                    throw new AssertionError(size);
+                }
+            case BOOLEAN:
+                return Randomly.fromOptions("BOOLEAN");
+            case TIMESTAMP:
+                return Randomly.fromOptions("TIMESTAMP");
+            case DATE:
+                return Randomly.fromOptions("DATE");
+            default:
+                throw new AssertionError(getPrimitiveDataType());
+            }
+        }
+
+    }
+
+    public static class YCQLColumn extends AbstractTableColumn<YCQLTable, YCQLCompositeDataType> {
+
+        private final boolean isPrimaryKey;
+        private final boolean isNullable;
+
+        public YCQLColumn(String name, YCQLCompositeDataType columnType, boolean isPrimaryKey, boolean isNullable) {
+            super(name, null, columnType);
+            this.isPrimaryKey = isPrimaryKey;
+            this.isNullable = isNullable;
+        }
+
+        public boolean isPrimaryKey() {
+            return isPrimaryKey;
+        }
+
+        public boolean isNullable() {
+            return isNullable;
+        }
+
+    }
+
+    public static class YCQLTables extends AbstractTables<YCQLTable, YCQLColumn> {
+
+        public YCQLTables(List<YCQLTable> tables) {
+            super(tables);
+        }
+
+    }
+
+    public YCQLSchema(List<YCQLTable> databaseTables) {
+        super(databaseTables);
+    }
+
+    public YCQLTables getRandomTableNonEmptyTables() {
+        return new YCQLTables(Randomly.nonEmptySubset(getDatabaseTables()));
+    }
+
+    private static YCQLCompositeDataType getColumnType(String typeString) {
+        YCQLDataType primitiveType;
+        int size = -1;
+        switch (typeString.toUpperCase()) {
+        case "INT":
+        case "INTEGER":
+            primitiveType = YCQLDataType.INT;
+            size = 4;
+            break;
+        case "SMALLINT":
+            primitiveType = YCQLDataType.INT;
+            size = 2;
+            break;
+        case "BIGINT":
+            primitiveType = YCQLDataType.INT;
+            size = 8;
+            break;
+        case "TINYINT":
+            primitiveType = YCQLDataType.INT;
+            size = 1;
+            break;
+        case "VARCHAR":
+        case "TEXT":
+            primitiveType = YCQLDataType.VARCHAR;
+            break;
+        case "FLOAT":
+            primitiveType = YCQLDataType.FLOAT;
+            size = 4;
+            break;
+        case "DOUBLE":
+            primitiveType = YCQLDataType.FLOAT;
+            size = 8;
+            break;
+        case "BOOLEAN":
+            primitiveType = YCQLDataType.BOOLEAN;
+            break;
+        case "DATE":
+            primitiveType = YCQLDataType.DATE;
+            break;
+        case "TIMESTAMP":
+            primitiveType = YCQLDataType.TIMESTAMP;
+            break;
+        case "INTERVAL":
+            throw new IgnoreMeException();
+        // TODO: caused when a view contains a computation like ((TIMESTAMP '1970-01-05 11:26:57')-(TIMESTAMP
+        // '1969-12-29 06:50:27'))
+        default:
+            throw new IgnoreMeException();
+        }
+        return new YCQLCompositeDataType(primitiveType, size);
+    }
+
+    public static class YCQLTable extends AbstractRelationalTable<YCQLColumn, TableIndex, YCQLGlobalState> {
+
+        public YCQLTable(String tableName, List<YCQLColumn> columns, boolean isView) {
+            super(tableName, columns, Collections.emptyList(), isView);
+        }
+
+    }
+
+    public static YCQLSchema fromConnection(SQLConnection con, String databaseName) throws SQLException {
+        List<YCQLTable> databaseTables = new ArrayList<>();
+        List<String> tableNames = getTableNames(con, databaseName);
+        for (String tableName : tableNames) {
+            if (DBMSCommon.matchesIndexName(tableName)) {
+                continue;
+            }
+            List<YCQLColumn> databaseColumns = getTableColumns(con, databaseName, tableName);
+            boolean isView = tableName.startsWith("v");
+            YCQLTable t = new YCQLTable(tableName, databaseColumns, isView);
+            for (YCQLColumn c : databaseColumns) {
+                c.setTable(t);
+            }
+            databaseTables.add(t);
+
+        }
+        return new YCQLSchema(databaseTables);
+    }
+
+    public static List<String> getTableNames(SQLConnection con, String databaseName) throws SQLException {
+        List<String> tableNames = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery(
+                    String.format("select * from system_schema.tables where keyspace_name = '%s'", databaseName))) {
+                while (rs.next()) {
+                    tableNames.add(rs.getString("table_name"));
+                }
+            }
+        }
+        return tableNames;
+    }
+
+    private static List<YCQLColumn> getTableColumns(SQLConnection con, String databaseName, String tableName)
+            throws SQLException {
+        List<YCQLColumn> columns = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery(String.format(
+                    "select * from system_schema.columns where keyspace_name = '%s' and table_name = '%s'",
+                    databaseName, tableName))) {
+                while (rs.next()) {
+                    String columnName = rs.getString("column_name");
+                    String dataType = rs.getString("type");
+                    boolean isPrimaryKey = rs.getString("kind").contentEquals("partition_key");
+                    YCQLColumn c = new YCQLColumn(columnName, getColumnType(dataType), isPrimaryKey, true);
+                    columns.add(c);
+                }
+            }
+        }
+        return columns;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/YCQLToStringVisitor.java
+++ b/src/sqlancer/yugabyte/ycql/YCQLToStringVisitor.java
@@ -1,0 +1,64 @@
+package sqlancer.yugabyte.ycql;
+
+import sqlancer.common.ast.newast.NewToStringVisitor;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.yugabyte.ycql.ast.YCQLConstant;
+import sqlancer.yugabyte.ycql.ast.YCQLExpression;
+import sqlancer.yugabyte.ycql.ast.YCQLSelect;
+
+public class YCQLToStringVisitor extends NewToStringVisitor<YCQLExpression> {
+
+    @Override
+    public void visitSpecific(Node<YCQLExpression> expr) {
+        if (expr instanceof YCQLConstant) {
+            visit((YCQLConstant) expr);
+        } else if (expr instanceof YCQLSelect) {
+            visit((YCQLSelect) expr);
+        } else {
+            throw new AssertionError(expr.getClass());
+        }
+    }
+
+    private void visit(YCQLConstant constant) {
+        sb.append(constant.toString());
+    }
+
+    private void visit(YCQLSelect select) {
+        sb.append("SELECT ");
+        if (select.isDistinct()) {
+            sb.append("DISTINCT ");
+        }
+        visit(select.getFetchColumns());
+        sb.append(" FROM ");
+        visit(select.getFromList());
+        if (!select.getFromList().isEmpty() && !select.getJoinList().isEmpty()) {
+            sb.append(", ");
+        }
+        if (!select.getJoinList().isEmpty()) {
+            visit(select.getJoinList());
+        }
+        if (select.getWhereClause() != null) {
+            sb.append(" WHERE ");
+            visit(select.getWhereClause());
+        }
+        if (!select.getOrderByExpressions().isEmpty()) {
+            sb.append(" ORDER BY ");
+            visit(select.getOrderByExpressions());
+        }
+        if (select.getLimitClause() != null) {
+            sb.append(" LIMIT ");
+            visit(select.getLimitClause());
+        }
+        if (select.getOffsetClause() != null) {
+            sb.append(" OFFSET ");
+            visit(select.getOffsetClause());
+        }
+    }
+
+    public static String asString(Node<YCQLExpression> expr) {
+        YCQLToStringVisitor visitor = new YCQLToStringVisitor();
+        visitor.visit(expr);
+        return visitor.get();
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/ast/YCQLConstant.java
+++ b/src/sqlancer/yugabyte/ycql/ast/YCQLConstant.java
@@ -1,0 +1,173 @@
+package sqlancer.yugabyte.ycql.ast;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+
+import sqlancer.common.ast.newast.Node;
+
+public class YCQLConstant implements Node<YCQLExpression> {
+
+    private YCQLConstant() {
+    }
+
+    public static class YCQLNullConstant extends YCQLConstant {
+
+        @Override
+        public String toString() {
+            return "NULL";
+        }
+
+    }
+
+    public static class YCQLIntConstant extends YCQLConstant {
+
+        private final long value;
+
+        public YCQLIntConstant(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public long getValue() {
+            return value;
+        }
+
+    }
+
+    public static class YCQLDoubleConstant extends YCQLConstant {
+
+        private final double value;
+
+        public YCQLDoubleConstant(double value) {
+            this.value = value;
+        }
+
+        public double getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            if (value == Double.POSITIVE_INFINITY) {
+                return "'+Inf'";
+            } else if (value == Double.NEGATIVE_INFINITY) {
+                return "'-Inf'";
+            }
+            return String.valueOf(value);
+        }
+
+    }
+
+    public static class YCQLTextConstant extends YCQLConstant {
+
+        private final String value;
+
+        public YCQLTextConstant(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return "'" + value.replace("'", "''") + "'";
+        }
+
+    }
+
+    public static class YCQLDateConstant extends YCQLConstant {
+
+        public String textRepr;
+
+        public YCQLDateConstant(long val) {
+            Timestamp timestamp = new Timestamp(val);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            textRepr = dateFormat.format(timestamp);
+        }
+
+        public String getValue() {
+            return textRepr;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("'%s'", textRepr);
+        }
+
+    }
+
+    public static class YCQLTimestampConstant extends YCQLConstant {
+
+        public String textRepr;
+
+        public YCQLTimestampConstant(long val) {
+            Timestamp timestamp = new Timestamp(val);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            textRepr = dateFormat.format(timestamp);
+        }
+
+        public String getValue() {
+            return textRepr;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("'%s'", textRepr);
+        }
+
+    }
+
+    public static class YCQLBooleanConstant extends YCQLConstant {
+
+        private final boolean value;
+
+        public YCQLBooleanConstant(boolean value) {
+            this.value = value;
+        }
+
+        public boolean getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+    }
+
+    public static Node<YCQLExpression> createStringConstant(String text) {
+        return new YCQLTextConstant(text);
+    }
+
+    public static Node<YCQLExpression> createFloatConstant(double val) {
+        return new YCQLDoubleConstant(val);
+    }
+
+    public static Node<YCQLExpression> createIntConstant(long val) {
+        return new YCQLIntConstant(val);
+    }
+
+    public static Node<YCQLExpression> createNullConstant() {
+        return new YCQLNullConstant();
+    }
+
+    public static Node<YCQLExpression> createBooleanConstant(boolean val) {
+        return new YCQLBooleanConstant(val);
+    }
+
+    public static Node<YCQLExpression> createDateConstant(long integer) {
+        return new YCQLDateConstant(integer);
+    }
+
+    public static Node<YCQLExpression> createTimestampConstant(long integer) {
+        return new YCQLTimestampConstant(integer);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/ast/YCQLExpression.java
+++ b/src/sqlancer/yugabyte/ycql/ast/YCQLExpression.java
@@ -1,0 +1,8 @@
+package sqlancer.yugabyte.ycql.ast;
+
+public interface YCQLExpression {
+
+    default YCQLConstant getExpectedValue() {
+        return null;
+    }
+}

--- a/src/sqlancer/yugabyte/ycql/ast/YCQLSelect.java
+++ b/src/sqlancer/yugabyte/ycql/ast/YCQLSelect.java
@@ -1,0 +1,18 @@
+package sqlancer.yugabyte.ycql.ast;
+
+import sqlancer.common.ast.SelectBase;
+import sqlancer.common.ast.newast.Node;
+
+public class YCQLSelect extends SelectBase<Node<YCQLExpression>> implements Node<YCQLExpression> {
+
+    private boolean isDistinct;
+
+    public void setDistinct(boolean isDistinct) {
+        this.isDistinct = isDistinct;
+    }
+
+    public boolean isDistinct() {
+        return isDistinct;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLAlterTableGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLAlterTableGenerator.java
@@ -1,0 +1,48 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLCompositeDataType;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
+
+public final class YCQLAlterTableGenerator {
+
+    private YCQLAlterTableGenerator() {
+    }
+
+    enum Action {
+        ADD_COLUMN, DROP_COLUMN
+    }
+
+    public static SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder("ALTER TABLE ");
+        YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        sb.append(table.getName());
+        sb.append(" ");
+        Action action = Randomly.fromOptions(Action.values());
+        switch (action) {
+        case ADD_COLUMN:
+            sb.append("ADD ");
+            String columnName = table.getFreeColumnName();
+            sb.append(columnName);
+            sb.append(" ");
+            sb.append(YCQLCompositeDataType.getRandom().toString());
+            break;
+        case DROP_COLUMN:
+            sb.append("DROP ");
+            sb.append(table.getRandomColumn().getName());
+            break;
+        default:
+            throw new AssertionError(action);
+        }
+
+        errors.add("Alter key column. Can't alter key column");
+        errors.add("cannot remove a key column");
+
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLDeleteGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLDeleteGenerator.java
@@ -1,0 +1,31 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ycql.YCQLErrors;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
+import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
+
+public final class YCQLDeleteGenerator {
+
+    private YCQLDeleteGenerator() {
+    }
+
+    public static SQLQueryAdapter generate(YCQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder("DELETE FROM ");
+        ExpectedErrors errors = new ExpectedErrors();
+        YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        sb.append(table.getName());
+        if (Randomly.getBoolean()) {
+            sb.append(" WHERE ");
+            sb.append(YCQLToStringVisitor.asString(
+                    new YCQLExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
+        }
+
+        YCQLErrors.addExpressionErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLExpressionGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLExpressionGenerator.java
@@ -1,0 +1,297 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.common.ast.newast.NewBetweenOperatorNode;
+import sqlancer.common.ast.newast.NewBinaryOperatorNode;
+import sqlancer.common.ast.newast.NewFunctionNode;
+import sqlancer.common.ast.newast.NewInOperatorNode;
+import sqlancer.common.ast.newast.NewOrderingTerm;
+import sqlancer.common.ast.newast.NewOrderingTerm.Ordering;
+import sqlancer.common.ast.newast.NewUnaryPostfixOperatorNode;
+import sqlancer.common.ast.newast.NewUnaryPrefixOperatorNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.gen.UntypedExpressionGenerator;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLDataType;
+import sqlancer.yugabyte.ycql.ast.YCQLConstant;
+import sqlancer.yugabyte.ycql.ast.YCQLExpression;
+
+public final class YCQLExpressionGenerator extends UntypedExpressionGenerator<Node<YCQLExpression>, YCQLColumn> {
+
+    private final YCQLGlobalState globalState;
+
+    public YCQLExpressionGenerator(YCQLGlobalState globalState) {
+        this.globalState = globalState;
+    }
+
+    private enum Expression {
+        BINARY_COMPARISON, BINARY_LOGICAL, BINARY_ARITHMETIC, FUNC, BETWEEN, IN
+    }
+
+    @Override
+    protected Node<YCQLExpression> generateExpression(int depth) {
+        if (depth >= globalState.getOptions().getMaxExpressionDepth() || Randomly.getBoolean()) {
+            return generateLeafNode();
+        }
+        if (allowAggregates && Randomly.getBoolean()) {
+            YCQLAggregateFunction aggregate = YCQLAggregateFunction.getRandom();
+            allowAggregates = false;
+            return new NewFunctionNode<>(generateExpressions(depth + 1, aggregate.getNrArgs()), aggregate);
+        }
+        List<Expression> possibleOptions = new ArrayList<>(Arrays.asList(Expression.values()));
+        Expression expr = Randomly.fromList(possibleOptions);
+        switch (expr) {
+        case BINARY_COMPARISON:
+            Operator op = YCQLBinaryComparisonOperator.getRandom();
+            return new NewBinaryOperatorNode<YCQLExpression>(generateExpression(depth + 1),
+                    generateExpression(depth + 1), op);
+        case BINARY_LOGICAL:
+            op = YCQLBinaryLogicalOperator.getRandom();
+            return new NewBinaryOperatorNode<YCQLExpression>(generateExpression(depth + 1),
+                    generateExpression(depth + 1), op);
+        case BINARY_ARITHMETIC:
+            return new NewBinaryOperatorNode<YCQLExpression>(generateExpression(depth + 1),
+                    generateExpression(depth + 1), YCQLBinaryArithmeticOperator.getRandom());
+        case FUNC:
+            DBFunction func = DBFunction.getRandom();
+            return new NewFunctionNode<YCQLExpression, DBFunction>(generateExpressions(func.getNrArgs()), func);
+        case BETWEEN:
+            return new NewBetweenOperatorNode<YCQLExpression>(generateExpression(depth + 1),
+                    generateExpression(depth + 1), generateExpression(depth + 1), Randomly.getBoolean());
+        case IN:
+            return new NewInOperatorNode<YCQLExpression>(generateExpression(depth + 1),
+                    generateExpressions(depth + 1, Randomly.smallNumber() + 1), Randomly.getBoolean());
+        default:
+            throw new AssertionError(expr);
+        }
+    }
+
+    @Override
+    protected Node<YCQLExpression> generateColumn() {
+        YCQLColumn column = Randomly.fromList(columns);
+        return new ColumnReferenceNode<YCQLExpression, YCQLColumn>(column);
+    }
+
+    @Override
+    public Node<YCQLExpression> generateConstant() {
+        if (Randomly.getBooleanWithSmallProbability()) {
+            return YCQLConstant.createNullConstant();
+        }
+        YCQLDataType type = YCQLDataType.getRandom();
+        switch (type) {
+        case INT:
+            return YCQLConstant.createIntConstant(globalState.getRandomly().getInteger());
+        case DATE:
+            return YCQLConstant.createDateConstant(globalState.getRandomly().getInteger());
+        case TIMESTAMP:
+            return YCQLConstant.createTimestampConstant(globalState.getRandomly().getInteger());
+        case VARCHAR:
+            return YCQLConstant.createStringConstant(globalState.getRandomly().getString());
+        case BOOLEAN:
+            return YCQLConstant.createBooleanConstant(Randomly.getBoolean());
+        case FLOAT:
+            return YCQLConstant.createFloatConstant(globalState.getRandomly().getDouble());
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    @Override
+    public List<Node<YCQLExpression>> generateOrderBys() {
+        List<Node<YCQLExpression>> expr = super.generateOrderBys();
+        List<Node<YCQLExpression>> newExpr = new ArrayList<>(expr.size());
+        for (Node<YCQLExpression> curExpr : expr) {
+            if (Randomly.getBoolean()) {
+                curExpr = new NewOrderingTerm<>(curExpr, Ordering.getRandom());
+            }
+            newExpr.add(curExpr);
+        }
+        return newExpr;
+    };
+
+    public enum YCQLAggregateFunction {
+        MAX(1), MIN(1), AVG(1), COUNT(1), SUM(1);
+
+        private final int nrArgs;
+
+        YCQLAggregateFunction(int nrArgs) {
+            this.nrArgs = nrArgs;
+        }
+
+        public static YCQLAggregateFunction getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public int getNrArgs() {
+            return nrArgs;
+        }
+
+    }
+
+    public enum DBFunction {
+        // YCQL functions
+        BLOB(1), //
+        TIMEUUID(1), //
+        DATE(0), //
+        TIME(0), //
+        TIMESTAMP(0), //
+        BIGINT(1), //
+        UUID(0); //
+        // // extras
+        // PARTITION_HASH(2), //
+        // WRITETIME(1), //
+        // TTL(1); //
+
+        private final int nrArgs;
+        private final boolean isVariadic;
+
+        DBFunction(int nrArgs) {
+            this(nrArgs, false);
+        }
+
+        DBFunction(int nrArgs, boolean isVariadic) {
+            this.nrArgs = nrArgs;
+            this.isVariadic = isVariadic;
+        }
+
+        public static DBFunction getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public int getNrArgs() {
+            if (isVariadic) {
+                return Randomly.smallNumber() + nrArgs;
+            } else {
+                return nrArgs;
+            }
+        }
+
+    }
+
+    public enum YCQLUnaryPostfixOperator implements Operator {
+
+        IS_NULL("IS NULL"), IS_NOT_NULL("IS NOT NULL");
+
+        private final String textRepr;
+
+        YCQLUnaryPostfixOperator(String textRepr) {
+            this.textRepr = textRepr;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepr;
+        }
+
+        public static YCQLUnaryPostfixOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+    }
+
+    public enum YCQLUnaryPrefixOperator implements Operator {
+
+        NOT("NOT"), PLUS("+"), MINUS("-");
+
+        private final String textRepr;
+
+        YCQLUnaryPrefixOperator(String textRepr) {
+            this.textRepr = textRepr;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepr;
+        }
+
+        public static YCQLUnaryPrefixOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+    }
+
+    public enum YCQLBinaryLogicalOperator implements Operator {
+
+        AND, OR;
+
+        @Override
+        public String getTextRepresentation() {
+            return toString();
+        }
+
+        public static Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+    }
+
+    public enum YCQLBinaryArithmeticOperator implements Operator {
+        ADD("+"), SUB("-"), MULT("*"), DIV("/");
+
+        private String textRepr;
+
+        YCQLBinaryArithmeticOperator(String textRepr) {
+            this.textRepr = textRepr;
+        }
+
+        public static Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepr;
+        }
+
+    }
+
+    public enum YCQLBinaryComparisonOperator implements Operator {
+
+        EQUALS("="), GREATER(">"), GREATER_EQUALS(">="), SMALLER("<"), SMALLER_EQUALS("<="), NOT_EQUALS("!=");
+
+        private final String textRepr;
+
+        YCQLBinaryComparisonOperator(String textRepr) {
+            this.textRepr = textRepr;
+        }
+
+        public static Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepr;
+        }
+
+    }
+
+    public NewFunctionNode<YCQLExpression, YCQLAggregateFunction> generateArgsForAggregate(
+            YCQLAggregateFunction aggregateFunction) {
+        return new NewFunctionNode<YCQLExpression, YCQLAggregateFunction>(
+                generateExpressions(aggregateFunction.getNrArgs()), aggregateFunction);
+    }
+
+    public Node<YCQLExpression> generateAggregate() {
+        YCQLAggregateFunction aggrFunc = YCQLAggregateFunction.getRandom();
+        return generateArgsForAggregate(aggrFunc);
+    }
+
+    @Override
+    public Node<YCQLExpression> negatePredicate(Node<YCQLExpression> predicate) {
+        return new NewUnaryPrefixOperatorNode<>(predicate, YCQLUnaryPrefixOperator.NOT);
+    }
+
+    @Override
+    public Node<YCQLExpression> isNull(Node<YCQLExpression> expr) {
+        return new NewUnaryPostfixOperatorNode<>(expr, YCQLUnaryPostfixOperator.IS_NULL);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLIndexGenerator.java
@@ -1,0 +1,56 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
+import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
+import sqlancer.yugabyte.ycql.ast.YCQLExpression;
+
+public final class YCQLIndexGenerator {
+
+    private YCQLIndexGenerator() {
+    }
+
+    public static SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE ");
+        if (Randomly.getBoolean()) {
+            errors.add("Cant create unique index, table contains duplicate data on indexed column(s)");
+            sb.append("UNIQUE ");
+        }
+        sb.append("INDEX ");
+        sb.append(Randomly.fromOptions("i0", "i1", "i2", "i3", "i4"));
+        sb.append(" ON ");
+        YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        sb.append(table.getName());
+        sb.append("(");
+        List<YCQLColumn> columns = table.getRandomNonEmptyColumnSubset();
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(columns.get(i).getName());
+        }
+        sb.append(")");
+        if (Randomly.getBoolean()) {
+            sb.append(" WHERE ");
+            Node<YCQLExpression> expr = new YCQLExpressionGenerator(globalState).setColumns(table.getColumns())
+                    .generateExpression();
+            sb.append(YCQLToStringVisitor.asString(expr));
+        }
+        errors.add("Query timed out after PT2S");
+        errors.add("Invalid SQL Statement");
+        errors.add("Invalid CQL Statement");
+        errors.add(
+                "Invalid Table Definition. Transactions cannot be enabled in an index of a table without transactions enabled.");
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLInsertGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLInsertGenerator.java
@@ -1,0 +1,65 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.common.gen.AbstractInsertGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.yugabyte.ycql.YCQLErrors;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
+import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
+
+public class YCQLInsertGenerator extends AbstractInsertGenerator<YCQLColumn> {
+
+    private final YCQLGlobalState globalState;
+    private final ExpectedErrors errors = new ExpectedErrors();
+
+    public YCQLInsertGenerator(YCQLGlobalState globalState) {
+        this.globalState = globalState;
+    }
+
+    public static SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
+        return new YCQLInsertGenerator(globalState).generate();
+    }
+
+    private SQLQueryAdapter generate() {
+        sb.append("INSERT INTO ");
+        YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        List<YCQLColumn> columns = table.getColumns();
+        sb.append(globalState.getDatabaseName()).append(".").append(table.getName());
+        sb.append("(");
+        sb.append(columns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
+        sb.append(")");
+        sb.append(" VALUES ");
+        insertColumns(columns);
+
+        errors.add("Invalid Arguments");
+        errors.add("Null Argument for Primary Key");
+
+        YCQLErrors.addExpressionErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+    @Override
+    protected void insertColumns(List<YCQLColumn> columns) {
+        sb.append("(");
+        for (int nrColumn = 0; nrColumn < columns.size(); nrColumn++) {
+            if (nrColumn != 0) {
+                sb.append(", ");
+            }
+            insertValue(columns.get(nrColumn));
+        }
+        sb.append(")");
+    }
+
+    @Override
+    protected void insertValue(YCQLColumn tiDBColumn) {
+        // TODO: select a more meaningful value
+        sb.append(YCQLToStringVisitor.asString(new YCQLExpressionGenerator(globalState).generateConstant()));
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLRandomQuerySynthesizer.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLRandomQuerySynthesizer.java
@@ -1,0 +1,55 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTables;
+import sqlancer.yugabyte.ycql.ast.YCQLConstant;
+import sqlancer.yugabyte.ycql.ast.YCQLExpression;
+import sqlancer.yugabyte.ycql.ast.YCQLSelect;
+
+public final class YCQLRandomQuerySynthesizer {
+
+    private YCQLRandomQuerySynthesizer() {
+    }
+
+    public static YCQLSelect generateSelect(YCQLGlobalState globalState, int nrColumns) {
+        YCQLTables targetTables = globalState.getSchema().getRandomTableNonEmptyTables();
+        YCQLExpressionGenerator gen = new YCQLExpressionGenerator(globalState).setColumns(targetTables.getColumns());
+        YCQLSelect select = new YCQLSelect();
+        List<Node<YCQLExpression>> columns = new ArrayList<>();
+        for (int i = 0; i < nrColumns; i++) {
+            Node<YCQLExpression> expression = gen.generateExpression();
+            columns.add(expression);
+        }
+        select.setFetchColumns(columns);
+        List<YCQLTable> tables = targetTables.getTables();
+        Optional<TableReferenceNode<YCQLExpression, YCQLTable>> table = tables.stream()
+                .map(t -> new TableReferenceNode<YCQLExpression, YCQLTable>(t)).findFirst();
+        select.setFromList(table.stream().collect(Collectors.toList()));
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression());
+        }
+        if (Randomly.getBoolean()) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+        if (Randomly.getBoolean()) {
+            select.setGroupByExpressions(Randomly.nonEmptySubset(select.getFetchColumns()));
+        }
+        if (Randomly.getBoolean()) {
+            select.setLimitClause(YCQLConstant.createIntConstant(Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)));
+        }
+        if (Randomly.getBoolean()) {
+            select.setOffsetClause(YCQLConstant.createIntConstant(Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)));
+        }
+        return select;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLTableGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLTableGenerator.java
@@ -1,0 +1,57 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLCompositeDataType;
+
+public class YCQLTableGenerator {
+
+    public SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder();
+        String tableName = globalState.getSchema().getFreeTableName();
+        sb.append("CREATE TABLE ");
+        if (Randomly.getBoolean()) {
+            sb.append("IF NOT EXISTS ");
+        }
+        sb.append(tableName);
+        sb.append("(");
+        List<YCQLColumn> columns = getNewColumns();
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(columns.get(i).getName());
+            sb.append(" ");
+            sb.append(columns.get(i).getType());
+            // todo PK, STATIC
+        }
+        errors.add("Query timed out after PT2S");
+        errors.add("Invalid type for index");
+        List<YCQLColumn> primaryKeyColumns = Randomly.nonEmptySubset(columns);
+        sb.append(", PRIMARY KEY(");
+        sb.append(primaryKeyColumns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
+        sb.append(")");
+        sb.append(")");
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+    private static List<YCQLColumn> getNewColumns() {
+        List<YCQLColumn> columns = new ArrayList<>();
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            String columnName = String.format("c%d", i);
+            YCQLCompositeDataType columnType = YCQLCompositeDataType.getRandom();
+            columns.add(new YCQLColumn(columnName, columnType, false, false));
+        }
+        return columns;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLUpdateGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLUpdateGenerator.java
@@ -1,0 +1,56 @@
+package sqlancer.yugabyte.ycql.gen;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ycql.YCQLErrors;
+import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
+import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
+import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
+import sqlancer.yugabyte.ycql.ast.YCQLExpression;
+
+public final class YCQLUpdateGenerator {
+
+    private YCQLUpdateGenerator() {
+    }
+
+    public static SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder("UPDATE ");
+        ExpectedErrors errors = new ExpectedErrors();
+        YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        sb.append(table.getName());
+        YCQLExpressionGenerator gen = new YCQLExpressionGenerator(globalState).setColumns(table.getColumns());
+        sb.append(" SET ");
+        List<YCQLColumn> columns = table.getRandomNonEmptyColumnSubset();
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(columns.get(i).getName());
+            sb.append("=");
+            Node<YCQLExpression> expr;
+            if (Randomly.getBooleanWithSmallProbability()) {
+                expr = gen.generateExpression();
+                YCQLErrors.addExpressionErrors(errors);
+            } else {
+                expr = gen.generateConstant();
+            }
+            sb.append(YCQLToStringVisitor.asString(expr));
+        }
+
+        errors.add("Invalid Arguments");
+        errors.add("Invalid CQL Statement");
+        errors.add("Invalid SQL Statement");
+        errors.add("Datatype Mismatch");
+        errors.add("Null Argument for Primary Key");
+        errors.add("Missing Argument for Primary Key");
+
+        YCQLErrors.addExpressionErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ycql/test/YCQLFuzzer.java
+++ b/src/sqlancer/yugabyte/ycql/test/YCQLFuzzer.java
@@ -1,0 +1,73 @@
+package sqlancer.yugabyte.ycql.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ycql.YCQLProvider;
+import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
+import sqlancer.yugabyte.ycql.gen.YCQLRandomQuerySynthesizer;
+
+public class YCQLFuzzer implements TestOracle {
+    private final YCQLProvider.YCQLGlobalState globalState;
+    private final List<Query> testQueries;
+    private final ExpectedErrors errors = new ExpectedErrors();
+
+    public YCQLFuzzer(YCQLProvider.YCQLGlobalState globalState) {
+        this.globalState = globalState;
+
+        errors.add("Query timed out after PT2S");
+        errors.add("Datatype Mismatch");
+        errors.add("Invalid CQL Statement");
+        errors.add("Invalid SQL Statement");
+        errors.add("Invalid Arguments");
+        errors.add("Invalid Function Call");
+
+        testQueries = new ArrayList<>();
+
+        testQueries.add(new SelectQuery());
+        testQueries.add(new ActionQuery(YCQLProvider.Action.UPDATE));
+        testQueries.add(new ActionQuery(YCQLProvider.Action.DELETE));
+        testQueries.add(new ActionQuery(YCQLProvider.Action.INSERT));
+    }
+
+    @Override
+    public void check() throws Exception {
+        Query s = testQueries.get(globalState.getRandomly().getInteger(0, testQueries.size()));
+        globalState.executeStatement(s.getQuery(globalState, errors));
+        globalState.getManager().incrementSelectQueryCount();
+    }
+
+    private static class Query {
+        public SQLQueryAdapter getQuery(YCQLProvider.YCQLGlobalState state, ExpectedErrors errors) throws Exception {
+            throw new IllegalAccessException("Should be implemented");
+        };
+    }
+
+    private static class ActionQuery extends Query {
+        private final YCQLProvider.Action action;
+
+        ActionQuery(YCQLProvider.Action action) {
+            this.action = action;
+        }
+
+        @Override
+        public SQLQueryAdapter getQuery(YCQLProvider.YCQLGlobalState state, ExpectedErrors errors) throws Exception {
+            return action.getQuery(state);
+        }
+    }
+
+    private static class SelectQuery extends Query {
+
+        @Override
+        public SQLQueryAdapter getQuery(YCQLProvider.YCQLGlobalState state, ExpectedErrors errors) throws Exception {
+            return new SQLQueryAdapter(
+                    YCQLToStringVisitor.asString(
+                            YCQLRandomQuerySynthesizer.generateSelect(state, Randomly.smallNumber() + 1)) + ";",
+                    errors);
+        }
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLCompoundDataType.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLCompoundDataType.java
@@ -1,0 +1,45 @@
+package sqlancer.yugabyte.ysql;
+
+import java.util.Optional;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public final class YSQLCompoundDataType {
+
+    private final YSQLDataType dataType;
+    private final YSQLCompoundDataType elemType;
+    private final Integer size;
+
+    private YSQLCompoundDataType(YSQLDataType dataType, YSQLCompoundDataType elemType, Integer size) {
+        this.dataType = dataType;
+        this.elemType = elemType;
+        this.size = size;
+    }
+
+    public static YSQLCompoundDataType create(YSQLDataType type, int size) {
+        return new YSQLCompoundDataType(type, null, size);
+    }
+
+    public static YSQLCompoundDataType create(YSQLDataType type) {
+        return new YSQLCompoundDataType(type, null, null);
+    }
+
+    public YSQLDataType getDataType() {
+        return dataType;
+    }
+
+    public YSQLCompoundDataType getElemType() {
+        if (elemType == null) {
+            throw new AssertionError();
+        }
+        return elemType;
+    }
+
+    public Optional<Integer> getSize() {
+        if (size == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(size);
+        }
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLExpectedValueVisitor.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLExpectedValueVisitor.java
@@ -1,0 +1,152 @@
+package sqlancer.yugabyte.ysql;
+
+import sqlancer.yugabyte.ysql.ast.YSQLAggregate;
+import sqlancer.yugabyte.ysql.ast.YSQLBetweenOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryLogicalOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLCastOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLColumnValue;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLFunction;
+import sqlancer.yugabyte.ysql.ast.YSQLInOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLOrderByTerm;
+import sqlancer.yugabyte.ysql.ast.YSQLPOSIXRegularExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixText;
+import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.YSQLFromTable;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.YSQLSubquery;
+import sqlancer.yugabyte.ysql.ast.YSQLSimilarTo;
+
+public final class YSQLExpectedValueVisitor implements YSQLVisitor {
+
+    private static final int NR_TABS = 0;
+    private final StringBuilder sb = new StringBuilder();
+
+    private void print(YSQLExpression expr) {
+        YSQLToStringVisitor v = new YSQLToStringVisitor();
+        v.visit(expr);
+        sb.append("\t".repeat(NR_TABS));
+        sb.append(v.get());
+        sb.append(" -- ");
+        sb.append(expr.getExpectedValue());
+        sb.append("\n");
+    }
+
+    @Override
+    public void visit(YSQLConstant constant) {
+        print(constant);
+    }
+
+    @Override
+    public void visit(YSQLPostfixOperation op) {
+        print(op);
+        visit(op.getExpression());
+    }
+
+    @Override
+    public void visit(YSQLColumnValue c) {
+        print(c);
+    }
+
+    @Override
+    public void visit(YSQLPrefixOperation op) {
+        print(op);
+        visit(op.getExpression());
+    }
+
+    @Override
+    public void visit(YSQLSelect op) {
+        visit(op.getWhereClause());
+    }
+
+    @Override
+    public void visit(YSQLOrderByTerm op) {
+
+    }
+
+    @Override
+    public void visit(YSQLFunction f) {
+        print(f);
+        for (int i = 0; i < f.getArguments().length; i++) {
+            visit(f.getArguments()[i]);
+        }
+    }
+
+    @Override
+    public void visit(YSQLCastOperation cast) {
+        print(cast);
+        visit(cast.getExpression());
+    }
+
+    @Override
+    public void visit(YSQLBetweenOperation op) {
+        print(op);
+        visit(op.getExpr());
+        visit(op.getLeft());
+        visit(op.getRight());
+    }
+
+    @Override
+    public void visit(YSQLInOperation op) {
+        print(op);
+        visit(op.getExpr());
+        for (YSQLExpression right : op.getListElements()) {
+            visit(right);
+        }
+    }
+
+    @Override
+    public void visit(YSQLPostfixText op) {
+        print(op);
+        visit(op.getExpr());
+    }
+
+    @Override
+    public void visit(YSQLAggregate op) {
+        print(op);
+        for (YSQLExpression expr : op.getArgs()) {
+            visit(expr);
+        }
+    }
+
+    @Override
+    public void visit(YSQLSimilarTo op) {
+        print(op);
+        visit(op.getString());
+        visit(op.getSimilarTo());
+        if (op.getEscapeCharacter() != null) {
+            visit(op.getEscapeCharacter());
+        }
+    }
+
+    @Override
+    public void visit(YSQLPOSIXRegularExpression op) {
+        print(op);
+        visit(op.getString());
+        visit(op.getRegex());
+    }
+
+    @Override
+    public void visit(YSQLFromTable from) {
+        print(from);
+    }
+
+    @Override
+    public void visit(YSQLSubquery subquery) {
+        print(subquery);
+    }
+
+    @Override
+    public void visit(YSQLBinaryLogicalOperation op) {
+        print(op);
+        visit(op.getLeft());
+        visit(op.getRight());
+    }
+
+    public String get() {
+        return sb.toString();
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLGlobalState.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLGlobalState.java
@@ -1,0 +1,127 @@
+package sqlancer.yugabyte.ysql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.SQLGlobalState;
+
+public class YSQLGlobalState extends SQLGlobalState<YSQLOptions, YSQLSchema> {
+
+    public static final char IMMUTABLE = 'i';
+    public static final char STABLE = 's';
+    public static final char VOLATILE = 'v';
+    // store and allow filtering by function volatility classifications
+    private final Map<String, Character> functionsAndTypes = new HashMap<>();
+    private List<String> operators = Collections.emptyList();
+    private List<String> collates = Collections.emptyList();
+    private List<String> opClasses = Collections.emptyList();
+    private List<Character> allowedFunctionTypes = Arrays.asList(IMMUTABLE, STABLE, VOLATILE);
+
+    @Override
+    public void setConnection(SQLConnection con) {
+        super.setConnection(con);
+        try {
+            this.opClasses = getOpclasses(getConnection());
+            this.operators = getOperators(getConnection());
+            this.collates = getCollnames(getConnection());
+        } catch (SQLException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Override
+    public YSQLSchema readSchema() throws SQLException {
+        return YSQLSchema.fromConnection(getConnection(), getDatabaseName());
+    }
+
+    private List<String> getCollnames(SQLConnection con) throws SQLException {
+        List<String> opClasses = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s
+                    .executeQuery("SELECT collname FROM pg_collation WHERE collname LIKE '%utf8' or collname = 'C';")) {
+                while (rs.next()) {
+                    opClasses.add(rs.getString(1));
+                }
+            }
+        }
+        return opClasses;
+    }
+
+    private List<String> getOpclasses(SQLConnection con) throws SQLException {
+        List<String> opClasses = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery("select opcname FROM pg_opclass;")) {
+                while (rs.next()) {
+                    opClasses.add(rs.getString(1));
+                }
+            }
+        }
+        return opClasses;
+    }
+
+    private List<String> getOperators(SQLConnection con) throws SQLException {
+        List<String> opClasses = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery("SELECT oprname FROM pg_operator;")) {
+                while (rs.next()) {
+                    opClasses.add(rs.getString(1));
+                }
+            }
+        }
+        return opClasses;
+    }
+
+    public List<String> getOperators() {
+        return operators;
+    }
+
+    public String getRandomOperator() {
+        return Randomly.fromList(operators);
+    }
+
+    public List<String> getCollates() {
+        return collates;
+    }
+
+    public String getRandomCollate() {
+        return Randomly.fromList(collates);
+    }
+
+    public List<String> getOpClasses() {
+        return opClasses;
+    }
+
+    public String getRandomOpclass() {
+        return Randomly.fromList(opClasses);
+    }
+
+    public void addFunctionAndType(String functionName, Character functionType) {
+        this.functionsAndTypes.put(functionName, functionType);
+    }
+
+    public Map<String, Character> getFunctionsAndTypes() {
+        return this.functionsAndTypes;
+    }
+
+    public void setDefaultAllowedFunctionTypes() {
+        this.allowedFunctionTypes = Arrays.asList(IMMUTABLE, STABLE, VOLATILE);
+    }
+
+    public List<Character> getAllowedFunctionTypes() {
+        return this.allowedFunctionTypes;
+    }
+
+    public void setAllowedFunctionTypes(List<Character> types) {
+        this.allowedFunctionTypes = types;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLOptions.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLOptions.java
@@ -1,0 +1,98 @@
+package sqlancer.yugabyte.ysql;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import sqlancer.DBMSSpecificOptions;
+import sqlancer.OracleFactory;
+import sqlancer.common.oracle.CompositeTestOracle;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.yugabyte.ysql.YSQLOptions.YSQLOracleFactory;
+import sqlancer.yugabyte.ysql.oracle.YSQLCatalog;
+import sqlancer.yugabyte.ysql.oracle.YSQLFuzzer;
+import sqlancer.yugabyte.ysql.oracle.YSQLNoRECOracle;
+import sqlancer.yugabyte.ysql.oracle.YSQLPivotedQuerySynthesisOracle;
+import sqlancer.yugabyte.ysql.oracle.tlp.YSQLTLPAggregateOracle;
+import sqlancer.yugabyte.ysql.oracle.tlp.YSQLTLPHavingOracle;
+import sqlancer.yugabyte.ysql.oracle.tlp.YSQLTLPWhereOracle;
+
+@Parameters(separators = "=", commandDescription = "YSQL (default port: " + YSQLOptions.DEFAULT_PORT
+        + ", default host: " + YSQLOptions.DEFAULT_HOST)
+public class YSQLOptions implements DBMSSpecificOptions<YSQLOracleFactory> {
+    public static final String DEFAULT_HOST = "localhost";
+    public static final int DEFAULT_PORT = 5433;
+
+    @Parameter(names = "--bulk-insert", description = "Specifies whether INSERT statements should be issued in bulk", arity = 1)
+    public boolean allowBulkInsert;
+
+    @Parameter(names = "--oracle", description = "Specifies which test oracle should be used for YSQL")
+    public List<YSQLOracleFactory> oracle = Arrays.asList(YSQLOracleFactory.QUERY_PARTITIONING);
+
+    @Parameter(names = "--test-collations", description = "Specifies whether to test different collations", arity = 1)
+    public boolean testCollations = true;
+
+    @Parameter(names = "--connection-url", description = "Specifies the URL for connecting to the YSQL server", arity = 1)
+    public String connectionURL = String.format("jdbc:yugabytedb://%s:%d/yugabyte", YSQLOptions.DEFAULT_HOST,
+            YSQLOptions.DEFAULT_PORT);
+
+    @Override
+    public List<YSQLOracleFactory> getTestOracleFactory() {
+        return oracle;
+    }
+
+    public enum YSQLOracleFactory implements OracleFactory<YSQLGlobalState> {
+        FUZZER {
+            @Override
+            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+                return new YSQLFuzzer(globalState);
+            }
+        },
+        CATALOG {
+            @Override
+            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+                return new YSQLCatalog(globalState);
+            }
+        },
+        NOREC {
+            @Override
+            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+                return new YSQLNoRECOracle(globalState);
+            }
+        },
+        PQS {
+            @Override
+            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+                return new YSQLPivotedQuerySynthesisOracle(globalState);
+            }
+
+            @Override
+            public boolean requiresAllTablesToContainRows() {
+                return true;
+            }
+        },
+        HAVING {
+            @Override
+            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+                return new YSQLTLPHavingOracle(globalState);
+            }
+
+        },
+        QUERY_PARTITIONING {
+            @Override
+            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+                List<TestOracle> oracles = new ArrayList<>();
+                oracles.add(new YSQLTLPWhereOracle(globalState));
+                oracles.add(new YSQLTLPHavingOracle(globalState));
+                oracles.add(new YSQLTLPAggregateOracle(globalState));
+                return new CompositeTestOracle(oracles, globalState);
+            }
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLProvider.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLProvider.java
@@ -1,0 +1,366 @@
+package sqlancer.yugabyte.ysql;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+
+import com.google.auto.service.AutoService;
+
+import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
+import sqlancer.IgnoreMeException;
+import sqlancer.MainOptions;
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.SQLProviderAdapter;
+import sqlancer.StatementExecutor;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLQueryProvider;
+import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.yugabyte.ysql.YSQLOptions.YSQLOracleFactory;
+import sqlancer.yugabyte.ysql.gen.YSQLAlterTableGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLAnalyzeGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLCommentGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLDeleteGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLDiscardGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLDropIndexGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLIndexGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLInsertGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLNotifyGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLSequenceGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLSetGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLTableGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLTableGroupGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLTransactionGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLTruncateGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLUpdateGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLVacuumGenerator;
+import sqlancer.yugabyte.ysql.gen.YSQLViewGenerator;
+
+@AutoService(DatabaseProvider.class)
+public class YSQLProvider extends SQLProviderAdapter<YSQLGlobalState, YSQLOptions> {
+
+    public static final Object CREATION_LOCK = new Object();
+    /**
+     * Generate only data types and expressions that are understood by PQS.
+     */
+    public static boolean generateOnlyKnown;
+    protected String entryURL;
+    protected String username;
+    protected String password;
+    protected String entryPath;
+    protected String host;
+    protected int port;
+    protected String testURL;
+    protected String databaseName;
+    protected String createDatabaseCommand;
+
+    public YSQLProvider() {
+        super(YSQLGlobalState.class, YSQLOptions.class);
+    }
+
+    protected YSQLProvider(Class<YSQLGlobalState> globalClass, Class<YSQLOptions> optionClass) {
+        super(globalClass, optionClass);
+    }
+
+    public static int mapActions(YSQLGlobalState globalState, Action a) {
+        Randomly r = globalState.getRandomly();
+        int nrPerformed;
+        switch (a) {
+        case CREATE_INDEX:
+            nrPerformed = r.getInteger(0, 3);
+            break;
+        case DISCARD:
+        case DROP_INDEX:
+            nrPerformed = r.getInteger(0, 5);
+            break;
+        case COMMIT:
+            nrPerformed = r.getInteger(0, 0);
+            break;
+        case ALTER_TABLE:
+            nrPerformed = r.getInteger(0, 5);
+            break;
+        case RESET:
+            nrPerformed = r.getInteger(0, 3);
+            break;
+        case ANALYZE:
+            nrPerformed = r.getInteger(0, 3);
+            break;
+        case TABLEGROUP:
+            nrPerformed = r.getInteger(0, 3);
+            break;
+        case DELETE:
+        case RESET_ROLE:
+        case VACUUM:
+        case SET_CONSTRAINTS:
+        case SET:
+        case COMMENT_ON:
+        case NOTIFY:
+        case LISTEN:
+        case UNLISTEN:
+        case CREATE_SEQUENCE:
+        case TRUNCATE:
+            nrPerformed = r.getInteger(0, 2);
+            break;
+        case CREATE_VIEW:
+            nrPerformed = r.getInteger(0, 2);
+            break;
+        case UPDATE:
+            nrPerformed = r.getInteger(0, 10);
+            break;
+        case INSERT:
+            nrPerformed = r.getInteger(0, globalState.getOptions().getMaxNumberInserts());
+            break;
+        default:
+            throw new AssertionError(a);
+        }
+        return nrPerformed;
+
+    }
+
+    @Override
+    public void generateDatabase(YSQLGlobalState globalState) throws Exception {
+        readFunctions(globalState);
+        createTables(globalState, Randomly.fromOptions(4, 5, 6));
+        prepareTables(globalState);
+    }
+
+    @Override
+    public SQLConnection createDatabase(YSQLGlobalState globalState) throws SQLException {
+        if (globalState.getDbmsSpecificOptions().getTestOracleFactory().stream()
+                .anyMatch((o) -> o == YSQLOracleFactory.PQS)) {
+            generateOnlyKnown = true;
+        }
+
+        username = globalState.getOptions().getUserName();
+        password = globalState.getOptions().getPassword();
+        host = globalState.getOptions().getHost();
+        port = globalState.getOptions().getPort();
+        entryPath = "/yugabyte";
+        entryURL = globalState.getDbmsSpecificOptions().connectionURL;
+        String entryDatabaseName = entryPath.substring(1);
+        databaseName = globalState.getDatabaseName();
+
+        try {
+            URI uri = new URI(entryURL);
+            String userInfoURI = uri.getUserInfo();
+            String pathURI = uri.getPath();
+            if (userInfoURI != null) {
+                // username and password specified in URL take precedence
+                if (userInfoURI.contains(":")) {
+                    String[] userInfo = userInfoURI.split(":", 2);
+                    username = userInfo[0];
+                    password = userInfo[1];
+                } else {
+                    username = userInfoURI;
+                    password = null;
+                }
+                int userInfoIndex = entryURL.indexOf(userInfoURI);
+                String preUserInfo = entryURL.substring(0, userInfoIndex);
+                String postUserInfo = entryURL.substring(userInfoIndex + userInfoURI.length() + 1);
+                entryURL = preUserInfo + postUserInfo;
+            }
+            if (pathURI != null) {
+                entryPath = pathURI;
+            }
+            if (host == null) {
+                host = uri.getHost();
+            }
+            if (port == MainOptions.NO_SET_PORT) {
+                port = uri.getPort();
+            }
+            entryURL = String.format("jdbc:yugabytedb://%s:%d/%s", host, port, entryDatabaseName);
+        } catch (URISyntaxException e) {
+            throw new AssertionError(e);
+        }
+
+        createDatabaseSync(globalState, entryDatabaseName);
+
+        int databaseIndex = entryURL.indexOf("/" + entryDatabaseName) + 1;
+        String preDatabaseName = entryURL.substring(0, databaseIndex);
+        String postDatabaseName = entryURL.substring(databaseIndex + entryDatabaseName.length());
+        testURL = preDatabaseName + databaseName + postDatabaseName;
+        globalState.getState().logStatement(String.format("\\c %s;", databaseName));
+
+        return new SQLConnection(createConnectionSafely(testURL, username, password));
+    }
+
+    @Override
+    public String getDBMSName() {
+        return "ysql";
+    }
+
+    // for some reason yugabyte unable to create few databases simultaneously
+    private void createDatabaseSync(YSQLGlobalState globalState, String entryDatabaseName) throws SQLException {
+        synchronized (CREATION_LOCK) {
+            exceptionLessSleep(5000);
+
+            Connection con = createConnectionSafely(entryURL, username, password);
+            globalState.getState().logStatement(String.format("\\c %s;", entryDatabaseName));
+            globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
+            createDatabaseCommand = getCreateDatabaseCommand(globalState);
+            globalState.getState().logStatement(createDatabaseCommand);
+            try (Statement s = con.createStatement()) {
+                s.execute("DROP DATABASE IF EXISTS " + databaseName);
+            }
+            try (Statement s = con.createStatement()) {
+                s.execute(createDatabaseCommand);
+            }
+            con.close();
+        }
+    }
+
+    private Connection createConnectionSafely(String entryURL, String user, String password) {
+        Connection con = null;
+        IllegalStateException lastException = new IllegalStateException("Empty exception");
+        long endTime = System.currentTimeMillis() + 30000;
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                con = DriverManager.getConnection(entryURL, user, password);
+                break;
+            } catch (SQLException throwables) {
+                lastException = new IllegalStateException(throwables);
+            }
+        }
+
+        if (con == null) {
+            throw lastException;
+        }
+
+        return con;
+    }
+
+    protected void readFunctions(YSQLGlobalState globalState) throws SQLException {
+        SQLQueryAdapter query = new SQLQueryAdapter("SELECT proname, provolatile FROM pg_proc;");
+        SQLancerResultSet rs = query.executeAndGet(globalState);
+        while (rs.next()) {
+            String functionName = rs.getString(1);
+            Character functionType = rs.getString(2).charAt(0);
+            globalState.addFunctionAndType(functionName, functionType);
+        }
+    }
+
+    protected void createTables(YSQLGlobalState globalState, int numTables) throws Exception {
+        synchronized (CREATION_LOCK) {
+            boolean prevCreationFailed = false; // small optimization - wait only after failed requests
+            while (globalState.getSchema().getDatabaseTables().size() < numTables) {
+                if (!prevCreationFailed) {
+                    exceptionLessSleep(5000);
+                }
+
+                try {
+                    String tableName = DBMSCommon.createTableName(globalState.getSchema().getDatabaseTables().size());
+                    SQLQueryAdapter createTable = YSQLTableGenerator.generate(tableName, generateOnlyKnown,
+                            globalState);
+                    globalState.executeStatement(createTable);
+                    prevCreationFailed = false;
+                } catch (IgnoreMeException e) {
+                    prevCreationFailed = true;
+                }
+            }
+        }
+    }
+
+    private void exceptionLessSleep(long timeout) {
+        try {
+            Thread.sleep(timeout);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected void prepareTables(YSQLGlobalState globalState) throws Exception {
+        StatementExecutor<YSQLGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
+                YSQLProvider::mapActions, (q) -> {
+                    if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+                        throw new IgnoreMeException();
+                    }
+                });
+        se.executeStatements();
+        globalState.executeStatement(new SQLQueryAdapter("COMMIT", true));
+        globalState.executeStatement(new SQLQueryAdapter("SET SESSION statement_timeout = 15000;\n"));
+    }
+
+    private String getCreateDatabaseCommand(YSQLGlobalState state) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE DATABASE ").append(databaseName).append(" ");
+        if (Randomly.getBoolean() && state.getDbmsSpecificOptions().testCollations) {
+            sb.append("WITH ");
+            if (Randomly.getBoolean()) {
+                sb.append("ENCODING '");
+                sb.append(Randomly.fromOptions("utf8"));
+                sb.append("' ");
+            }
+            // disabled due to https://github.com/yugabyte/yugabyte-db/issues/11357
+            // if (Randomly.getBoolean()) {
+            // sb.append("COLOCATED = true ");
+            // }
+            for (String lc : Arrays.asList("LC_COLLATE", "LC_CTYPE")) {
+                if (!state.getCollates().isEmpty() && Randomly.getBoolean()) {
+                    sb.append(String.format(" %s = '%s'", lc, Randomly.fromList(state.getCollates())));
+                }
+            }
+            sb.append(" TEMPLATE template0");
+
+        }
+        return sb.toString();
+    }
+
+    public enum Action implements AbstractAction<YSQLGlobalState> {
+        ANALYZE(YSQLAnalyzeGenerator::create), //
+        ALTER_TABLE(g -> YSQLAlterTableGenerator.create(g.getSchema().getRandomTable(t -> !t.isView()), g)), //
+        COMMIT(g -> {
+            SQLQueryAdapter query;
+            if (Randomly.getBoolean()) {
+                query = new SQLQueryAdapter("COMMIT", true);
+            } else if (Randomly.getBoolean()) {
+                query = YSQLTransactionGenerator.executeBegin();
+            } else {
+                query = new SQLQueryAdapter("ROLLBACK", true);
+            }
+            return query;
+        }), //
+        DELETE(YSQLDeleteGenerator::create), //
+        DISCARD(YSQLDiscardGenerator::create), //
+        DROP_INDEX(YSQLDropIndexGenerator::create), //
+        CREATE_INDEX(YSQLIndexGenerator::generate), //
+        INSERT(YSQLInsertGenerator::insert), //
+        UPDATE(YSQLUpdateGenerator::create), //
+        TRUNCATE(YSQLTruncateGenerator::create), //
+        TABLEGROUP(YSQLTableGroupGenerator::create), //
+        VACUUM(YSQLVacuumGenerator::create), //
+        SET(YSQLSetGenerator::create), // TODO insert yugabyte sets
+        SET_CONSTRAINTS((g) -> {
+            String sb = "SET CONSTRAINTS ALL " + Randomly.fromOptions("DEFERRED", "IMMEDIATE");
+            return new SQLQueryAdapter(sb);
+        }), //
+        RESET_ROLE((g) -> new SQLQueryAdapter("RESET ROLE")), //
+        COMMENT_ON(YSQLCommentGenerator::generate), //
+        RESET((g) -> new SQLQueryAdapter("RESET ALL") /*
+                                                       * https://www.postgres.org/docs/devel/sql-reset.html TODO: also
+                                                       * configuration parameter
+                                                       */), //
+        NOTIFY(YSQLNotifyGenerator::createNotify), //
+        LISTEN((g) -> YSQLNotifyGenerator.createListen()), //
+        UNLISTEN((g) -> YSQLNotifyGenerator.createUnlisten()), //
+        CREATE_SEQUENCE(YSQLSequenceGenerator::createSequence), //
+        CREATE_VIEW(YSQLViewGenerator::create);
+
+        private final SQLQueryProvider<YSQLGlobalState> sqlQueryProvider;
+
+        Action(SQLQueryProvider<YSQLGlobalState> sqlQueryProvider) {
+            this.sqlQueryProvider = sqlQueryProvider;
+        }
+
+        @Override
+        public SQLQueryAdapter getQuery(YSQLGlobalState state) throws Exception {
+            return sqlQueryProvider.getQuery(state);
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLSchema.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLSchema.java
@@ -1,0 +1,329 @@
+package sqlancer.yugabyte.ysql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.postgresql.util.PSQLException;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.schema.AbstractRelationalTable;
+import sqlancer.common.schema.AbstractRowValue;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+import sqlancer.common.schema.TableIndex;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+
+public class YSQLSchema extends AbstractSchema<YSQLGlobalState, YSQLTable> {
+
+    private final String databaseName;
+
+    public YSQLSchema(List<YSQLTable> databaseTables, String databaseName) {
+        super(databaseTables);
+        this.databaseName = databaseName;
+    }
+
+    public static YSQLDataType getColumnType(String typeString) {
+        switch (typeString) {
+        case "smallint":
+        case "integer":
+        case "bigint":
+            return YSQLDataType.INT;
+        case "boolean":
+            return YSQLDataType.BOOLEAN;
+        case "text":
+        case "character":
+        case "character varying":
+        case "name":
+            return YSQLDataType.TEXT;
+        case "numeric":
+            return YSQLDataType.DECIMAL;
+        case "double precision":
+            return YSQLDataType.FLOAT;
+        case "real":
+            return YSQLDataType.REAL;
+        case "int4range":
+            return YSQLDataType.RANGE;
+        case "money":
+            return YSQLDataType.MONEY;
+        case "bytea":
+            return YSQLDataType.BYTEA;
+        case "bit":
+        case "bit varying":
+            return YSQLDataType.BIT;
+        case "inet":
+            return YSQLDataType.INET;
+        default:
+            throw new AssertionError(typeString);
+        }
+    }
+
+    public static YSQLSchema fromConnection(SQLConnection con, String databaseName) throws SQLException {
+        try {
+            List<YSQLTable> databaseTables = new ArrayList<>();
+            try (Statement s = con.createStatement()) {
+                try (ResultSet rs = s.executeQuery(
+                        "SELECT table_name, table_schema, table_type, is_insertable_into FROM information_schema.tables WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%' ORDER BY table_name;")) {
+                    while (rs.next()) {
+                        String tableName = rs.getString("table_name");
+                        String tableTypeSchema = rs.getString("table_schema");
+                        boolean isInsertable = rs.getBoolean("is_insertable_into");
+                        // TODO: also check insertable
+                        // TODO: insert into view?
+                        boolean isView = tableName.startsWith("v"); // tableTypeStr.contains("VIEW") ||
+                        // tableTypeStr.contains("LOCAL TEMPORARY") &&
+                        // !isInsertable;
+                        YSQLTable.TableType tableType = getTableType(tableTypeSchema);
+                        List<YSQLColumn> databaseColumns = getTableColumns(con, tableName);
+                        List<YSQLIndex> indexes = getIndexes(con, tableName);
+                        List<YSQLStatisticsObject> statistics = getStatistics(con);
+                        YSQLTable t = new YSQLTable(tableName, databaseColumns, indexes, tableType, statistics, isView,
+                                isInsertable);
+                        for (YSQLColumn c : databaseColumns) {
+                            c.setTable(t);
+                        }
+                        databaseTables.add(t);
+                    }
+                }
+            }
+            return new YSQLSchema(databaseTables, databaseName);
+        } catch (SQLIntegrityConstraintViolationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    protected static List<YSQLStatisticsObject> getStatistics(SQLConnection con) throws SQLException {
+        List<YSQLStatisticsObject> statistics = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery("SELECT stxname FROM pg_statistic_ext ORDER BY stxname;")) {
+                while (rs.next()) {
+                    statistics.add(new YSQLStatisticsObject(rs.getString("stxname")));
+                }
+            }
+        }
+        return statistics;
+    }
+
+    protected static YSQLTable.TableType getTableType(String tableTypeStr) throws AssertionError {
+        YSQLTable.TableType tableType;
+        if (tableTypeStr.contentEquals("public")) {
+            tableType = YSQLTable.TableType.STANDARD;
+        } else if (tableTypeStr.startsWith("pg_temp")) {
+            tableType = YSQLTable.TableType.TEMPORARY;
+        } else {
+            throw new AssertionError(tableTypeStr);
+        }
+        return tableType;
+    }
+
+    protected static List<YSQLIndex> getIndexes(SQLConnection con, String tableName) throws SQLException {
+        List<YSQLIndex> indexes = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery(String
+                    .format("SELECT indexname FROM pg_indexes WHERE tablename='%s' ORDER BY indexname;", tableName))) {
+                while (rs.next()) {
+                    String indexName = rs.getString("indexname");
+                    if (DBMSCommon.matchesIndexName(indexName)) {
+                        indexes.add(YSQLIndex.create(indexName));
+                    }
+                }
+            }
+        }
+        return indexes;
+    }
+
+    protected static List<YSQLColumn> getTableColumns(SQLConnection con, String tableName) throws SQLException {
+        List<YSQLColumn> columns = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s
+                    .executeQuery("select column_name, data_type from INFORMATION_SCHEMA.COLUMNS where table_name = '"
+                            + tableName + "' ORDER BY column_name")) {
+                while (rs.next()) {
+                    String columnName = rs.getString("column_name");
+                    String dataType = rs.getString("data_type");
+                    YSQLColumn c = new YSQLColumn(columnName, getColumnType(dataType));
+                    columns.add(c);
+                }
+            }
+        }
+        return columns;
+    }
+
+    public YSQLTables getRandomTableNonEmptyTables() {
+        return new YSQLTables(Randomly.nonEmptySubset(getDatabaseTables()));
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public enum YSQLDataType {
+        // TODO: 23.02.2022 Planned types
+        // SMALLINT, INT, BIGINT, NUMERIC, DECIMAL, REAL, DOUBLE_PRECISION, VARCHAR, CHAR, TEXT, DATE, TIME,
+        // TIMESTAMP, TIMESTAMPZ, INTERVAL, INTEGER_ARR
+        INT, BOOLEAN, BYTEA, TEXT, DECIMAL, FLOAT, REAL, RANGE, MONEY, BIT, INET;
+
+        public static YSQLDataType getRandomType() {
+            List<YSQLDataType> dataTypes = new ArrayList<>(Arrays.asList(values()));
+            if (YSQLProvider.generateOnlyKnown) {
+                dataTypes.remove(YSQLDataType.DECIMAL);
+                dataTypes.remove(YSQLDataType.FLOAT);
+                dataTypes.remove(YSQLDataType.REAL);
+                dataTypes.remove(YSQLDataType.INET);
+                dataTypes.remove(YSQLDataType.RANGE);
+                dataTypes.remove(YSQLDataType.MONEY);
+                dataTypes.remove(YSQLDataType.BIT);
+            }
+            return Randomly.fromList(dataTypes);
+        }
+    }
+
+    public static class YSQLColumn extends AbstractTableColumn<YSQLTable, YSQLDataType> {
+
+        public YSQLColumn(String name, YSQLDataType columnType) {
+            super(name, null, columnType);
+        }
+
+        public static YSQLColumn createDummy(String name) {
+            return new YSQLColumn(name, YSQLDataType.INT);
+        }
+
+    }
+
+    public static class YSQLTables extends AbstractTables<YSQLTable, YSQLColumn> {
+
+        public YSQLTables(List<YSQLTable> tables) {
+            super(tables);
+        }
+
+        public YSQLRowValue getRandomRowValue(SQLConnection con) throws SQLException {
+            String randomRow = String.format("SELECT %s FROM %s ORDER BY RANDOM() LIMIT 1", columnNamesAsString(
+                    c -> c.getTable().getName() + "." + c.getName() + " AS " + c.getTable().getName() + c.getName()),
+                    // columnNamesAsString(c -> "typeof(" + c.getTable().getName() + "." +
+                    // c.getName() + ")")
+                    tableNamesAsString());
+            Map<YSQLColumn, YSQLConstant> values = new HashMap<>();
+            try (Statement s = con.createStatement()) {
+                ResultSet randomRowValues = s.executeQuery(randomRow);
+                if (!randomRowValues.next()) {
+                    throw new AssertionError("could not find random row! " + randomRow + "\n");
+                }
+                for (int i = 0; i < getColumns().size(); i++) {
+                    YSQLColumn column = getColumns().get(i);
+                    int columnIndex = randomRowValues.findColumn(column.getTable().getName() + column.getName());
+                    assert columnIndex == i + 1;
+                    YSQLConstant constant;
+                    if (randomRowValues.getString(columnIndex) == null) {
+                        constant = YSQLConstant.createNullConstant();
+                    } else {
+                        switch (column.getType()) {
+                        case INT:
+                            constant = YSQLConstant.createIntConstant(randomRowValues.getLong(columnIndex));
+                            break;
+                        case BOOLEAN:
+                            constant = YSQLConstant.createBooleanConstant(randomRowValues.getBoolean(columnIndex));
+                            break;
+                        case TEXT:
+                            constant = YSQLConstant.createTextConstant(randomRowValues.getString(columnIndex));
+                            break;
+                        default:
+                            throw new IgnoreMeException();
+                        }
+                    }
+                    values.put(column, constant);
+                }
+                assert !randomRowValues.next();
+                return new YSQLRowValue(this, values);
+            } catch (PSQLException e) {
+                throw new IgnoreMeException();
+            }
+
+        }
+
+    }
+
+    public static class YSQLRowValue extends AbstractRowValue<YSQLTables, YSQLColumn, YSQLConstant> {
+
+        protected YSQLRowValue(YSQLTables tables, Map<YSQLColumn, YSQLConstant> values) {
+            super(tables, values);
+        }
+
+    }
+
+    public static class YSQLTable extends AbstractRelationalTable<YSQLColumn, YSQLIndex, YSQLGlobalState> {
+
+        private final TableType tableType;
+        private final List<YSQLStatisticsObject> statistics;
+        private final boolean isInsertable;
+
+        public YSQLTable(String tableName, List<YSQLColumn> columns, List<YSQLIndex> indexes, TableType tableType,
+                List<YSQLStatisticsObject> statistics, boolean isView, boolean isInsertable) {
+            super(tableName, columns, indexes, isView);
+            this.statistics = statistics;
+            this.isInsertable = isInsertable;
+            this.tableType = tableType;
+        }
+
+        public List<YSQLStatisticsObject> getStatistics() {
+            return statistics;
+        }
+
+        public TableType getTableType() {
+            return tableType;
+        }
+
+        public boolean isInsertable() {
+            return isInsertable;
+        }
+
+        public enum TableType {
+            STANDARD, TEMPORARY
+        }
+
+    }
+
+    public static final class YSQLStatisticsObject {
+        private final String name;
+
+        public YSQLStatisticsObject(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static final class YSQLIndex extends TableIndex {
+
+        private YSQLIndex(String indexName) {
+            super(indexName);
+        }
+
+        public static YSQLIndex create(String indexName) {
+            return new YSQLIndex(indexName);
+        }
+
+        @Override
+        public String getIndexName() {
+            if (super.getIndexName().contentEquals("PRIMARY")) {
+                return "`PRIMARY`";
+            } else {
+                return super.getIndexName();
+            }
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLToStringVisitor.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLToStringVisitor.java
@@ -1,0 +1,329 @@
+package sqlancer.yugabyte.ysql;
+
+import java.util.Optional;
+
+import sqlancer.Randomly;
+import sqlancer.common.visitor.BinaryOperation;
+import sqlancer.common.visitor.ToStringVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLAggregate;
+import sqlancer.yugabyte.ysql.ast.YSQLBetweenOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryLogicalOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLCastOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLColumnValue;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLFunction;
+import sqlancer.yugabyte.ysql.ast.YSQLInOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLJoin;
+import sqlancer.yugabyte.ysql.ast.YSQLJoin.YSQLJoinType;
+import sqlancer.yugabyte.ysql.ast.YSQLOrderByTerm;
+import sqlancer.yugabyte.ysql.ast.YSQLPOSIXRegularExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixText;
+import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.YSQLFromTable;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.YSQLSubquery;
+import sqlancer.yugabyte.ysql.ast.YSQLSimilarTo;
+
+public final class YSQLToStringVisitor extends ToStringVisitor<YSQLExpression> implements YSQLVisitor {
+
+    @Override
+    public void visitSpecific(YSQLExpression expr) {
+        YSQLVisitor.super.visit(expr);
+    }
+
+    @Override
+    public String get() {
+        return sb.toString();
+    }
+
+    @Override
+    public void visit(YSQLConstant constant) {
+        sb.append(constant.getTextRepresentation());
+    }
+
+    @Override
+    public void visit(YSQLPostfixOperation op) {
+        sb.append("(");
+        visit(op.getExpression());
+        sb.append(")");
+        sb.append(" ");
+        sb.append(op.getOperatorTextRepresentation());
+    }
+
+    @Override
+    public void visit(YSQLColumnValue c) {
+        sb.append(c.getColumn().getFullQualifiedName());
+    }
+
+    @Override
+    public void visit(YSQLPrefixOperation op) {
+        sb.append(op.getTextRepresentation());
+        sb.append(" (");
+        visit(op.getExpression());
+        sb.append(")");
+    }
+
+    @Override
+    public void visit(YSQLSelect s) {
+        sb.append("SELECT ");
+        switch (s.getSelectOption()) {
+        case DISTINCT:
+            sb.append("DISTINCT ");
+            if (s.getDistinctOnClause() != null) {
+                sb.append("ON (");
+                visit(s.getDistinctOnClause());
+                sb.append(") ");
+            }
+            break;
+        case ALL:
+            sb.append(Randomly.fromOptions("ALL ", ""));
+            break;
+        default:
+            throw new AssertionError();
+        }
+        if (s.getFetchColumns() == null) {
+            sb.append("*");
+        } else {
+            visit(s.getFetchColumns());
+        }
+        sb.append(" FROM ");
+        visit(s.getFromList());
+
+        for (YSQLJoin j : s.getJoinClauses()) {
+            sb.append(" ");
+            switch (j.getType()) {
+            case INNER:
+                if (Randomly.getBoolean()) {
+                    sb.append("INNER ");
+                }
+                sb.append("JOIN");
+                break;
+            case LEFT:
+                sb.append("LEFT OUTER JOIN");
+                break;
+            case RIGHT:
+                sb.append("RIGHT OUTER JOIN");
+                break;
+            case FULL:
+                sb.append("FULL OUTER JOIN");
+                break;
+            case CROSS:
+                sb.append("CROSS JOIN");
+                break;
+            default:
+                throw new AssertionError(j.getType());
+            }
+            sb.append(" ");
+            visit(j.getTableReference());
+            if (j.getType() != YSQLJoinType.CROSS) {
+                sb.append(" ON ");
+                visit(j.getOnClause());
+            }
+        }
+
+        if (s.getWhereClause() != null) {
+            sb.append(" WHERE ");
+            visit(s.getWhereClause());
+        }
+        if (s.getGroupByExpressions().size() > 0) {
+            sb.append(" GROUP BY ");
+            visit(s.getGroupByExpressions());
+        }
+        if (s.getHavingClause() != null) {
+            sb.append(" HAVING ");
+            visit(s.getHavingClause());
+
+        }
+        if (!s.getOrderByExpressions().isEmpty()) {
+            sb.append(" ORDER BY ");
+            visit(s.getOrderByExpressions());
+        }
+        if (s.getLimitClause() != null) {
+            sb.append(" LIMIT ");
+            visit(s.getLimitClause());
+        }
+
+        if (s.getOffsetClause() != null) {
+            sb.append(" OFFSET ");
+            visit(s.getOffsetClause());
+        }
+    }
+
+    @Override
+    public void visit(YSQLOrderByTerm op) {
+        visit(op.getExpr());
+        sb.append(" ");
+        sb.append(op.getOrder());
+    }
+
+    @Override
+    public void visit(YSQLFunction f) {
+        sb.append(f.getFunctionName());
+        sb.append("(");
+        int i = 0;
+        for (YSQLExpression arg : f.getArguments()) {
+            if (i++ != 0) {
+                sb.append(", ");
+            }
+            visit(arg);
+        }
+        sb.append(")");
+    }
+
+    @Override
+    public void visit(YSQLCastOperation cast) {
+        if (Randomly.getBoolean()) {
+            sb.append("CAST(");
+            visit(cast.getExpression());
+            sb.append(" AS ");
+            appendType(cast);
+            sb.append(")");
+        } else {
+            sb.append("(");
+            visit(cast.getExpression());
+            sb.append(")::");
+            appendType(cast);
+        }
+    }
+
+    @Override
+    public void visit(YSQLBetweenOperation op) {
+        sb.append("(");
+        visit(op.getExpr());
+        sb.append(") BETWEEN ");
+        if (op.isSymmetric()) {
+            sb.append("SYMMETRIC ");
+        }
+        sb.append("(");
+        visit(op.getLeft());
+        sb.append(") AND (");
+        visit(op.getRight());
+        sb.append(")");
+    }
+
+    @Override
+    public void visit(YSQLInOperation op) {
+        sb.append("(");
+        visit(op.getExpr());
+        sb.append(")");
+        if (!op.isTrue()) {
+            sb.append(" NOT");
+        }
+        sb.append(" IN (");
+        visit(op.getListElements());
+        sb.append(")");
+    }
+
+    @Override
+    public void visit(YSQLPostfixText op) {
+        visit(op.getExpr());
+        sb.append(op.getText());
+    }
+
+    @Override
+    public void visit(YSQLAggregate op) {
+        sb.append(op.getFunction());
+        sb.append("(");
+        visit(op.getArgs());
+        sb.append(")");
+    }
+
+    @Override
+    public void visit(YSQLSimilarTo op) {
+        sb.append("(");
+        visit(op.getString());
+        sb.append(" SIMILAR TO ");
+        visit(op.getSimilarTo());
+        if (op.getEscapeCharacter() != null) {
+            visit(op.getEscapeCharacter());
+        }
+        sb.append(")");
+    }
+
+    @Override
+    public void visit(YSQLPOSIXRegularExpression op) {
+        visit(op.getString());
+        sb.append(op.getOp().getStringRepresentation());
+        visit(op.getRegex());
+    }
+
+    @Override
+    public void visit(YSQLFromTable from) {
+        if (from.isOnly()) {
+            sb.append("ONLY ");
+        }
+        sb.append(from.getTable().getName());
+        if (!from.isOnly() && Randomly.getBoolean()) {
+            sb.append("*");
+        }
+    }
+
+    @Override
+    public void visit(YSQLSubquery subquery) {
+        sb.append("(");
+        visit(subquery.getSelect());
+        sb.append(") AS ");
+        sb.append(subquery.getName());
+    }
+
+    @Override
+    public void visit(YSQLBinaryLogicalOperation op) {
+        super.visit((BinaryOperation<YSQLExpression>) op);
+    }
+
+    private void appendType(YSQLCastOperation cast) {
+        YSQLCompoundDataType compoundType = cast.getCompoundType();
+        switch (compoundType.getDataType()) {
+        case BOOLEAN:
+            sb.append("BOOLEAN");
+            break;
+        case INT: // TODO support also other int types
+            sb.append("INT");
+            break;
+        case TEXT:
+            // TODO: append TEXT, CHAR
+            sb.append(Randomly.fromOptions("VARCHAR"));
+            break;
+        case REAL:
+            sb.append("REAL");
+            break;
+        case DECIMAL:
+            sb.append("DECIMAL");
+            break;
+        case FLOAT:
+            sb.append("FLOAT");
+            break;
+        case RANGE:
+            sb.append("int4range");
+            break;
+        case MONEY:
+            sb.append("MONEY");
+            break;
+        case INET:
+            sb.append("INET");
+            break;
+        case BIT:
+            sb.append("BIT");
+            break;
+        case BYTEA:
+            sb.append("BYTEA");
+            break;
+        // if (Randomly.getBoolean()) {
+        // sb.append("(");
+        // sb.append(Randomly.getNotCachedInteger(1, 100));
+        // sb.append(")");
+        // }
+        default:
+            throw new AssertionError(cast.getType());
+        }
+        Optional<Integer> size = compoundType.getSize();
+        if (size.isPresent()) {
+            sb.append("(");
+            sb.append(size.get());
+            sb.append(")");
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/YSQLVisitor.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLVisitor.java
@@ -1,0 +1,120 @@
+package sqlancer.yugabyte.ysql;
+
+import java.util.List;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.ast.YSQLAggregate;
+import sqlancer.yugabyte.ysql.ast.YSQLBetweenOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryLogicalOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLCastOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLColumnValue;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLFunction;
+import sqlancer.yugabyte.ysql.ast.YSQLInOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLOrderByTerm;
+import sqlancer.yugabyte.ysql.ast.YSQLPOSIXRegularExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixText;
+import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.YSQLFromTable;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.YSQLSubquery;
+import sqlancer.yugabyte.ysql.ast.YSQLSimilarTo;
+import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
+
+public interface YSQLVisitor {
+
+    static String asString(YSQLExpression expr) {
+        YSQLToStringVisitor visitor = new YSQLToStringVisitor();
+        visitor.visit(expr);
+        return visitor.get();
+    }
+
+    static String asExpectedValues(YSQLExpression expr) {
+        YSQLExpectedValueVisitor v = new YSQLExpectedValueVisitor();
+        v.visit(expr);
+        return v.get();
+    }
+
+    static String getExpressionAsString(YSQLGlobalState globalState, YSQLDataType type, List<YSQLColumn> columns) {
+        YSQLExpression expression = YSQLExpressionGenerator.generateExpression(globalState, columns, type);
+        YSQLToStringVisitor visitor = new YSQLToStringVisitor();
+        visitor.visit(expression);
+        return visitor.get();
+    }
+
+    void visit(YSQLConstant constant);
+
+    void visit(YSQLPostfixOperation op);
+
+    void visit(YSQLColumnValue c);
+
+    void visit(YSQLPrefixOperation op);
+
+    void visit(YSQLSelect op);
+
+    void visit(YSQLOrderByTerm op);
+
+    void visit(YSQLFunction f);
+
+    void visit(YSQLCastOperation cast);
+
+    void visit(YSQLBetweenOperation op);
+
+    void visit(YSQLInOperation op);
+
+    void visit(YSQLPostfixText op);
+
+    void visit(YSQLAggregate op);
+
+    void visit(YSQLSimilarTo op);
+
+    void visit(YSQLPOSIXRegularExpression op);
+
+    void visit(YSQLFromTable from);
+
+    void visit(YSQLSubquery subquery);
+
+    void visit(YSQLBinaryLogicalOperation op);
+
+    default void visit(YSQLExpression expression) {
+        if (expression instanceof YSQLConstant) {
+            visit((YSQLConstant) expression);
+        } else if (expression instanceof YSQLPostfixOperation) {
+            visit((YSQLPostfixOperation) expression);
+        } else if (expression instanceof YSQLColumnValue) {
+            visit((YSQLColumnValue) expression);
+        } else if (expression instanceof YSQLPrefixOperation) {
+            visit((YSQLPrefixOperation) expression);
+        } else if (expression instanceof YSQLSelect) {
+            visit((YSQLSelect) expression);
+        } else if (expression instanceof YSQLOrderByTerm) {
+            visit((YSQLOrderByTerm) expression);
+        } else if (expression instanceof YSQLFunction) {
+            visit((YSQLFunction) expression);
+        } else if (expression instanceof YSQLCastOperation) {
+            visit((YSQLCastOperation) expression);
+        } else if (expression instanceof YSQLBetweenOperation) {
+            visit((YSQLBetweenOperation) expression);
+        } else if (expression instanceof YSQLInOperation) {
+            visit((YSQLInOperation) expression);
+        } else if (expression instanceof YSQLAggregate) {
+            visit((YSQLAggregate) expression);
+        } else if (expression instanceof YSQLPostfixText) {
+            visit((YSQLPostfixText) expression);
+        } else if (expression instanceof YSQLSimilarTo) {
+            visit((YSQLSimilarTo) expression);
+        } else if (expression instanceof YSQLPOSIXRegularExpression) {
+            visit((YSQLPOSIXRegularExpression) expression);
+        } else if (expression instanceof YSQLFromTable) {
+            visit((YSQLFromTable) expression);
+        } else if (expression instanceof YSQLSubquery) {
+            visit((YSQLSubquery) expression);
+        } else {
+            throw new AssertionError(expression);
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLAggregate.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLAggregate.java
@@ -1,0 +1,58 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.FunctionNode;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.ast.YSQLAggregate.YSQLAggregateFunction;
+
+/**
+ * @see <a href="https://www.sqlite.org/lang_aggfunc.html">Built-in Aggregate Functions</a>
+ */
+public class YSQLAggregate extends FunctionNode<YSQLAggregateFunction, YSQLExpression> implements YSQLExpression {
+
+    public YSQLAggregate(List<YSQLExpression> args, YSQLAggregateFunction func) {
+        super(func, args);
+    }
+
+    public enum YSQLAggregateFunction {
+        AVG(YSQLDataType.INT, YSQLDataType.FLOAT, YSQLDataType.REAL, YSQLDataType.DECIMAL), BIT_AND(YSQLDataType.INT),
+        BIT_OR(YSQLDataType.INT), BOOL_AND(YSQLDataType.BOOLEAN), BOOL_OR(YSQLDataType.BOOLEAN),
+        COUNT(YSQLDataType.INT), EVERY(YSQLDataType.BOOLEAN), MAX, MIN,
+        // STRING_AGG
+        SUM(YSQLDataType.INT, YSQLDataType.FLOAT, YSQLDataType.REAL, YSQLDataType.DECIMAL);
+
+        private final YSQLDataType[] supportedReturnTypes;
+
+        YSQLAggregateFunction(YSQLDataType... supportedReturnTypes) {
+            this.supportedReturnTypes = supportedReturnTypes.clone();
+        }
+
+        public static List<YSQLAggregateFunction> getAggregates(YSQLDataType type) {
+            return Arrays.stream(values()).filter(p -> p.supportsReturnType(type)).collect(Collectors.toList());
+        }
+
+        public List<YSQLDataType> getTypes(YSQLDataType returnType) {
+            return Collections.singletonList(returnType);
+        }
+
+        public boolean supportsReturnType(YSQLDataType returnType) {
+            return Arrays.stream(supportedReturnTypes).anyMatch(t -> t == returnType)
+                    || supportedReturnTypes.length == 0;
+        }
+
+        public YSQLDataType getRandomReturnType() {
+            if (supportedReturnTypes.length == 0) {
+                return Randomly.fromOptions(YSQLDataType.getRandomType());
+            } else {
+                return Randomly.fromOptions(supportedReturnTypes);
+            }
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLAlias.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLAlias.java
@@ -1,0 +1,35 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.common.visitor.UnaryOperation;
+
+public class YSQLAlias implements UnaryOperation<YSQLExpression>, YSQLExpression {
+
+    private final YSQLExpression expr;
+    private final String alias;
+
+    public YSQLAlias(YSQLExpression expr, String alias) {
+        this.expr = expr;
+        this.alias = alias;
+    }
+
+    @Override
+    public YSQLExpression getExpression() {
+        return expr;
+    }
+
+    @Override
+    public String getOperatorRepresentation() {
+        return " as " + alias;
+    }
+
+    @Override
+    public boolean omitBracketsWhenPrinting() {
+        return true;
+    }
+
+    @Override
+    public OperatorKind getOperatorKind() {
+        return OperatorKind.POSTFIX;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLBetweenOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLBetweenOperation.java
@@ -1,0 +1,63 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public final class YSQLBetweenOperation implements YSQLExpression {
+
+    private final YSQLExpression expr;
+    private final YSQLExpression left;
+    private final YSQLExpression right;
+    private final boolean isSymmetric;
+
+    public YSQLBetweenOperation(YSQLExpression expr, YSQLExpression left, YSQLExpression right, boolean symmetric) {
+        this.expr = expr;
+        this.left = left;
+        this.right = right;
+        isSymmetric = symmetric;
+    }
+
+    public YSQLExpression getExpr() {
+        return expr;
+    }
+
+    public YSQLExpression getLeft() {
+        return left;
+    }
+
+    public YSQLExpression getRight() {
+        return right;
+    }
+
+    public boolean isSymmetric() {
+        return isSymmetric;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLBinaryComparisonOperation leftComparison = new YSQLBinaryComparisonOperation(left, expr,
+                YSQLBinaryComparisonOperation.YSQLBinaryComparisonOperator.LESS_EQUALS);
+        YSQLBinaryComparisonOperation rightComparison = new YSQLBinaryComparisonOperation(expr, right,
+                YSQLBinaryComparisonOperation.YSQLBinaryComparisonOperator.LESS_EQUALS);
+        YSQLBinaryLogicalOperation andOperation = new YSQLBinaryLogicalOperation(leftComparison, rightComparison,
+                YSQLBinaryLogicalOperation.BinaryLogicalOperator.AND);
+        if (isSymmetric) {
+            YSQLBinaryComparisonOperation leftComparison2 = new YSQLBinaryComparisonOperation(right, expr,
+                    YSQLBinaryComparisonOperation.YSQLBinaryComparisonOperator.LESS_EQUALS);
+            YSQLBinaryComparisonOperation rightComparison2 = new YSQLBinaryComparisonOperation(expr, left,
+                    YSQLBinaryComparisonOperation.YSQLBinaryComparisonOperator.LESS_EQUALS);
+            YSQLBinaryLogicalOperation andOperation2 = new YSQLBinaryLogicalOperation(leftComparison2, rightComparison2,
+                    YSQLBinaryLogicalOperation.BinaryLogicalOperator.AND);
+            YSQLBinaryLogicalOperation orOp = new YSQLBinaryLogicalOperation(andOperation, andOperation2,
+                    YSQLBinaryLogicalOperation.BinaryLogicalOperator.OR);
+            return orOp.getExpectedValue();
+        } else {
+            return andOperation.getExpectedValue();
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryArithmeticOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryArithmeticOperation.java
@@ -1,0 +1,106 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import java.util.function.BinaryOperator;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryArithmeticOperation.YSQLBinaryOperator;
+
+public class YSQLBinaryArithmeticOperation extends BinaryOperatorNode<YSQLExpression, YSQLBinaryOperator>
+        implements YSQLExpression {
+
+    public YSQLBinaryArithmeticOperation(YSQLExpression left, YSQLExpression right, YSQLBinaryOperator op) {
+        super(left, right, op);
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.INT;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant leftExpected = getLeft().getExpectedValue();
+        YSQLConstant rightExpected = getRight().getExpectedValue();
+        if (leftExpected == null || rightExpected == null) {
+            return null;
+        }
+        return getOp().apply(leftExpected, rightExpected);
+    }
+
+    public enum YSQLBinaryOperator implements Operator {
+
+        ADDITION("+") {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                return applyBitOperation(left, right, Long::sum);
+            }
+
+        },
+        SUBTRACTION("-") {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                return applyBitOperation(left, right, (l, r) -> l - r);
+            }
+        },
+        MULTIPLICATION("*") {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                return applyBitOperation(left, right, (l, r) -> l * r);
+            }
+        },
+        DIVISION("/") {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                return applyBitOperation(left, right, (l, r) -> r == 0 ? -1 : l / r);
+
+            }
+
+        },
+        MODULO("%") {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                return applyBitOperation(left, right, (l, r) -> r == 0 ? -1 : l % r);
+
+            }
+        },
+        EXPONENTIATION("^") {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                return null;
+            }
+        };
+
+        private final String textRepresentation;
+
+        YSQLBinaryOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        private static YSQLConstant applyBitOperation(YSQLConstant left, YSQLConstant right, BinaryOperator<Long> op) {
+            if (left.isNull() || right.isNull()) {
+                return YSQLConstant.createNullConstant();
+            } else {
+                long leftVal = left.cast(YSQLDataType.INT).asInt();
+                long rightVal = right.cast(YSQLDataType.INT).asInt();
+                long value = op.apply(leftVal, rightVal);
+                return YSQLConstant.createIntConstant(value);
+            }
+        }
+
+        public static YSQLBinaryOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+        public abstract YSQLConstant apply(YSQLConstant left, YSQLConstant right);
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryBitOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryBitOperation.java
@@ -1,0 +1,46 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryBitOperation.YSQLBinaryBitOperator;
+
+public class YSQLBinaryBitOperation extends BinaryOperatorNode<YSQLExpression, YSQLBinaryBitOperator>
+        implements YSQLExpression {
+
+    public YSQLBinaryBitOperation(YSQLBinaryBitOperator op, YSQLExpression left, YSQLExpression right) {
+        super(left, right, op);
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BIT;
+    }
+
+    public enum YSQLBinaryBitOperator implements Operator {
+        CONCATENATION("||"), //
+        BITWISE_AND("&"), //
+        BITWISE_OR("|"), //
+        BITWISE_XOR("#"), //
+        BITWISE_SHIFT_LEFT("<<"), //
+        BITWISE_SHIFT_RIGHT(">>");
+
+        private final String text;
+
+        YSQLBinaryBitOperator(String text) {
+            this.text = text;
+        }
+
+        public static YSQLBinaryBitOperator getRandom() {
+            return Randomly.fromOptions(YSQLBinaryBitOperator.values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return text;
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryComparisonOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryComparisonOperation.java
@@ -1,0 +1,135 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryComparisonOperation.YSQLBinaryComparisonOperator;
+
+public class YSQLBinaryComparisonOperation extends BinaryOperatorNode<YSQLExpression, YSQLBinaryComparisonOperator>
+        implements YSQLExpression {
+
+    public YSQLBinaryComparisonOperation(YSQLExpression left, YSQLExpression right, YSQLBinaryComparisonOperator op) {
+        super(left, right, op);
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant leftExpectedValue = getLeft().getExpectedValue();
+        YSQLConstant rightExpectedValue = getRight().getExpectedValue();
+        if (leftExpectedValue == null || rightExpectedValue == null) {
+            return null;
+        }
+        return getOp().getExpectedValue(leftExpectedValue, rightExpectedValue);
+    }
+
+    public enum YSQLBinaryComparisonOperator implements Operator {
+        EQUALS("=") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                return leftVal.isEquals(rightVal);
+            }
+        },
+        IS_DISTINCT("IS DISTINCT FROM") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                return YSQLConstant
+                        .createBooleanConstant(!IS_NOT_DISTINCT.getExpectedValue(leftVal, rightVal).asBoolean());
+            }
+        },
+        IS_NOT_DISTINCT("IS NOT DISTINCT FROM") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                if (leftVal.isNull()) {
+                    return YSQLConstant.createBooleanConstant(rightVal.isNull());
+                } else if (rightVal.isNull()) {
+                    return YSQLConstant.createFalse();
+                } else {
+                    return leftVal.isEquals(rightVal);
+                }
+            }
+        },
+        NOT_EQUALS("!=") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                YSQLConstant isEquals = leftVal.isEquals(rightVal);
+                if (isEquals.isBoolean()) {
+                    return YSQLConstant.createBooleanConstant(!isEquals.asBoolean());
+                }
+                return isEquals;
+            }
+        },
+        LESS("<") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                return leftVal.isLessThan(rightVal);
+            }
+        },
+        LESS_EQUALS("<=") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                YSQLConstant lessThan = leftVal.isLessThan(rightVal);
+                if (lessThan.isBoolean() && !lessThan.asBoolean()) {
+                    return leftVal.isEquals(rightVal);
+                } else {
+                    return lessThan;
+                }
+            }
+        },
+        GREATER(">") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                YSQLConstant equals = leftVal.isEquals(rightVal);
+                if (equals.isBoolean() && equals.asBoolean()) {
+                    return YSQLConstant.createFalse();
+                } else {
+                    YSQLConstant applyLess = leftVal.isLessThan(rightVal);
+                    if (applyLess.isNull()) {
+                        return YSQLConstant.createNullConstant();
+                    }
+                    return YSQLPrefixOperation.PrefixOperator.NOT.getExpectedValue(applyLess);
+                }
+            }
+        },
+        GREATER_EQUALS(">=") {
+            @Override
+            public YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal) {
+                YSQLConstant equals = leftVal.isEquals(rightVal);
+                if (equals.isBoolean() && equals.asBoolean()) {
+                    return YSQLConstant.createTrue();
+                } else {
+                    YSQLConstant applyLess = leftVal.isLessThan(rightVal);
+                    if (applyLess.isNull()) {
+                        return YSQLConstant.createNullConstant();
+                    }
+                    return YSQLPrefixOperation.PrefixOperator.NOT.getExpectedValue(applyLess);
+                }
+            }
+
+        };
+
+        private final String textRepresentation;
+
+        YSQLBinaryComparisonOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static YSQLBinaryComparisonOperator getRandom() {
+            return Randomly.fromOptions(YSQLBinaryComparisonOperator.values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+        public abstract YSQLConstant getExpectedValue(YSQLConstant leftVal, YSQLConstant rightVal);
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryLogicalOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryLogicalOperation.java
@@ -1,0 +1,88 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryLogicalOperation.BinaryLogicalOperator;
+
+public class YSQLBinaryLogicalOperation extends BinaryOperatorNode<YSQLExpression, BinaryLogicalOperator>
+        implements YSQLExpression {
+
+    public YSQLBinaryLogicalOperation(YSQLExpression left, YSQLExpression right, BinaryLogicalOperator op) {
+        super(left, right, op);
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant leftExpectedValue = getLeft().getExpectedValue();
+        YSQLConstant rightExpectedValue = getRight().getExpectedValue();
+        if (leftExpectedValue == null || rightExpectedValue == null) {
+            return null;
+        }
+        return getOp().apply(leftExpectedValue, rightExpectedValue);
+    }
+
+    public enum BinaryLogicalOperator implements Operator {
+        AND {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                YSQLConstant leftBool = left.cast(YSQLDataType.BOOLEAN);
+                YSQLConstant rightBool = right.cast(YSQLDataType.BOOLEAN);
+                if (leftBool.isNull()) {
+                    if (rightBool.isNull()) {
+                        return YSQLConstant.createNullConstant();
+                    } else {
+                        if (rightBool.asBoolean()) {
+                            return YSQLConstant.createNullConstant();
+                        } else {
+                            return YSQLConstant.createFalse();
+                        }
+                    }
+                } else if (!leftBool.asBoolean()) {
+                    return YSQLConstant.createFalse();
+                }
+                assert leftBool.asBoolean();
+                if (rightBool.isNull()) {
+                    return YSQLConstant.createNullConstant();
+                } else {
+                    return YSQLConstant.createBooleanConstant(rightBool.isBoolean() && rightBool.asBoolean());
+                }
+            }
+        },
+        OR {
+            @Override
+            public YSQLConstant apply(YSQLConstant left, YSQLConstant right) {
+                YSQLConstant leftBool = left.cast(YSQLDataType.BOOLEAN);
+                YSQLConstant rightBool = right.cast(YSQLDataType.BOOLEAN);
+                if (leftBool.isBoolean() && leftBool.asBoolean()) {
+                    return YSQLConstant.createTrue();
+                }
+                if (rightBool.isBoolean() && rightBool.asBoolean()) {
+                    return YSQLConstant.createTrue();
+                }
+                if (leftBool.isNull() || rightBool.isNull()) {
+                    return YSQLConstant.createNullConstant();
+                }
+                return YSQLConstant.createFalse();
+            }
+        };
+
+        public static BinaryLogicalOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public abstract YSQLConstant apply(YSQLConstant left, YSQLConstant right);
+
+        @Override
+        public String getTextRepresentation() {
+            return toString();
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryRangeOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLBinaryRangeOperation.java
@@ -1,0 +1,71 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryNode;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLBinaryRangeOperation extends BinaryNode<YSQLExpression> implements YSQLExpression {
+
+    private final String op;
+
+    public YSQLBinaryRangeOperation(YSQLBinaryRangeComparisonOperator op, YSQLExpression left, YSQLExpression right) {
+        super(left, right);
+        this.op = op.getTextRepresentation();
+    }
+
+    public YSQLBinaryRangeOperation(YSQLBinaryRangeOperator op, YSQLExpression left, YSQLExpression right) {
+        super(left, right);
+        this.op = op.getTextRepresentation();
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public String getOperatorRepresentation() {
+        return op;
+    }
+
+    public enum YSQLBinaryRangeOperator implements Operator {
+        UNION("+"), INTERSECTION("*"), DIFFERENCE("-");
+
+        private final String textRepresentation;
+
+        YSQLBinaryRangeOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static YSQLBinaryRangeOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+    }
+
+    public enum YSQLBinaryRangeComparisonOperator {
+        CONTAINS_RANGE_OR_ELEMENT("@>"), RANGE_OR_ELEMENT_IS_CONTAINED("<@"), OVERLAP("&&"), STRICT_LEFT_OF("<<"),
+        STRICT_RIGHT_OF(">>"), NOT_RIGHT_OF("&<"), NOT_LEFT_OF(">&"), ADJACENT("-|-");
+
+        private final String textRepresentation;
+
+        YSQLBinaryRangeComparisonOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static YSQLBinaryRangeComparisonOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLCastOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLCastOperation.java
@@ -1,0 +1,45 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLCompoundDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLCastOperation implements YSQLExpression {
+
+    private final YSQLExpression expression;
+    private final YSQLCompoundDataType type;
+
+    public YSQLCastOperation(YSQLExpression expression, YSQLCompoundDataType type) {
+        if (expression == null) {
+            throw new AssertionError();
+        }
+        this.expression = expression;
+        this.type = type;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return type.getDataType();
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant expectedValue = expression.getExpectedValue();
+        if (expectedValue == null) {
+            return null;
+        }
+        return expectedValue.cast(type.getDataType());
+    }
+
+    public YSQLExpression getExpression() {
+        return expression;
+    }
+
+    public YSQLDataType getType() {
+        return type.getDataType();
+    }
+
+    public YSQLCompoundDataType getCompoundType() {
+        return type;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLCollate.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLCollate.java
@@ -1,0 +1,33 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLCollate implements YSQLExpression {
+
+    private final YSQLExpression expr;
+    private final String collate;
+
+    public YSQLCollate(YSQLExpression expr, String collate) {
+        this.expr = expr;
+        this.collate = collate;
+    }
+
+    public String getCollate() {
+        return collate;
+    }
+
+    public YSQLExpression getExpr() {
+        return expr;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return expr.getExpressionType();
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        return null;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLColumnValue.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLColumnValue.java
@@ -1,0 +1,34 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLColumnValue implements YSQLExpression {
+
+    private final YSQLColumn c;
+    private final YSQLConstant expectedValue;
+
+    public YSQLColumnValue(YSQLColumn c, YSQLConstant expectedValue) {
+        this.c = c;
+        this.expectedValue = expectedValue;
+    }
+
+    public static YSQLColumnValue create(YSQLColumn c, YSQLConstant expected) {
+        return new YSQLColumnValue(c, expected);
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return c.getType();
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        return expectedValue;
+    }
+
+    public YSQLColumn getColumn() {
+        return c;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLConcatOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLConcatOperation.java
@@ -1,0 +1,37 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.common.ast.BinaryNode;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLConcatOperation extends BinaryNode<YSQLExpression> implements YSQLExpression {
+
+    public YSQLConcatOperation(YSQLExpression left, YSQLExpression right) {
+        super(left, right);
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.TEXT;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant leftExpectedValue = getLeft().getExpectedValue();
+        YSQLConstant rightExpectedValue = getRight().getExpectedValue();
+        if (leftExpectedValue == null || rightExpectedValue == null) {
+            return null;
+        }
+        if (leftExpectedValue.isNull() || rightExpectedValue.isNull()) {
+            return YSQLConstant.createNullConstant();
+        }
+        String leftStr = leftExpectedValue.cast(YSQLDataType.TEXT).getUnquotedTextRepresentation();
+        String rightStr = rightExpectedValue.cast(YSQLDataType.TEXT).getUnquotedTextRepresentation();
+        return YSQLConstant.createTextConstant(leftStr + rightStr);
+    }
+
+    @Override
+    public String getOperatorRepresentation() {
+        return "||";
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLConstant.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLConstant.java
@@ -1,0 +1,611 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import java.math.BigDecimal;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public abstract class YSQLConstant implements YSQLExpression {
+
+    public static YSQLConstant createNullConstant() {
+        return new YSQLNullConstant();
+    }
+
+    public static YSQLConstant createIntConstant(long val) {
+        return new IntConstant(val);
+    }
+
+    public static YSQLConstant createBooleanConstant(boolean val) {
+        return new BooleanConstant(val);
+    }
+
+    public static YSQLConstant createFalse() {
+        return createBooleanConstant(false);
+    }
+
+    public static YSQLConstant createTrue() {
+        return createBooleanConstant(true);
+    }
+
+    public static YSQLConstant createTextConstant(String string) {
+        return new StringConstant(string);
+    }
+
+    public static YSQLConstant createByteConstant(String string) {
+        return new ByteConstant(string);
+    }
+
+    public static YSQLConstant createDecimalConstant(BigDecimal bigDecimal) {
+        return new DecimalConstant(bigDecimal);
+    }
+
+    public static YSQLConstant createFloatConstant(float val) {
+        return new FloatConstant(val);
+    }
+
+    public static YSQLConstant createDoubleConstant(double val) {
+        return new DoubleConstant(val);
+    }
+
+    public static YSQLConstant createRange(long left, boolean leftIsInclusive, long right, boolean rightIsInclusive) {
+        long realLeft;
+        long realRight;
+        if (left > right) {
+            realRight = left;
+            realLeft = right;
+        } else {
+            realLeft = left;
+            realRight = right;
+        }
+        return new RangeConstant(realLeft, leftIsInclusive, realRight, rightIsInclusive);
+    }
+
+    public static YSQLExpression createBitConstant(long integer) {
+        return new BitConstant(integer);
+    }
+
+    public static YSQLExpression createInetConstant(String val) {
+        return new InetConstant(val);
+    }
+
+    public abstract String getTextRepresentation();
+
+    public abstract String getUnquotedTextRepresentation();
+
+    public String asString() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public boolean isString() {
+        return false;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        return this;
+    }
+
+    public boolean isNull() {
+        return false;
+    }
+
+    public boolean asBoolean() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public long asInt() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public boolean isBoolean() {
+        return false;
+    }
+
+    public abstract YSQLConstant isEquals(YSQLConstant rightVal);
+
+    public boolean isInt() {
+        return false;
+    }
+
+    protected abstract YSQLConstant isLessThan(YSQLConstant rightVal);
+
+    @Override
+    public String toString() {
+        return getTextRepresentation();
+    }
+
+    public abstract YSQLConstant cast(YSQLDataType type);
+
+    public static class BooleanConstant extends YSQLConstant {
+
+        private final boolean value;
+
+        public BooleanConstant(boolean value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return value ? "TRUE" : "FALSE";
+        }
+
+        @Override
+        public String getUnquotedTextRepresentation() {
+            return getTextRepresentation();
+        }
+
+        @Override
+        public boolean asBoolean() {
+            return value;
+        }
+
+        @Override
+        public boolean isBoolean() {
+            return true;
+        }
+
+        @Override
+        public YSQLConstant isEquals(YSQLConstant rightVal) {
+            if (rightVal.isNull()) {
+                return YSQLConstant.createNullConstant();
+            } else if (rightVal.isBoolean()) {
+                return YSQLConstant.createBooleanConstant(value == rightVal.asBoolean());
+            } else if (rightVal.isString()) {
+                return YSQLConstant.createBooleanConstant(value == rightVal.cast(YSQLDataType.BOOLEAN).asBoolean());
+            } else {
+                throw new AssertionError(rightVal);
+            }
+        }
+
+        @Override
+        protected YSQLConstant isLessThan(YSQLConstant rightVal) {
+            if (rightVal.isNull()) {
+                return YSQLConstant.createNullConstant();
+            } else if (rightVal.isString()) {
+                return isLessThan(rightVal.cast(YSQLDataType.BOOLEAN));
+            } else {
+                assert rightVal.isBoolean();
+                return YSQLConstant.createBooleanConstant((value ? 1 : 0) < (rightVal.asBoolean() ? 1 : 0));
+            }
+        }
+
+        @Override
+        public YSQLConstant cast(YSQLDataType type) {
+            switch (type) {
+            case BOOLEAN:
+                return this;
+            case INT:
+                return YSQLConstant.createIntConstant(value ? 1 : 0);
+            case TEXT:
+                return YSQLConstant.createTextConstant(value ? "true" : "false");
+            default:
+                return null;
+            }
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.BOOLEAN;
+        }
+
+    }
+
+    public static class YSQLNullConstant extends YSQLConstant {
+
+        @Override
+        public String getTextRepresentation() {
+            return "NULL";
+        }
+
+        @Override
+        public String getUnquotedTextRepresentation() {
+            return getTextRepresentation();
+        }
+
+        @Override
+        public boolean isNull() {
+            return true;
+        }
+
+        @Override
+        public YSQLConstant isEquals(YSQLConstant rightVal) {
+            return YSQLConstant.createNullConstant();
+        }
+
+        @Override
+        protected YSQLConstant isLessThan(YSQLConstant rightVal) {
+            return YSQLConstant.createNullConstant();
+        }
+
+        @Override
+        public YSQLConstant cast(YSQLDataType type) {
+            return YSQLConstant.createNullConstant();
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return null;
+        }
+
+    }
+
+    public static class StringConstant extends YSQLConstant {
+
+        protected final String value;
+
+        public StringConstant(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return String.format("'%s'", value.replace("'", "''"));
+        }
+
+        @Override
+        public String getUnquotedTextRepresentation() {
+            return value;
+        }
+
+        @Override
+        public String asString() {
+            return value;
+        }
+
+        @Override
+        public boolean isString() {
+            return true;
+        }
+
+        @Override
+        public YSQLConstant isEquals(YSQLConstant rightVal) {
+            if (rightVal.isNull()) {
+                return YSQLConstant.createNullConstant();
+            } else if (rightVal.isInt()) {
+                return cast(YSQLDataType.INT).isEquals(rightVal.cast(YSQLDataType.INT));
+            } else if (rightVal.isBoolean()) {
+                return cast(YSQLDataType.BOOLEAN).isEquals(rightVal.cast(YSQLDataType.BOOLEAN));
+            } else if (rightVal.isString()) {
+                return YSQLConstant.createBooleanConstant(value.contentEquals(rightVal.asString()));
+            } else {
+                throw new AssertionError(rightVal);
+            }
+        }
+
+        @Override
+        protected YSQLConstant isLessThan(YSQLConstant rightVal) {
+            if (rightVal.isNull()) {
+                return YSQLConstant.createNullConstant();
+            } else if (rightVal.isInt()) {
+                return cast(YSQLDataType.INT).isLessThan(rightVal.cast(YSQLDataType.INT));
+            } else if (rightVal.isBoolean()) {
+                return cast(YSQLDataType.BOOLEAN).isLessThan(rightVal.cast(YSQLDataType.BOOLEAN));
+            } else if (rightVal.isString()) {
+                return YSQLConstant.createBooleanConstant(value.compareTo(rightVal.asString()) < 0);
+            } else {
+                throw new AssertionError(rightVal);
+            }
+        }
+
+        @Override
+        public YSQLConstant cast(YSQLDataType type) {
+            if (type == YSQLDataType.TEXT) {
+                return this;
+            }
+            String s = value.trim();
+            switch (type) {
+            case BOOLEAN:
+                try {
+                    return YSQLConstant.createBooleanConstant(Long.parseLong(s) != 0);
+                } catch (NumberFormatException e) {
+                }
+                switch (s.toUpperCase()) {
+                case "T":
+                case "TR":
+                case "TRU":
+                case "TRUE":
+                case "1":
+                case "YES":
+                case "YE":
+                case "Y":
+                case "ON":
+                    return YSQLConstant.createTrue();
+                case "F":
+                case "FA":
+                case "FAL":
+                case "FALS":
+                case "FALSE":
+                case "N":
+                case "NO":
+                case "OF":
+                case "OFF":
+                default:
+                    return YSQLConstant.createFalse();
+                }
+            case INT:
+                try {
+                    return YSQLConstant.createIntConstant(Long.parseLong(s));
+                } catch (NumberFormatException e) {
+                    return YSQLConstant.createIntConstant(-1);
+                }
+            case TEXT:
+                return this;
+            default:
+                return null;
+            }
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.TEXT;
+        }
+
+    }
+
+    public static class IntConstant extends YSQLConstant {
+
+        private final long val;
+
+        public IntConstant(long val) {
+            this.val = val;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return String.valueOf(val);
+        }
+
+        @Override
+        public String getUnquotedTextRepresentation() {
+            return getTextRepresentation();
+        }
+
+        @Override
+        public long asInt() {
+            return val;
+        }
+
+        @Override
+        public YSQLConstant isEquals(YSQLConstant rightVal) {
+            if (rightVal.isNull()) {
+                return YSQLConstant.createNullConstant();
+            } else if (rightVal.isBoolean()) {
+                return cast(YSQLDataType.BOOLEAN).isEquals(rightVal);
+            } else if (rightVal.isInt()) {
+                return YSQLConstant.createBooleanConstant(val == rightVal.asInt());
+            } else if (rightVal.isString()) {
+                return YSQLConstant.createBooleanConstant(val == rightVal.cast(YSQLDataType.INT).asInt());
+            } else {
+                throw new AssertionError(rightVal);
+            }
+        }
+
+        @Override
+        public boolean isInt() {
+            return true;
+        }
+
+        @Override
+        protected YSQLConstant isLessThan(YSQLConstant rightVal) {
+            if (rightVal.isNull()) {
+                return YSQLConstant.createNullConstant();
+            } else if (rightVal.isInt()) {
+                return YSQLConstant.createBooleanConstant(val < rightVal.asInt());
+            } else if (rightVal.isBoolean()) {
+                throw new AssertionError(rightVal);
+            } else if (rightVal.isString()) {
+                return YSQLConstant.createBooleanConstant(val < rightVal.cast(YSQLDataType.INT).asInt());
+            } else {
+                throw new IgnoreMeException();
+            }
+
+        }
+
+        @Override
+        public YSQLConstant cast(YSQLDataType type) {
+            switch (type) {
+            case BOOLEAN:
+                return YSQLConstant.createBooleanConstant(val != 0);
+            case INT:
+                return this;
+            case TEXT:
+                return YSQLConstant.createTextConstant(String.valueOf(val));
+            default:
+                return null;
+            }
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.INT;
+        }
+
+    }
+
+    public static class ByteConstant extends StringConstant {
+
+        public ByteConstant(String value) {
+            super(value);
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return String.format("'%s'::bytea", value.replace("'", "''"));
+        }
+    }
+
+    public abstract static class YSQLConstantBase extends YSQLConstant {
+
+        @Override
+        public String getUnquotedTextRepresentation() {
+            return null;
+        }
+
+        @Override
+        public YSQLConstant isEquals(YSQLConstant rightVal) {
+            return null;
+        }
+
+        @Override
+        protected YSQLConstant isLessThan(YSQLConstant rightVal) {
+            return null;
+        }
+
+        @Override
+        public YSQLConstant cast(YSQLDataType type) {
+            return null;
+        }
+    }
+
+    public static class DecimalConstant extends YSQLConstantBase {
+
+        private final BigDecimal val;
+
+        public DecimalConstant(BigDecimal val) {
+            this.val = val;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return String.valueOf(val);
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.DECIMAL;
+        }
+
+    }
+
+    public static class InetConstant extends YSQLConstantBase {
+
+        private final String val;
+
+        public InetConstant(String val) {
+            this.val = "'" + val + "'";
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return val;
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.INET;
+        }
+
+    }
+
+    public static class FloatConstant extends YSQLConstantBase {
+
+        private final float val;
+
+        public FloatConstant(float val) {
+            this.val = val;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            if (Double.isFinite(val)) {
+                return String.valueOf(val);
+            } else {
+                return "'" + val + "'";
+            }
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.FLOAT;
+        }
+
+    }
+
+    public static class DoubleConstant extends YSQLConstantBase {
+
+        private final double val;
+
+        public DoubleConstant(double val) {
+            this.val = val;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            if (Double.isFinite(val)) {
+                return String.valueOf(val);
+            } else {
+                return "'" + val + "'";
+            }
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.FLOAT;
+        }
+
+    }
+
+    public static class BitConstant extends YSQLConstantBase {
+
+        private final long val;
+
+        public BitConstant(long val) {
+            this.val = val;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return String.format("B'%s'", Long.toBinaryString(val));
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.BIT;
+        }
+
+    }
+
+    public static class RangeConstant extends YSQLConstantBase {
+
+        private final long left;
+        private final boolean leftIsInclusive;
+        private final long right;
+        private final boolean rightIsInclusive;
+
+        public RangeConstant(long left, boolean leftIsInclusive, long right, boolean rightIsInclusive) {
+            this.left = left;
+            this.leftIsInclusive = leftIsInclusive;
+            this.right = right;
+            this.rightIsInclusive = rightIsInclusive;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("'");
+            if (leftIsInclusive) {
+                sb.append("[");
+            } else {
+                sb.append("(");
+            }
+            sb.append(left);
+            sb.append(",");
+            sb.append(right);
+            if (rightIsInclusive) {
+                sb.append("]");
+            } else {
+                sb.append(")");
+            }
+            sb.append("'");
+            sb.append("::int4range");
+            return sb.toString();
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return YSQLDataType.RANGE;
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLExpression.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLExpression.java
@@ -1,0 +1,14 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public interface YSQLExpression {
+
+    default YSQLDataType getExpressionType() {
+        return null;
+    }
+
+    default YSQLConstant getExpectedValue() {
+        return null;
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLFunction.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLFunction.java
@@ -1,0 +1,283 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLFunction implements YSQLExpression {
+
+    private final String func;
+    private final YSQLExpression[] args;
+    private final YSQLDataType returnType;
+    private YSQLFunctionWithResult functionWithKnownResult;
+
+    public YSQLFunction(YSQLFunctionWithResult func, YSQLDataType returnType, YSQLExpression... args) {
+        functionWithKnownResult = func;
+        this.func = func.getName();
+        this.returnType = returnType;
+        this.args = args.clone();
+    }
+
+    public YSQLFunction(YSQLFunctionWithUnknownResult f, YSQLDataType returnType, YSQLExpression... args) {
+        this.func = f.getName();
+        this.returnType = returnType;
+        this.args = args.clone();
+    }
+
+    public String getFunctionName() {
+        return func;
+    }
+
+    public YSQLExpression[] getArguments() {
+        return args.clone();
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return returnType;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        if (functionWithKnownResult == null) {
+            return null;
+        }
+        YSQLConstant[] constants = new YSQLConstant[args.length];
+        for (int i = 0; i < constants.length; i++) {
+            constants[i] = args[i].getExpectedValue();
+            if (constants[i] == null) {
+                return null;
+            }
+        }
+        return functionWithKnownResult.apply(constants, args);
+    }
+
+    public enum YSQLFunctionWithResult {
+        ABS(1, "abs") {
+            @Override
+            public YSQLConstant apply(YSQLConstant[] evaluatedArgs, YSQLExpression... args) {
+                if (evaluatedArgs[0].isNull()) {
+                    return YSQLConstant.createNullConstant();
+                } else {
+                    return YSQLConstant.createIntConstant(Math.abs(evaluatedArgs[0].cast(YSQLDataType.INT).asInt()));
+                }
+            }
+
+            @Override
+            public boolean supportsReturnType(YSQLDataType type) {
+                return type == YSQLDataType.INT;
+            }
+
+            @Override
+            public YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments) {
+                return new YSQLDataType[] { returnType };
+            }
+
+        },
+        LOWER(1, "lower") {
+            @Override
+            public YSQLConstant apply(YSQLConstant[] evaluatedArgs, YSQLExpression... args) {
+                if (evaluatedArgs[0].isNull()) {
+                    return YSQLConstant.createNullConstant();
+                } else {
+                    String text = evaluatedArgs[0].asString();
+                    return YSQLConstant.createTextConstant(text.toLowerCase());
+                }
+            }
+
+            @Override
+            public boolean supportsReturnType(YSQLDataType type) {
+                return type == YSQLDataType.TEXT;
+            }
+
+            @Override
+            public YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments) {
+                return new YSQLDataType[] { YSQLDataType.TEXT };
+            }
+
+        },
+        LENGTH(1, "length") {
+            @Override
+            public YSQLConstant apply(YSQLConstant[] evaluatedArgs, YSQLExpression... args) {
+                if (evaluatedArgs[0].isNull()) {
+                    return YSQLConstant.createNullConstant();
+                }
+                String text = evaluatedArgs[0].asString();
+                return YSQLConstant.createIntConstant(text.length());
+            }
+
+            @Override
+            public boolean supportsReturnType(YSQLDataType type) {
+                return type == YSQLDataType.INT;
+            }
+
+            @Override
+            public YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments) {
+                return new YSQLDataType[] { YSQLDataType.TEXT };
+            }
+        },
+        UPPER(1, "upper") {
+            @Override
+            public YSQLConstant apply(YSQLConstant[] evaluatedArgs, YSQLExpression... args) {
+                if (evaluatedArgs[0].isNull()) {
+                    return YSQLConstant.createNullConstant();
+                } else {
+                    String text = evaluatedArgs[0].asString();
+                    return YSQLConstant.createTextConstant(text.toUpperCase());
+                }
+            }
+
+            @Override
+            public boolean supportsReturnType(YSQLDataType type) {
+                return type == YSQLDataType.TEXT;
+            }
+
+            @Override
+            public YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments) {
+                return new YSQLDataType[] { YSQLDataType.TEXT };
+            }
+
+        },
+        // NULL_IF(2, "nullif") {
+        //
+        // @Override
+        // public YSQLConstant apply(YSQLConstant[] evaluatedArgs, YSQLExpression[] args) {
+        // YSQLConstant equals = evaluatedArgs[0].isEquals(evaluatedArgs[1]);
+        // if (equals.isBoolean() && equals.asBoolean()) {
+        // return YSQLConstant.createNullConstant();
+        // } else {
+        // // TODO: SELECT (nullif('1', FALSE)); yields '1', but should yield TRUE
+        // return evaluatedArgs[0];
+        // }
+        // }
+        //
+        // @Override
+        // public boolean supportsReturnType(YSQLDataType type) {
+        // return true;
+        // }
+        //
+        // @Override
+        // public YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments) {
+        // return getType(nrArguments, returnType);
+        // }
+        //
+        // @Override
+        // public boolean checkArguments(YSQLExpression[] constants) {
+        // for (YSQLExpression e : constants) {
+        // if (!(e instanceof YSQLNullConstant)) {
+        // return true;
+        // }
+        // }
+        // return false;
+        // }
+        //
+        // },
+        NUM_NONNULLS(1, "num_nonnulls") {
+            @Override
+            public YSQLConstant apply(YSQLConstant[] args, YSQLExpression... origArgs) {
+                int nr = 0;
+                for (YSQLConstant c : args) {
+                    if (!c.isNull()) {
+                        nr++;
+                    }
+                }
+                return YSQLConstant.createIntConstant(nr);
+            }
+
+            @Override
+            public YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments) {
+                return getRandomTypes(nrArguments);
+            }
+
+            @Override
+            public boolean supportsReturnType(YSQLDataType type) {
+                return type == YSQLDataType.INT;
+            }
+
+            @Override
+            public boolean isVariadic() {
+                return true;
+            }
+
+        },
+        NUM_NULLS(1, "num_nulls") {
+            @Override
+            public YSQLConstant apply(YSQLConstant[] args, YSQLExpression... origArgs) {
+                int nr = 0;
+                for (YSQLConstant c : args) {
+                    if (c.isNull()) {
+                        nr++;
+                    }
+                }
+                return YSQLConstant.createIntConstant(nr);
+            }
+
+            @Override
+            public YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments) {
+                return getRandomTypes(nrArguments);
+            }
+
+            @Override
+            public boolean supportsReturnType(YSQLDataType type) {
+                return type == YSQLDataType.INT;
+            }
+
+            @Override
+            public boolean isVariadic() {
+                return true;
+            }
+
+        };
+
+        final int nrArgs;
+        private final String functionName;
+        private final boolean variadic;
+
+        YSQLFunctionWithResult(int nrArgs, String functionName) {
+            this.nrArgs = nrArgs;
+            this.functionName = functionName;
+            this.variadic = false;
+        }
+
+        public YSQLDataType[] getRandomTypes(int nr) {
+            YSQLDataType[] types = new YSQLDataType[nr];
+            for (int i = 0; i < types.length; i++) {
+                types[i] = YSQLDataType.getRandomType();
+            }
+            return types;
+        }
+
+        /**
+         * Gets the number of arguments if the function is non-variadic. If the function is variadic, the minimum number
+         * of arguments is returned.
+         *
+         * @return the number of arguments
+         */
+        public int getNrArgs() {
+            return nrArgs;
+        }
+
+        public abstract YSQLConstant apply(YSQLConstant[] evaluatedArgs, YSQLExpression... args);
+
+        @Override
+        public String toString() {
+            return functionName;
+        }
+
+        public boolean isVariadic() {
+            return variadic;
+        }
+
+        public String getName() {
+            return functionName;
+        }
+
+        public abstract boolean supportsReturnType(YSQLDataType type);
+
+        public abstract YSQLDataType[] getInputTypesForReturnType(YSQLDataType returnType, int nrArguments);
+
+        public boolean checkArguments(YSQLExpression... constants) {
+            return true;
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLFunctionWithUnknownResult.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLFunctionWithUnknownResult.java
@@ -1,0 +1,174 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
+
+public enum YSQLFunctionWithUnknownResult {
+
+    ABBREV("abbrev", YSQLDataType.TEXT, YSQLDataType.INET),
+    BROADCAST("broadcast", YSQLDataType.INET, YSQLDataType.INET), FAMILY("family", YSQLDataType.INT, YSQLDataType.INET),
+    HOSTMASK("hostmask", YSQLDataType.INET, YSQLDataType.INET), MASKLEN("masklen", YSQLDataType.INT, YSQLDataType.INET),
+    NETMASK("netmask", YSQLDataType.INET, YSQLDataType.INET),
+    SET_MASKLEN("set_masklen", YSQLDataType.INET, YSQLDataType.INET, YSQLDataType.INT),
+    TEXT("text", YSQLDataType.TEXT, YSQLDataType.INET),
+    INET_SAME_FAMILY("inet_same_family", YSQLDataType.BOOLEAN, YSQLDataType.INET, YSQLDataType.INET),
+
+    // https://www.postgres.org/docs/devel/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL-TABLE
+    // PG_RELOAD_CONF("pg_reload_conf", YSQLDataType.BOOLEAN), // too much output
+    // PG_ROTATE_LOGFILE("pg_rotate_logfile", YSQLDataType.BOOLEAN), prints warning
+
+    // https://www.postgresql.org/docs/devel/functions-info.html#FUNCTIONS-INFO-SESSION-TABLE
+    CURRENT_DATABASE("current_database", YSQLDataType.TEXT), // name
+    // CURRENT_QUERY("current_query", YSQLDataType.TEXT), // can generate false positives
+    CURRENT_SCHEMA("current_schema", YSQLDataType.TEXT), // name
+    // CURRENT_SCHEMAS("current_schemas", YSQLDataType.TEXT, YSQLDataType.BOOLEAN),
+    INET_CLIENT_PORT("inet_client_port", YSQLDataType.INT), INET_SERVER_PORT("inet_server_port", YSQLDataType.INT),
+    PG_BACKEND_PID("pg_backend_pid", YSQLDataType.INT), PG_CURRENT_LOGFILE("pg_current_logfile", YSQLDataType.TEXT),
+    // PG_IS_OTHER_TEMP_SCHEMA("pg_is_other_temp_schema", YSQLDataType.BOOLEAN),
+    // PG_JIT_AVAILABLE("pg_is_other_temp_schema", YSQLDataType.BOOLEAN),
+    PG_NOTIFICATION_QUEUE_USAGE("pg_notification_queue_usage", YSQLDataType.REAL),
+    PG_TRIGGER_DEPTH("pg_trigger_depth", YSQLDataType.INT), VERSION("version", YSQLDataType.TEXT),
+
+    //
+    TO_CHAR("to_char", YSQLDataType.TEXT, YSQLDataType.BYTEA, YSQLDataType.TEXT) {
+        @Override
+        public YSQLExpression[] getArguments(YSQLDataType returnType, YSQLExpressionGenerator gen, int depth) {
+            YSQLExpression[] args = super.getArguments(returnType, gen, depth);
+            args[0] = gen.generateExpression(YSQLDataType.getRandomType());
+            return args;
+        }
+    },
+
+    // String functions
+    ASCII("ascii", YSQLDataType.INT, YSQLDataType.TEXT),
+    BTRIM("btrim", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT),
+    CHR("chr", YSQLDataType.TEXT, YSQLDataType.INT),
+    CONVERT_FROM("convert_from", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT) {
+        @Override
+        public YSQLExpression[] getArguments(YSQLDataType returnType, YSQLExpressionGenerator gen, int depth) {
+            YSQLExpression[] args = super.getArguments(returnType, gen, depth);
+            args[1] = YSQLConstant.createTextConstant("UTF8");
+            return args;
+        }
+    },
+    // concat
+    // segfault
+    BIT_LENGTH("bit_length", YSQLDataType.INT, YSQLDataType.BYTEA),
+    INITCAP("initcap", YSQLDataType.TEXT, YSQLDataType.TEXT),
+    LEFT("left", YSQLDataType.TEXT, YSQLDataType.INT, YSQLDataType.TEXT),
+    LOWER("lower", YSQLDataType.TEXT, YSQLDataType.TEXT), MD5("md5", YSQLDataType.TEXT, YSQLDataType.TEXT),
+    UPPER("upper", YSQLDataType.TEXT, YSQLDataType.TEXT),
+    // PG_CLIENT_ENCODING("pg_client_encoding", YSQLDataType.TEXT),
+    QUOTE_LITERAL("quote_literal", YSQLDataType.TEXT, YSQLDataType.TEXT),
+    QUOTE_IDENT("quote_ident", YSQLDataType.TEXT, YSQLDataType.TEXT),
+    REGEX_REPLACE("regexp_replace", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT),
+    // todo mute repeat function because it may provide OOMs
+    // REPEAT("repeat", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.INT),
+    REPLACE("replace", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT),
+    REVERSE("reverse", YSQLDataType.TEXT, YSQLDataType.TEXT),
+    RIGHT("right", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.INT),
+    RPAD("rpad", YSQLDataType.TEXT, YSQLDataType.INT, YSQLDataType.TEXT),
+    RTRIM("rtrim", YSQLDataType.TEXT, YSQLDataType.TEXT),
+    SPLIT_PART("split_part", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.INT),
+    STRPOS("strpos", YSQLDataType.INT, YSQLDataType.TEXT, YSQLDataType.TEXT),
+    SUBSTR("substr", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.INT, YSQLDataType.INT),
+    TO_ASCII("to_ascii", YSQLDataType.TEXT, YSQLDataType.TEXT), TO_HEX("to_hex", YSQLDataType.INT, YSQLDataType.TEXT),
+    TRANSLATE("translate", YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT, YSQLDataType.TEXT),
+    // mathematical functions
+    // https://www.postgresql.org/docs/9.5/functions-math.html
+    ABS("abs", YSQLDataType.REAL, YSQLDataType.REAL), CBRT("cbrt", YSQLDataType.REAL, YSQLDataType.REAL),
+    CEILING("ceiling", YSQLDataType.REAL), //
+    DEGREES("degrees", YSQLDataType.REAL), EXP("exp", YSQLDataType.REAL), LN("ln", YSQLDataType.REAL),
+    LOG("log", YSQLDataType.REAL), LOG2("log", YSQLDataType.REAL, YSQLDataType.REAL), PI("pi", YSQLDataType.REAL),
+    POWER("power", YSQLDataType.REAL, YSQLDataType.REAL), TRUNC("trunc", YSQLDataType.REAL, YSQLDataType.INT),
+    TRUNC2("trunc", YSQLDataType.REAL, YSQLDataType.INT, YSQLDataType.REAL), FLOOR("floor", YSQLDataType.REAL),
+
+    // trigonometric functions - complete
+    // https://www.postgresql.org/docs/12/functions-math.html#FUNCTIONS-MATH-TRIG-TABLE
+    ACOS("acos", YSQLDataType.REAL), //
+    ACOSD("acosd", YSQLDataType.REAL), //
+    ASIN("asin", YSQLDataType.REAL), //
+    ASIND("asind", YSQLDataType.REAL), //
+    ATAN("atan", YSQLDataType.REAL), //
+    ATAND("atand", YSQLDataType.REAL), //
+    ATAN2("atan2", YSQLDataType.REAL, YSQLDataType.REAL), //
+    ATAN2D("atan2d", YSQLDataType.REAL, YSQLDataType.REAL), //
+    COS("cos", YSQLDataType.REAL), //
+    COSD("cosd", YSQLDataType.REAL), //
+    COT("cot", YSQLDataType.REAL), //
+    COTD("cotd", YSQLDataType.REAL), //
+    SIN("sin", YSQLDataType.REAL), //
+    SIND("sind", YSQLDataType.REAL), //
+    TAN("tan", YSQLDataType.REAL), //
+    TAND("tand", YSQLDataType.REAL), //
+
+    // hyperbolic functions - complete
+    // https://www.postgresql.org/docs/12/functions-math.html#FUNCTIONS-MATH-HYP-TABLE
+    SINH("sinh", YSQLDataType.REAL), //
+    COSH("cosh", YSQLDataType.REAL), //
+    TANH("tanh", YSQLDataType.REAL), //
+    ASINH("asinh", YSQLDataType.REAL), //
+    ACOSH("acosh", YSQLDataType.REAL), //
+    ATANH("atanh", YSQLDataType.REAL), //
+
+    // https://www.postgresql.org/docs/devel/functions-binarystring.html
+    GET_BIT("get_bit", YSQLDataType.INT, YSQLDataType.TEXT, YSQLDataType.INT),
+    GET_BYTE("get_byte", YSQLDataType.INT, YSQLDataType.TEXT, YSQLDataType.INT),
+
+    // range functions
+    // https://www.postgresql.org/docs/devel/functions-range.html#RANGE-FUNCTIONS-TABLE
+    RANGE_LOWER("lower", YSQLDataType.INT, YSQLDataType.RANGE), //
+    RANGE_UPPER("upper", YSQLDataType.INT, YSQLDataType.RANGE), //
+    RANGE_ISEMPTY("isempty", YSQLDataType.BOOLEAN, YSQLDataType.RANGE), //
+    RANGE_LOWER_INC("lower_inc", YSQLDataType.BOOLEAN, YSQLDataType.RANGE), //
+    RANGE_UPPER_INC("upper_inc", YSQLDataType.BOOLEAN, YSQLDataType.RANGE), //
+    RANGE_LOWER_INF("lower_inf", YSQLDataType.BOOLEAN, YSQLDataType.RANGE), //
+    RANGE_UPPER_INF("upper_inf", YSQLDataType.BOOLEAN, YSQLDataType.RANGE), //
+    RANGE_MERGE("range_merge", YSQLDataType.RANGE, YSQLDataType.RANGE, YSQLDataType.RANGE), //
+
+    // https://www.postgresql.org/docs/devel/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE
+    GET_COLUMN_SIZE("get_column_size", YSQLDataType.INT, YSQLDataType.TEXT);
+    // PG_DATABASE_SIZE("pg_database_size", YSQLDataType.INT, YSQLDataType.INT);
+    // PG_SIZE_BYTES("pg_size_bytes", YSQLDataType.INT, YSQLDataType.TEXT);
+
+    private final String functionName;
+    private final YSQLDataType returnType;
+    private final YSQLDataType[] argTypes;
+
+    YSQLFunctionWithUnknownResult(String functionName, YSQLDataType returnType, YSQLDataType... indexType) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+        this.argTypes = indexType.clone();
+    }
+
+    public static List<YSQLFunctionWithUnknownResult> getSupportedFunctions(YSQLDataType type) {
+        List<YSQLFunctionWithUnknownResult> functions = new ArrayList<>();
+        for (YSQLFunctionWithUnknownResult func : values()) {
+            if (func.isCompatibleWithReturnType(type)) {
+                functions.add(func);
+            }
+        }
+        return functions;
+    }
+
+    public boolean isCompatibleWithReturnType(YSQLDataType t) {
+        return t == returnType;
+    }
+
+    public YSQLExpression[] getArguments(YSQLDataType returnType, YSQLExpressionGenerator gen, int depth) {
+        YSQLExpression[] args = new YSQLExpression[argTypes.length];
+        for (int i = 0; i < args.length; i++) {
+            args[i] = gen.generateExpression(depth, argTypes[i]);
+        }
+        return args;
+
+    }
+
+    public String getName() {
+        return functionName;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLInOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLInOperation.java
@@ -1,0 +1,65 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import java.util.List;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLInOperation implements YSQLExpression {
+
+    private final YSQLExpression expr;
+    private final List<YSQLExpression> listElements;
+    private final boolean isTrue;
+
+    public YSQLInOperation(YSQLExpression expr, List<YSQLExpression> listElements, boolean isTrue) {
+        this.expr = expr;
+        this.listElements = listElements;
+        this.isTrue = isTrue;
+    }
+
+    public YSQLExpression getExpr() {
+        return expr;
+    }
+
+    public List<YSQLExpression> getListElements() {
+        return listElements;
+    }
+
+    public boolean isTrue() {
+        return isTrue;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant leftValue = expr.getExpectedValue();
+        if (leftValue == null) {
+            return null;
+        }
+        if (leftValue.isNull()) {
+            return YSQLConstant.createNullConstant();
+        }
+        boolean isNull = false;
+        for (YSQLExpression expr : getListElements()) {
+            YSQLConstant rightExpectedValue = expr.getExpectedValue();
+            if (rightExpectedValue == null) {
+                return null;
+            }
+            if (rightExpectedValue.isNull()) {
+                isNull = true;
+            } else if (rightExpectedValue.isEquals(this.expr.getExpectedValue()).isBoolean()
+                    && rightExpectedValue.isEquals(this.expr.getExpectedValue()).asBoolean()) {
+                return YSQLConstant.createBooleanConstant(isTrue);
+            }
+        }
+
+        if (isNull) {
+            return YSQLConstant.createNullConstant();
+        } else {
+            return YSQLConstant.createBooleanConstant(!isTrue);
+        }
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLJoin.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLJoin.java
@@ -1,0 +1,49 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLJoin implements YSQLExpression {
+
+    private final YSQLExpression tableReference;
+    private final YSQLExpression onClause;
+    private final YSQLJoinType type;
+
+    public YSQLJoin(YSQLExpression tableReference, YSQLExpression onClause, YSQLJoinType type) {
+        this.tableReference = tableReference;
+        this.onClause = onClause;
+        this.type = type;
+    }
+
+    public YSQLExpression getTableReference() {
+        return tableReference;
+    }
+
+    public YSQLExpression getOnClause() {
+        return onClause;
+    }
+
+    public YSQLJoinType getType() {
+        return type;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        throw new AssertionError();
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        throw new AssertionError();
+    }
+
+    public enum YSQLJoinType {
+        INNER, LEFT, RIGHT, FULL, CROSS;
+
+        public static YSQLJoinType getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLOrderByTerm.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLOrderByTerm.java
@@ -1,0 +1,42 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLOrderByTerm implements YSQLExpression {
+
+    private final YSQLOrder order;
+    private final YSQLExpression expr;
+
+    public YSQLOrderByTerm(YSQLExpression expr, YSQLOrder order) {
+        this.expr = expr;
+        this.order = order;
+    }
+
+    public YSQLOrder getOrder() {
+        return order;
+    }
+
+    public YSQLExpression getExpr() {
+        return expr;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return null;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        throw new AssertionError(this);
+    }
+
+    public enum YSQLOrder {
+        ASC, DESC;
+
+        public static YSQLOrder getRandomOrder() {
+            return Randomly.fromOptions(YSQLOrder.values());
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLPOSIXRegularExpression.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLPOSIXRegularExpression.java
@@ -1,0 +1,65 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLPOSIXRegularExpression implements YSQLExpression {
+
+    private final YSQLExpression string;
+    private final YSQLExpression regex;
+    private final POSIXRegex op;
+
+    public YSQLPOSIXRegularExpression(YSQLExpression string, YSQLExpression regex, POSIXRegex op) {
+        this.string = string;
+        this.regex = regex;
+        this.op = op;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        return null;
+    }
+
+    public YSQLExpression getRegex() {
+        return regex;
+    }
+
+    public YSQLExpression getString() {
+        return string;
+    }
+
+    public POSIXRegex getOp() {
+        return op;
+    }
+
+    public enum POSIXRegex implements Operator {
+        MATCH_CASE_SENSITIVE("~"), MATCH_CASE_INSENSITIVE("~*"), NOT_MATCH_CASE_SENSITIVE("!~"),
+        NOT_MATCH_CASE_INSENSITIVE("!~*");
+
+        private final String repr;
+
+        POSIXRegex(String repr) {
+            this.repr = repr;
+        }
+
+        public static POSIXRegex getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public String getStringRepresentation() {
+            return repr;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return toString();
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLPostfixOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLPostfixOperation.java
@@ -1,0 +1,146 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLPostfixOperation implements YSQLExpression {
+
+    private final YSQLExpression expr;
+    private final PostfixOperator op;
+    private final String operatorTextRepresentation;
+
+    public YSQLPostfixOperation(YSQLExpression expr, PostfixOperator op) {
+        this.expr = expr;
+        this.operatorTextRepresentation = Randomly.fromOptions(op.textRepresentations);
+        this.op = op;
+    }
+
+    public static YSQLExpression create(YSQLExpression expr, PostfixOperator op) {
+        return new YSQLPostfixOperation(expr, op);
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant expectedValue = expr.getExpectedValue();
+        if (expectedValue == null) {
+            return null;
+        }
+        return op.apply(expectedValue);
+    }
+
+    public String getOperatorTextRepresentation() {
+        return operatorTextRepresentation;
+    }
+
+    public YSQLExpression getExpression() {
+        return expr;
+    }
+
+    public enum PostfixOperator implements Operator {
+        IS_NULL("IS NULL", "ISNULL") {
+            @Override
+            public YSQLConstant apply(YSQLConstant expectedValue) {
+                return YSQLConstant.createBooleanConstant(expectedValue.isNull());
+            }
+
+            @Override
+            public YSQLDataType[] getInputDataTypes() {
+                return YSQLDataType.values();
+            }
+
+        },
+        IS_UNKNOWN("IS UNKNOWN") {
+            @Override
+            public YSQLConstant apply(YSQLConstant expectedValue) {
+                return YSQLConstant.createBooleanConstant(expectedValue.isNull());
+            }
+
+            @Override
+            public YSQLDataType[] getInputDataTypes() {
+                return new YSQLDataType[] { YSQLDataType.BOOLEAN };
+            }
+        },
+
+        IS_NOT_NULL("IS NOT NULL", "NOTNULL") {
+            @Override
+            public YSQLConstant apply(YSQLConstant expectedValue) {
+                return YSQLConstant.createBooleanConstant(!expectedValue.isNull());
+            }
+
+            @Override
+            public YSQLDataType[] getInputDataTypes() {
+                return YSQLDataType.values();
+            }
+
+        },
+        IS_NOT_UNKNOWN("IS NOT UNKNOWN") {
+            @Override
+            public YSQLConstant apply(YSQLConstant expectedValue) {
+                return YSQLConstant.createBooleanConstant(!expectedValue.isNull());
+            }
+
+            @Override
+            public YSQLDataType[] getInputDataTypes() {
+                return new YSQLDataType[] { YSQLDataType.BOOLEAN };
+            }
+        },
+        IS_TRUE("IS TRUE") {
+            @Override
+            public YSQLConstant apply(YSQLConstant expectedValue) {
+                if (expectedValue.isNull()) {
+                    return YSQLConstant.createFalse();
+                } else {
+                    return YSQLConstant.createBooleanConstant(expectedValue.cast(YSQLDataType.BOOLEAN).asBoolean());
+                }
+            }
+
+            @Override
+            public YSQLDataType[] getInputDataTypes() {
+                return new YSQLDataType[] { YSQLDataType.BOOLEAN };
+            }
+
+        },
+        IS_FALSE("IS FALSE") {
+            @Override
+            public YSQLConstant apply(YSQLConstant expectedValue) {
+                if (expectedValue.isNull()) {
+                    return YSQLConstant.createFalse();
+                } else {
+                    return YSQLConstant.createBooleanConstant(!expectedValue.cast(YSQLDataType.BOOLEAN).asBoolean());
+                }
+            }
+
+            @Override
+            public YSQLDataType[] getInputDataTypes() {
+                return new YSQLDataType[] { YSQLDataType.BOOLEAN };
+            }
+
+        };
+
+        private final String[] textRepresentations;
+
+        PostfixOperator(String... textRepresentations) {
+            this.textRepresentations = textRepresentations.clone();
+        }
+
+        public static PostfixOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public abstract YSQLConstant apply(YSQLConstant expectedValue);
+
+        public abstract YSQLDataType[] getInputDataTypes();
+
+        @Override
+        public String getTextRepresentation() {
+            return toString();
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLPostfixText.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLPostfixText.java
@@ -1,0 +1,36 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLPostfixText implements YSQLExpression {
+
+    private final YSQLExpression expr;
+    private final String text;
+    private final YSQLConstant expectedValue;
+    private final YSQLDataType type;
+
+    public YSQLPostfixText(YSQLExpression expr, String text, YSQLConstant expectedValue, YSQLDataType type) {
+        this.expr = expr;
+        this.text = text;
+        this.expectedValue = expectedValue;
+        this.type = type;
+    }
+
+    public YSQLExpression getExpr() {
+        return expr;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return type;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        return expectedValue;
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLPrefixOperation.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLPrefixOperation.java
@@ -1,0 +1,115 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.common.ast.BinaryOperatorNode.Operator;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLPrefixOperation implements YSQLExpression {
+
+    private final YSQLExpression expr;
+    private final PrefixOperator op;
+
+    public YSQLPrefixOperation(YSQLExpression expr, PrefixOperator op) {
+        this.expr = expr;
+        this.op = op;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return op.getExpressionType();
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        YSQLConstant expectedValue = expr.getExpectedValue();
+        if (expectedValue == null) {
+            return null;
+        }
+        return op.getExpectedValue(expectedValue);
+    }
+
+    public YSQLDataType[] getInputDataTypes() {
+        return op.dataTypes;
+    }
+
+    public String getTextRepresentation() {
+        return op.textRepresentation;
+    }
+
+    public YSQLExpression getExpression() {
+        return expr;
+    }
+
+    public enum PrefixOperator implements Operator {
+        NOT("NOT", YSQLDataType.BOOLEAN) {
+            @Override
+            public YSQLDataType getExpressionType() {
+                return YSQLDataType.BOOLEAN;
+            }
+
+            @Override
+            protected YSQLConstant getExpectedValue(YSQLConstant expectedValue) {
+                if (expectedValue.isNull()) {
+                    return YSQLConstant.createNullConstant();
+                } else {
+                    return YSQLConstant.createBooleanConstant(!expectedValue.cast(YSQLDataType.BOOLEAN).asBoolean());
+                }
+            }
+        },
+        UNARY_PLUS("+", YSQLDataType.INT) {
+            @Override
+            public YSQLDataType getExpressionType() {
+                return YSQLDataType.INT;
+            }
+
+            @Override
+            protected YSQLConstant getExpectedValue(YSQLConstant expectedValue) {
+                // TODO: actual converts to double precision
+                return expectedValue;
+            }
+
+        },
+        UNARY_MINUS("-", YSQLDataType.INT) {
+            @Override
+            public YSQLDataType getExpressionType() {
+                return YSQLDataType.INT;
+            }
+
+            @Override
+            protected YSQLConstant getExpectedValue(YSQLConstant expectedValue) {
+                if (expectedValue.isNull()) {
+                    // TODO
+                    throw new IgnoreMeException();
+                }
+                if (expectedValue.isInt() && expectedValue.asInt() == Long.MIN_VALUE) {
+                    throw new IgnoreMeException();
+                }
+                try {
+                    return YSQLConstant.createIntConstant(-expectedValue.asInt());
+                } catch (UnsupportedOperationException e) {
+                    return null;
+                }
+            }
+
+        };
+
+        private final String textRepresentation;
+        private final YSQLDataType[] dataTypes;
+
+        PrefixOperator(String textRepresentation, YSQLDataType... dataTypes) {
+            this.textRepresentation = textRepresentation;
+            this.dataTypes = dataTypes.clone();
+        }
+
+        public abstract YSQLDataType getExpressionType();
+
+        protected abstract YSQLConstant getExpectedValue(YSQLConstant expectedValue);
+
+        @Override
+        public String getTextRepresentation() {
+            return toString();
+        }
+
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLSelect.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLSelect.java
@@ -1,0 +1,135 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import java.util.Collections;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.SelectBase;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+
+public class YSQLSelect extends SelectBase<YSQLExpression> implements YSQLExpression {
+
+    private SelectType selectOption = SelectType.ALL;
+    private List<YSQLJoin> joinClauses = Collections.emptyList();
+    private YSQLExpression distinctOnClause;
+    private ForClause forClause;
+
+    public void setSelectType(SelectType fromOptions) {
+        this.setSelectOption(fromOptions);
+    }
+
+    public SelectType getSelectOption() {
+        return selectOption;
+    }
+
+    public void setSelectOption(SelectType fromOptions) {
+        this.selectOption = fromOptions;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return null;
+    }
+
+    public List<YSQLJoin> getJoinClauses() {
+        return joinClauses;
+    }
+
+    public void setJoinClauses(List<YSQLJoin> joinStatements) {
+        this.joinClauses = joinStatements;
+
+    }
+
+    public YSQLExpression getDistinctOnClause() {
+        return distinctOnClause;
+    }
+
+    public void setDistinctOnClause(YSQLExpression distinctOnClause) {
+        if (selectOption != SelectType.DISTINCT) {
+            throw new IllegalArgumentException();
+        }
+        this.distinctOnClause = distinctOnClause;
+    }
+
+    public ForClause getForClause() {
+        return forClause;
+    }
+
+    public void setForClause(ForClause forClause) {
+        this.forClause = forClause;
+    }
+
+    public enum ForClause {
+        UPDATE("UPDATE"), NO_KEY_UPDATE("NO KEY UPDATE"), SHARE("SHARE"), KEY_SHARE("KEY SHARE");
+
+        private final String textRepresentation;
+
+        ForClause(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static ForClause getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+    }
+
+    public enum SelectType {
+        DISTINCT, ALL;
+
+        public static SelectType getRandom() {
+            return Randomly.fromOptions(values());
+        }
+    }
+
+    public static class YSQLFromTable implements YSQLExpression {
+        private final YSQLTable t;
+        private final boolean only;
+
+        public YSQLFromTable(YSQLTable t, boolean only) {
+            this.t = t;
+            this.only = only;
+        }
+
+        public YSQLTable getTable() {
+            return t;
+        }
+
+        public boolean isOnly() {
+            return only;
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return null;
+        }
+    }
+
+    public static class YSQLSubquery implements YSQLExpression {
+        private final YSQLSelect s;
+        private final String name;
+
+        public YSQLSubquery(YSQLSelect s, String name) {
+            this.s = s;
+            this.name = name;
+        }
+
+        public YSQLSelect getSelect() {
+            return s;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public YSQLDataType getExpressionType() {
+            return null;
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/ast/YSQLSimilarTo.java
+++ b/src/sqlancer/yugabyte/ysql/ast/YSQLSimilarTo.java
@@ -1,0 +1,39 @@
+package sqlancer.yugabyte.ysql.ast;
+
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+
+public class YSQLSimilarTo implements YSQLExpression {
+
+    private final YSQLExpression string;
+    private final YSQLExpression similarTo;
+    private final YSQLExpression escapeCharacter;
+
+    public YSQLSimilarTo(YSQLExpression string, YSQLExpression similarTo, YSQLExpression escapeCharacter) {
+        this.string = string;
+        this.similarTo = similarTo;
+        this.escapeCharacter = escapeCharacter;
+    }
+
+    public YSQLExpression getString() {
+        return string;
+    }
+
+    public YSQLExpression getSimilarTo() {
+        return similarTo;
+    }
+
+    public YSQLExpression getEscapeCharacter() {
+        return escapeCharacter;
+    }
+
+    @Override
+    public YSQLDataType getExpressionType() {
+        return YSQLDataType.BOOLEAN;
+    }
+
+    @Override
+    public YSQLConstant getExpectedValue() {
+        return null;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLAlterTableGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLAlterTableGenerator.java
@@ -1,0 +1,182 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+
+public class YSQLAlterTableGenerator {
+
+    private final YSQLTable randomTable;
+    private final Randomly r;
+    private final YSQLGlobalState globalState;
+
+    public YSQLAlterTableGenerator(YSQLTable randomTable, YSQLGlobalState globalState) {
+        this.randomTable = randomTable;
+        this.globalState = globalState;
+        this.r = globalState.getRandomly();
+    }
+
+    public static SQLQueryAdapter create(YSQLTable randomTable, YSQLGlobalState globalState) {
+        return new YSQLAlterTableGenerator(randomTable, globalState).generate();
+    }
+
+    public List<Action> getActions(ExpectedErrors errors) {
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonInsertUpdateErrors(errors);
+        YSQLCommon.addCommonTableErrors(errors);
+        errors.add("duplicate key value violates unique constraint");
+        errors.add("cannot drop key column");
+        errors.add("cannot drop desired object(s) because other objects depend on them");
+        errors.add("invalid input syntax for");
+        errors.add("cannot remove a key column");
+        errors.add("it has pending trigger events");
+        errors.add("could not open relation");
+        errors.add("functions in index expression must be marked IMMUTABLE");
+        errors.add("functions in index predicate must be marked IMMUTABLE");
+        errors.add("has no default operator class for access method");
+        errors.add("does not accept data type");
+        errors.add("does not exist for access method");
+        errors.add("could not find cast from");
+        errors.add("does not exist"); // TODO: investigate
+        errors.add("constraints on permanent tables may reference only permanent tables");
+        List<Action> action;
+        if (Randomly.getBoolean()) {
+            action = Randomly.nonEmptySubset(Action.values());
+        } else {
+            // make it more likely that the ALTER TABLE succeeds
+            action = Randomly.subset(Randomly.smallNumber(), Action.values());
+        }
+        if (randomTable.getColumns().size() == 1) {
+            action.remove(Action.ALTER_TABLE_DROP_COLUMN);
+        }
+        if (!randomTable.hasIndexes()) {
+            action.remove(Action.ADD_TABLE_CONSTRAINT_USING_INDEX);
+        }
+        if (action.isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        return action;
+    }
+
+    public SQLQueryAdapter generate() {
+        ExpectedErrors errors = new ExpectedErrors();
+        int i = 0;
+        List<Action> action = getActions(errors);
+        StringBuilder sb = new StringBuilder();
+        sb.append("ALTER TABLE ");
+        if (Randomly.getBoolean()) {
+            sb.append(" ONLY");
+            errors.add("cannot use ONLY for foreign key on partitioned table");
+        }
+        sb.append(" ");
+        sb.append(randomTable.getName());
+        sb.append(" ");
+        for (Action a : action) {
+            if (i++ != 0) {
+                sb.append(", ");
+            }
+            switch (a) {
+            case ALTER_TABLE_DROP_COLUMN:
+                sb.append("DROP ");
+                if (Randomly.getBoolean()) {
+                    sb.append(" IF EXISTS ");
+                }
+                sb.append(randomTable.getRandomColumn().getName());
+                errors.add("because other objects depend on it");
+                if (Randomly.getBoolean()) {
+                    sb.append(" ");
+                    sb.append(Randomly.fromOptions("RESTRICT", "CASCADE"));
+                }
+                errors.add("does not exist");
+                errors.add("cannot drop column");
+                errors.add("cannot drop key column");
+                errors.add("cannot drop inherited column");
+                break;
+            case ADD_TABLE_CONSTRAINT:
+                sb.append("ADD ");
+                sb.append("CONSTRAINT " + r.getAlphabeticChar() + " ");
+                YSQLCommon.addTableConstraint(sb, randomTable, globalState, errors);
+                errors.add("already exists");
+                errors.add("multiple primary keys for table");
+                errors.add("could not create unique index");
+                errors.add("contains null values");
+                errors.add("cannot cast type");
+                errors.add("unsupported PRIMARY KEY constraint with partition key definition");
+                errors.add("unsupported UNIQUE constraint with partition key definition");
+                errors.add("insufficient columns in UNIQUE constraint definition");
+                errors.add("which is part of the partition key");
+                errors.add("out of range");
+                errors.add("there is no unique constraint matching given keys for referenced table");
+                errors.add("constraints on temporary tables may reference only temporary tables");
+                errors.add("constraints on unlogged tables may reference only permanent or unlogged tables");
+                errors.add("constraints on permanent tables may reference only permanent tables");
+                errors.add("cannot reference partitioned table");
+                errors.add("cannot be implemented");
+                errors.add("violates foreign key constraint");
+                errors.add("unsupported ON COMMIT and foreign key combination");
+                errors.add("USING INDEX is not supported on partitioned tables");
+                if (Randomly.getBoolean()) {
+                    sb.append(" NOT VALID");
+                    errors.add("cannot be marked NOT VALID");
+                    errors.add("cannot add NOT VALID foreign key on partitioned table");
+                } else {
+                    errors.add("is violated by some row");
+                }
+                break;
+            case ADD_TABLE_CONSTRAINT_USING_INDEX:
+                sb.append("ADD ");
+                sb.append("CONSTRAINT " + r.getAlphabeticChar() + " ");
+                sb.append(Randomly.fromOptions("UNIQUE", "PRIMARY KEY"));
+                sb.append(" USING INDEX ");
+                sb.append(randomTable.getRandomIndex().getIndexName());
+                errors.add("already exists");
+                errors.add("PRIMARY KEY containing column of type");
+                errors.add("not valid");
+                errors.add("is not a unique index");
+                errors.add("is already associated with a constraint");
+                errors.add("Cannot create a primary key or unique constraint using such an index");
+                errors.add("multiple primary keys for table");
+                errors.add("appears twice in unique constraint");
+                errors.add("appears twice in primary key constraint");
+                errors.add("contains null values");
+                errors.add("insufficient columns in PRIMARY KEY constraint definition");
+                errors.add("which is part of the partition key");
+                break;
+            case DISABLE_ROW_LEVEL_SECURITY:
+                sb.append("DISABLE ROW LEVEL SECURITY");
+                break;
+            case ENABLE_ROW_LEVEL_SECURITY:
+                sb.append("ENABLE ROW LEVEL SECURITY");
+                break;
+            case FORCE_ROW_LEVEL_SECURITY:
+                sb.append("FORCE ROW LEVEL SECURITY");
+                break;
+            case NO_FORCE_ROW_LEVEL_SECURITY:
+                sb.append("NO FORCE ROW LEVEL SECURITY");
+                break;
+            default:
+                throw new AssertionError(a);
+            }
+        }
+
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+    protected enum Action {
+        // ALTER_TABLE_ADD_COLUMN, // [ COLUMN ] column data_type [ COLLATE collation ] [
+        // column_constraint [ ... ] ]
+        ALTER_TABLE_DROP_COLUMN, // DROP [ COLUMN ] [ IF EXISTS ] column [ RESTRICT | CASCADE ]
+        ADD_TABLE_CONSTRAINT, // ADD table_constraint [ NOT VALID ]
+        ADD_TABLE_CONSTRAINT_USING_INDEX, // ADD table_constraint_using_index
+        DISABLE_ROW_LEVEL_SECURITY, // DISABLE ROW LEVEL SECURITY
+        ENABLE_ROW_LEVEL_SECURITY, // ENABLE ROW LEVEL SECURITY
+        FORCE_ROW_LEVEL_SECURITY, // FORCE ROW LEVEL SECURITY
+        NO_FORCE_ROW_LEVEL_SECURITY, // NO FORCE ROW LEVEL SECURITY
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLAnalyzeGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLAnalyzeGenerator.java
@@ -1,0 +1,37 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+
+public final class YSQLAnalyzeGenerator {
+
+    private YSQLAnalyzeGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        YSQLTable table = globalState.getSchema().getRandomTable();
+        StringBuilder sb = new StringBuilder("ANALYZE");
+        if (Randomly.getBoolean()) {
+            sb.append("(");
+            sb.append(" VERBOSE");
+            sb.append(")");
+        }
+        sb.append(" ");
+        sb.append(table.getName());
+        if (Randomly.getBoolean()) {
+            sb.append("(");
+            sb.append(table.getRandomNonEmptyColumnSubset().stream().map(AbstractTableColumn::getName)
+                    .collect(Collectors.joining(", ")));
+            sb.append(")");
+        }
+
+        return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("deadlock"));
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLClusterGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLClusterGenerator.java
@@ -1,0 +1,32 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+
+public final class YSQLClusterGenerator {
+
+    private YSQLClusterGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("there is no previously clustered index for table");
+        errors.add("cannot cluster a partitioned table");
+        errors.add("access method does not support clustering");
+        StringBuilder sb = new StringBuilder("CLUSTER ");
+        if (Randomly.getBoolean()) {
+            YSQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+            sb.append(table.getName());
+            if (Randomly.getBoolean() && !table.getIndexes().isEmpty()) {
+                sb.append(" USING ");
+                sb.append(table.getRandomIndex().getIndexName());
+                errors.add("cannot cluster on partial index");
+            }
+        }
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLCommentGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLCommentGenerator.java
@@ -1,0 +1,68 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+
+/**
+ * @see <a href="https://www.postgresql.org/docs/devel/sql-comment.html">COMMENT</a>
+ */
+public final class YSQLCommentGenerator {
+
+    private YSQLCommentGenerator() {
+    }
+
+    public static SQLQueryAdapter generate(YSQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("COMMENT ON ");
+        Action type = Randomly.fromOptions(Action.values());
+        YSQLTable randomTable = globalState.getSchema().getRandomTable();
+        switch (type) {
+        case INDEX:
+            sb.append("INDEX ");
+            if (randomTable.getIndexes().isEmpty()) {
+                throw new IgnoreMeException();
+            } else {
+                sb.append(randomTable.getRandomIndex().getIndexName());
+            }
+            break;
+        case COLUMN:
+            sb.append("COLUMN ");
+            sb.append(randomTable.getRandomColumn().getFullQualifiedName());
+            break;
+        case STATISTICS:
+            sb.append("STATISTICS ");
+            if (randomTable.getStatistics().isEmpty()) {
+                throw new IgnoreMeException();
+            } else {
+                sb.append(randomTable.getStatistics().get(0).getName());
+            }
+            break;
+        case TABLE:
+            sb.append("TABLE ");
+            if (randomTable.isView()) {
+                throw new IgnoreMeException();
+            }
+            sb.append(randomTable.getName());
+            break;
+        default:
+            throw new AssertionError(type);
+        }
+        sb.append(" IS ");
+        if (Randomly.getBoolean()) {
+            sb.append("NULL");
+        } else {
+            sb.append("'");
+            sb.append(globalState.getRandomly().getString().replace("'", "''"));
+            sb.append("'");
+        }
+        return new SQLQueryAdapter(sb.toString());
+    }
+
+    private enum Action {
+        INDEX, COLUMN, STATISTICS, TABLE
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLCommon.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLCommon.java
@@ -1,0 +1,441 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLProvider;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+
+public final class YSQLCommon {
+
+    private YSQLCommon() {
+    }
+
+    public static void addCommonFetchErrors(ExpectedErrors errors) {
+        errors.add("An I/O error occurred while sending to the backend");
+        errors.add("Conflicts with committed transaction");
+        errors.add("cannot be changed");
+        errors.add("SET TRANSACTION ISOLATION LEVEL must be called before any query");
+
+        errors.add("FULL JOIN is only supported with merge-joinable or hash-joinable join conditions");
+        errors.add("but it cannot be referenced from this part of the query");
+        errors.add("missing FROM-clause entry for table");
+
+        errors.add("canceling statement due to statement timeout");
+
+        errors.add("non-integer constant in");
+        errors.add("must appear in the GROUP BY clause or be used in an aggregate function");
+        errors.add("GROUP BY position");
+    }
+
+    public static void addCommonTableErrors(ExpectedErrors errors) {
+        errors.add("PRIMARY KEY containing column of type 'INET' not yet supported");
+        errors.add("PRIMARY KEY containing column of type 'VARBIT' not yet supported");
+        errors.add("PRIMARY KEY containing column of type 'INT4RANGE' not yet supported");
+        errors.add("INDEX on column of type 'INET' not yet supported");
+        errors.add("INDEX on column of type 'VARBIT' not yet supported");
+        errors.add("INDEX on column of type 'INT4RANGE' not yet supported");
+        errors.add("is not commutative"); // exclude
+        errors.add("cannot be changed");
+        errors.add("operator requires run-time type coercion"); // exclude
+    }
+
+    public static void addCommonExpressionErrors(ExpectedErrors errors) {
+        errors.add("syntax error at or near \"(\"");
+        errors.add("does not exist");
+        errors.add("is not unique");
+        errors.add("cannot be changed");
+        errors.add("invalid reference to FROM-clause entry for table");
+
+        errors.add("Invalid column number");
+        errors.add("specified more than once");
+        errors.add("You might need to add explicit type casts");
+        errors.add("invalid regular expression");
+        errors.add("could not determine which collation to use");
+        errors.add("invalid input syntax for integer");
+        errors.add("invalid regular expression");
+        errors.add("operator does not exist");
+        errors.add("quantifier operand invalid");
+        errors.add("collation mismatch");
+        errors.add("collations are not supported");
+        errors.add("operator is not unique");
+        errors.add("is not a valid binary digit");
+        errors.add("invalid hexadecimal digit");
+        errors.add("invalid hexadecimal data: odd number of digits");
+        errors.add("zero raised to a negative power is undefined");
+        errors.add("cannot convert infinity to numeric");
+        errors.add("division by zero");
+        errors.add("invalid input syntax for type money");
+        errors.add("invalid input syntax for type");
+        errors.add("cannot cast type");
+        errors.add("value overflows numeric format");
+        errors.add("is of type boolean but expression is of type text");
+        errors.add("a negative number raised to a non-integer power yields a complex result");
+        errors.add("could not determine polymorphic type because input has type unknown");
+        addToCharFunctionErrors(errors);
+        addBitStringOperationErrors(errors);
+        addFunctionErrors(errors);
+        addCommonRangeExpressionErrors(errors);
+        addCommonRegexExpressionErrors(errors);
+    }
+
+    private static void addToCharFunctionErrors(ExpectedErrors errors) {
+        errors.add("multiple decimal points");
+        errors.add("and decimal point together");
+        errors.add("multiple decimal points");
+        errors.add("cannot use \"S\" twice");
+        errors.add("must be ahead of \"PR\"");
+        errors.add("cannot use \"S\" and \"PL\"/\"MI\"/\"SG\"/\"PR\" together");
+        errors.add("cannot use \"S\" and \"SG\" together");
+        errors.add("cannot use \"S\" and \"MI\" together");
+        errors.add("cannot use \"S\" and \"PL\" together");
+        errors.add("cannot use \"PR\" and \"S\"/\"PL\"/\"MI\"/\"SG\" together");
+        errors.add("is not a number");
+    }
+
+    private static void addBitStringOperationErrors(ExpectedErrors errors) {
+        errors.add("cannot XOR bit strings of different sizes");
+        errors.add("cannot AND bit strings of different sizes");
+        errors.add("cannot OR bit strings of different sizes");
+        errors.add("must be type boolean, not type text");
+    }
+
+    private static void addFunctionErrors(ExpectedErrors errors) {
+        errors.add("out of valid range"); // get_bit/get_byte
+        errors.add("cannot take logarithm of a negative number");
+        errors.add("cannot take logarithm of zero");
+        errors.add("requested character too large for encoding"); // chr
+        errors.add("null character not permitted"); // chr
+        errors.add("requested character not valid for encoding"); // chr
+        errors.add("requested length too large"); // repeat
+        errors.add("invalid memory alloc request size"); // repeat
+        errors.add("encoding conversion from UTF8 to ASCII not supported"); // to_ascii
+        errors.add("negative substring length not allowed"); // substr
+        errors.add("invalid mask length"); // set_masklen
+    }
+
+    private static void addCommonRegexExpressionErrors(ExpectedErrors errors) {
+        errors.add("is not a valid hexadecimal digit");
+    }
+
+    public static void addCommonRangeExpressionErrors(ExpectedErrors errors) {
+        errors.add("range lower bound must be less than or equal to range upper bound");
+        errors.add("result of range difference would not be contiguous");
+        errors.add("out of range");
+        errors.add("malformed range literal");
+        errors.add("result of range union would not be contiguous");
+    }
+
+    public static void addCommonInsertUpdateErrors(ExpectedErrors errors) {
+        errors.add("value too long for type character");
+        errors.add("not found in view targetlist");
+    }
+
+    public static boolean appendDataType(YSQLDataType type, StringBuilder sb, boolean allowSerial,
+            boolean generateOnlyKnown, List<String> opClasses) throws AssertionError {
+        boolean serial = false;
+        switch (type) {
+        case BOOLEAN:
+            sb.append("boolean");
+            break;
+        case INT:
+            if (Randomly.getBoolean() && allowSerial) {
+                serial = true;
+                sb.append(Randomly.fromOptions("serial", "bigserial"));
+            } else {
+                sb.append(Randomly.fromOptions("smallint", "integer", "bigint"));
+            }
+            break;
+        case TEXT:
+            if (Randomly.getBoolean()) {
+                sb.append("TEXT");
+            } else if (Randomly.getBoolean()) {
+                // TODO: support CHAR (without VAR)
+                if (YSQLProvider.generateOnlyKnown || Randomly.getBoolean()) {
+                    sb.append("VAR");
+                }
+                sb.append("CHAR");
+                sb.append("(");
+                sb.append(ThreadLocalRandom.current().nextInt(1, 500));
+                sb.append(")");
+            } else {
+                sb.append("name");
+            }
+            break;
+        case DECIMAL:
+            sb.append("DECIMAL");
+            break;
+        case FLOAT:
+        case REAL:
+            if (Randomly.getBoolean()) {
+                sb.append("REAL");
+            } else {
+                sb.append("FLOAT");
+            }
+            break;
+        case RANGE:
+            sb.append(Randomly.fromOptions("int4range", "int4range")); // , "int8range", "numrange"
+            break;
+        case MONEY:
+            sb.append("money");
+            break;
+        case BYTEA:
+            sb.append("bytea");
+            break;
+        case BIT:
+            sb.append("BIT");
+            // if (Randomly.getBoolean()) {
+            sb.append(" VARYING");
+            // }
+            sb.append("(");
+            sb.append(Randomly.getNotCachedInteger(1, 500));
+            sb.append(")");
+            break;
+        case INET:
+            sb.append("inet");
+            break;
+        default:
+            throw new AssertionError(type);
+        }
+        return serial;
+    }
+
+    public static void generateWith(StringBuilder sb, YSQLGlobalState globalState, ExpectedErrors errors,
+            List<YSQLColumn> columnsToBeAdded, boolean isTemporaryTable) {
+        if (Randomly.getBoolean()) {
+            if (Randomly.getBoolean()) {
+                sb.append(" ");
+                // disabled https://github.com/yugabyte/yugabyte-db/issues/11357
+                // sb.append(" WITH (");
+                // ArrayList<StorageParameters> values = new ArrayList<>(Arrays.asList(StorageParameters.values()));
+                // errors.add("unrecognized parameter");
+                // errors.add("ALTER TABLE / ADD CONSTRAINT USING INDEX is not supported on partitioned tables");
+                // List<StorageParameters> subset = Randomly.nonEmptySubset(values);
+                // int i = 0;
+                // for (StorageParameters parameter : subset) {
+                // if (i++ != 0) {
+                // sb.append(", ");
+                // }
+                // sb.append(parameter.parameter);
+                // sb.append("=");
+                // sb.append(parameter.op.apply(globalState.getRandomly()));
+                // }
+                // sb.append(")");
+            } else {
+                sb.append(" WITHOUT OIDS ");
+            }
+        } else if (Randomly.getBoolean() && !isTemporaryTable) {
+            if (Randomly.getBoolean()) {
+                sb.append(" SPLIT INTO ");
+                sb.append(Randomly.smallNumber() + 1);
+                sb.append(" TABLETS ");
+
+                errors.add("cannot create colocated table with split option");
+                errors.add("columns must be present to split by number of tablets");
+                errors.add("option is not yet supported for hash partitioned tables");
+            } else {
+                sb.append(" SPLIT AT VALUES (");
+
+                errors.add("cannot create colocated table with split option");
+                errors.add("SPLIT AT option is not yet supported for hash partitioned tables");
+                errors.add("Cannot have duplicate split rows"); // just in case
+
+                boolean hasBoolean = false;
+                for (YSQLColumn column : columnsToBeAdded) {
+                    if (column.getType().equals(YSQLDataType.BOOLEAN)) {
+                        hasBoolean = true;
+                        break;
+                    }
+                }
+
+                int splits = hasBoolean ? 2 : Randomly.smallNumber() + 2;
+                long start = Randomly.smallNumber();
+                boolean[] bools = { false, true };
+                for (int i = 1; i <= splits; i++) {
+                    int size = columnsToBeAdded.size();
+                    int counter = 1;
+                    for (YSQLColumn c : columnsToBeAdded) {
+                        sb.append("(");
+                        switch (c.getType()) {
+                        case INT:
+                        case REAL:
+                            sb.append(YSQLConstant.createDoubleConstant(start));
+                        case FLOAT:
+                            sb.append(YSQLConstant.createIntConstant(start));
+                            break;
+                        case BOOLEAN:
+                            sb.append(YSQLConstant.createBooleanConstant(bools[i - 1]));
+                            break;
+                        case TEXT:
+                            sb.append(YSQLConstant.createTextConstant(String.valueOf(start)));
+                            break;
+                        default:
+                            throw new IgnoreMeException();
+                        }
+                        sb.append(")");
+                        counter++;
+                        start += Randomly.smallNumber() + 1;
+                        if (counter <= size) {
+                            sb.append(",");
+                        }
+                    }
+
+                    if (i < splits) {
+                        sb.append(",");
+                    }
+                }
+                sb.append(")");
+            }
+        } else if (Randomly.getBoolean()) {
+            errors.add("Cannot use TABLEGROUP with TEMP table");
+            sb.append(" TABLEGROUP tg").append(
+                    Randomly.getNotCachedInteger(1, (int) YSQLTableGroupGenerator.UNIQUE_TABLEGROUP_COUNTER.get()));
+        }
+    }
+
+    public static void addTableConstraints(boolean excludePrimaryKey, StringBuilder sb, YSQLTable table,
+            YSQLGlobalState globalState, ExpectedErrors errors) {
+        // TODO constraint name
+        List<TableConstraints> tableConstraints = Randomly.nonEmptySubset(TableConstraints.values());
+        if (excludePrimaryKey) {
+            tableConstraints.remove(TableConstraints.PRIMARY_KEY);
+        }
+        if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+            tableConstraints.remove(TableConstraints.FOREIGN_KEY);
+        }
+        for (TableConstraints t : tableConstraints) {
+            sb.append(", ");
+            // TODO add index parameters
+            addTableConstraint(sb, table, globalState, t, errors);
+        }
+    }
+
+    public static void addTableConstraint(StringBuilder sb, YSQLTable table, YSQLGlobalState globalState,
+            ExpectedErrors errors) {
+        addTableConstraint(sb, table, globalState, Randomly.fromOptions(TableConstraints.values()), errors);
+    }
+
+    private static void addTableConstraint(StringBuilder sb, YSQLTable table, YSQLGlobalState globalState,
+            TableConstraints t, ExpectedErrors errors) {
+        List<YSQLColumn> randomNonEmptyColumnSubset = table.getRandomNonEmptyColumnSubset();
+        List<YSQLColumn> otherColumns;
+        YSQLCommon.addCommonExpressionErrors(errors);
+        switch (t) {
+        case CHECK:
+            sb.append("CHECK(");
+            sb.append(YSQLVisitor.getExpressionAsString(globalState, YSQLDataType.BOOLEAN, table.getColumns()));
+            sb.append(")");
+            errors.add("constraint must be added to child tables too");
+            errors.add("missing FROM-clause entry for table");
+            break;
+        case UNIQUE:
+            sb.append("UNIQUE(");
+            sb.append(randomNonEmptyColumnSubset.stream().map(AbstractTableColumn::getName)
+                    .collect(Collectors.joining(", ")));
+            sb.append(")");
+            break;
+        case PRIMARY_KEY:
+            sb.append("PRIMARY KEY(");
+            sb.append(randomNonEmptyColumnSubset.stream().map(AbstractTableColumn::getName)
+                    .collect(Collectors.joining(", ")));
+            sb.append(")");
+            break;
+        case FOREIGN_KEY:
+            sb.append("FOREIGN KEY (");
+            sb.append(randomNonEmptyColumnSubset.stream().map(AbstractTableColumn::getName)
+                    .collect(Collectors.joining(", ")));
+            sb.append(") REFERENCES ");
+            YSQLTable randomOtherTable = globalState.getSchema().getRandomTable(tab -> !tab.isView());
+            sb.append(randomOtherTable.getName());
+            if (randomOtherTable.getColumns().size() < randomNonEmptyColumnSubset.size()) {
+                throw new IgnoreMeException();
+            }
+            otherColumns = randomOtherTable.getRandomNonEmptyColumnSubset(randomNonEmptyColumnSubset.size());
+            sb.append("(");
+            sb.append(otherColumns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
+            sb.append(")");
+            if (Randomly.getBoolean()) {
+                sb.append(" ");
+                sb.append(Randomly.fromOptions("MATCH FULL", "MATCH SIMPLE"));
+            }
+            if (Randomly.getBoolean()) {
+                sb.append(" ON DELETE ");
+                errors.add("ERROR: invalid ON DELETE action for foreign key constraint containing generated column");
+                deleteOrUpdateAction(sb);
+            }
+            if (Randomly.getBoolean()) {
+                sb.append(" ON UPDATE ");
+                errors.add("invalid ON UPDATE action for foreign key constraint containing generated column");
+                deleteOrUpdateAction(sb);
+            }
+            if (Randomly.getBoolean()) {
+                sb.append(" ");
+                if (Randomly.getBoolean()) {
+                    sb.append("DEFERRABLE");
+                    if (Randomly.getBoolean()) {
+                        sb.append(" ");
+                        sb.append(Randomly.fromOptions("INITIALLY DEFERRED", "INITIALLY IMMEDIATE"));
+                    }
+                } else {
+                    sb.append("NOT DEFERRABLE");
+                }
+            }
+            break;
+        default:
+            throw new AssertionError(t);
+        }
+    }
+
+    private static void deleteOrUpdateAction(StringBuilder sb) {
+        sb.append(Randomly.fromOptions("NO ACTION", "RESTRICT", "CASCADE", "SET NULL", "SET DEFAULT"));
+    }
+
+    public static void addGroupingErrors(ExpectedErrors errors) {
+        errors.add("non-integer constant in GROUP BY"); // TODO
+        errors.add("must appear in the GROUP BY clause or be used in an aggregate function");
+        errors.add("is not in select list");
+        errors.add("aggregate functions are not allowed in GROUP BY");
+    }
+
+    public static void addViewErrors(ExpectedErrors errors) {
+        errors.add("already exists");
+        errors.add("cannot drop columns from view");
+        errors.add("non-integer constant in ORDER BY"); // TODO
+        errors.add("for SELECT DISTINCT, ORDER BY expressions must appear in select list"); // TODO
+        errors.add("cannot change data type of view column");
+        errors.add("specified more than once"); // TODO
+        errors.add("materialized views must not use temporary tables or views");
+        errors.add("does not have the form non-recursive-term UNION [ALL] recursive-term");
+        errors.add("is not a view");
+        errors.add("non-integer constant in DISTINCT ON");
+        errors.add("SELECT DISTINCT ON expressions must match initial ORDER BY expressions");
+    }
+
+    public enum TableConstraints {
+        CHECK, UNIQUE, PRIMARY_KEY, FOREIGN_KEY
+    }
+
+    // private enum StorageParameters {
+    // COLOCATED("COLOCATED", (r) -> Randomly.getBoolean());
+    // // TODO
+    //
+    // private final String parameter;
+    // private final Function<Randomly, Object> op;
+    //
+    // StorageParameters(String parameter, Function<Randomly, Object> op) {
+    // this.parameter = parameter;
+    // this.op = op;
+    // }
+    // }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDeleteGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDeleteGenerator.java
@@ -1,0 +1,46 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+
+public final class YSQLDeleteGenerator {
+
+    private YSQLDeleteGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        YSQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("violates foreign key constraint");
+        errors.add("violates not-null constraint");
+        errors.add("could not determine which collation to use for string comparison");
+        StringBuilder sb = new StringBuilder("DELETE FROM");
+        if (Randomly.getBoolean()) {
+            sb.append(" ONLY");
+        }
+        sb.append(" ");
+        sb.append(table.getName());
+        if (Randomly.getBoolean()) {
+            sb.append(" WHERE ");
+            sb.append(YSQLVisitor.asString(
+                    YSQLExpressionGenerator.generateExpression(globalState, table.getColumns(), YSQLDataType.BOOLEAN)));
+        }
+        if (Randomly.getBoolean()) {
+            sb.append(" RETURNING ");
+            sb.append(
+                    YSQLVisitor.asString(YSQLExpressionGenerator.generateExpression(globalState, table.getColumns())));
+        }
+        YSQLCommon.addCommonExpressionErrors(errors);
+        errors.add("out of range");
+        errors.add("cannot cast");
+        errors.add("invalid input syntax for");
+        errors.add("division by zero");
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
@@ -1,0 +1,39 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable.TableType;
+
+public final class YSQLDiscardGenerator {
+
+    private YSQLDiscardGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DISCARD ");
+        // prevent that DISCARD discards all tables (if they are TEMP tables)
+        boolean hasNonTempTables = globalState.getSchema().getDatabaseTables().stream()
+                .anyMatch(t -> t.getTableType() == TableType.STANDARD);
+        String what;
+        if (hasNonTempTables) {
+            what = Randomly.fromOptions("ALL", "PLANS", "SEQUENCES", "TEMPORARY", "TEMP");
+        } else {
+            what = Randomly.fromOptions("PLANS", "SEQUENCES");
+        }
+        sb.append(what);
+        return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("cannot run inside a transaction block")) {
+
+            @Override
+            public boolean couldAffectSchema() {
+                return canDiscardTemporaryTables(what);
+            }
+        };
+    }
+
+    private static boolean canDiscardTemporaryTables(String what) {
+        return what.contentEquals("TEMPORARY") || what.contentEquals("TEMP") || what.contentEquals("ALL");
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDropIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDropIndexGenerator.java
@@ -1,0 +1,41 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLIndex;
+
+public final class YSQLDropIndexGenerator {
+
+    private YSQLDropIndexGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        List<YSQLIndex> indexes = globalState.getSchema().getRandomTable().getIndexes();
+        StringBuilder sb = new StringBuilder();
+        sb.append("DROP INDEX ");
+        if (Randomly.getBoolean() || indexes.isEmpty()) {
+            sb.append("IF EXISTS ");
+            if (indexes.isEmpty() || Randomly.getBoolean()) {
+                sb.append(DBMSCommon.createIndexName(Randomly.smallNumber()));
+            } else {
+                sb.append(Randomly.fromList(indexes).getIndexName());
+            }
+        } else {
+            sb.append(Randomly.fromList(indexes).getIndexName());
+        }
+        if (Randomly.getBoolean()) {
+            sb.append(" ");
+            sb.append(Randomly.fromOptions("CASCADE", "RESTRICT"));
+        }
+        return new SQLQueryAdapter(sb.toString(),
+                ExpectedErrors.from("cannot drop desired object(s) because other objects depend on them",
+                        "cannot drop index", "does not exist"),
+                true);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLExpressionGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLExpressionGenerator.java
@@ -1,0 +1,563 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.gen.ExpressionGenerator;
+import sqlancer.yugabyte.ysql.YSQLCompoundDataType;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLProvider;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLRowValue;
+import sqlancer.yugabyte.ysql.ast.YSQLAggregate;
+import sqlancer.yugabyte.ysql.ast.YSQLBetweenOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryArithmeticOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryBitOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryComparisonOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryLogicalOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLBinaryRangeOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLCastOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLColumnValue;
+import sqlancer.yugabyte.ysql.ast.YSQLConcatOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLFunction;
+import sqlancer.yugabyte.ysql.ast.YSQLFunctionWithUnknownResult;
+import sqlancer.yugabyte.ysql.ast.YSQLInOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLOrderByTerm;
+import sqlancer.yugabyte.ysql.ast.YSQLPOSIXRegularExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLSimilarTo;
+
+public class YSQLExpressionGenerator implements ExpressionGenerator<YSQLExpression> {
+
+    private final int maxDepth;
+
+    private final Randomly r;
+    private final Map<String, Character> functionsAndTypes;
+    private final List<Character> allowedFunctionTypes;
+    private List<YSQLColumn> columns;
+    private YSQLRowValue rw;
+    private boolean expectedResult;
+    private YSQLGlobalState globalState;
+    private boolean allowAggregateFunctions;
+
+    public YSQLExpressionGenerator(YSQLGlobalState globalState) {
+        this.r = globalState.getRandomly();
+        this.maxDepth = globalState.getOptions().getMaxExpressionDepth();
+        this.globalState = globalState;
+        this.functionsAndTypes = globalState.getFunctionsAndTypes();
+        this.allowedFunctionTypes = globalState.getAllowedFunctionTypes();
+    }
+
+    public static YSQLExpression generateExpression(YSQLGlobalState globalState, YSQLDataType type) {
+        return new YSQLExpressionGenerator(globalState).generateExpression(0, type);
+    }
+
+    private static YSQLCompoundDataType getCompoundDataType(YSQLDataType type) {
+        switch (type) {
+        case BOOLEAN:
+        case DECIMAL: // TODO
+        case FLOAT:
+        case INT:
+        case MONEY:
+        case RANGE:
+        case REAL:
+        case INET:
+        case BYTEA:
+            return YSQLCompoundDataType.create(type);
+        case TEXT: // TODO
+        case BIT:
+            if (Randomly.getBoolean()
+                    || YSQLProvider.generateOnlyKnown /*
+                                                       * The PQS implementation does not check for size specifications
+                                                       */) {
+                return YSQLCompoundDataType.create(type);
+            } else {
+                return YSQLCompoundDataType.create(type, (int) Randomly.getNotCachedInteger(1, 1000));
+            }
+        default:
+            throw new AssertionError(type);
+        }
+
+    }
+
+    public static YSQLExpression generateConstant(Randomly r, YSQLDataType type) {
+        if (Randomly.getBooleanWithSmallProbability()) {
+            return YSQLConstant.createNullConstant();
+        }
+        // if (Randomly.getBooleanWithSmallProbability()) {
+        // return YSQLConstant.createTextConstant(r.getString());
+        // }
+        switch (type) {
+        case INT:
+            if (Randomly.getBooleanWithSmallProbability()) {
+                return YSQLConstant.createTextConstant(String.valueOf(r.getInteger()));
+            } else {
+                return YSQLConstant.createIntConstant(r.getInteger());
+            }
+        case BOOLEAN:
+            if (Randomly.getBooleanWithSmallProbability() && !YSQLProvider.generateOnlyKnown) {
+                return YSQLConstant
+                        .createTextConstant(Randomly.fromOptions("TR", "TRUE", "FA", "FALSE", "0", "1", "ON", "off"));
+            } else {
+                return YSQLConstant.createBooleanConstant(Randomly.getBoolean());
+            }
+        case TEXT:
+            return YSQLConstant.createTextConstant(r.getString());
+        case DECIMAL:
+            return YSQLConstant.createDecimalConstant(r.getRandomBigDecimal());
+        case FLOAT:
+            return YSQLConstant.createFloatConstant((float) r.getDouble());
+        case REAL:
+            return YSQLConstant.createDoubleConstant(r.getDouble());
+        case RANGE:
+            return YSQLConstant.createRange(r.getInteger(), Randomly.getBoolean(), r.getInteger(),
+                    Randomly.getBoolean());
+        case MONEY:
+            return new YSQLCastOperation(generateConstant(r, YSQLDataType.FLOAT),
+                    getCompoundDataType(YSQLDataType.MONEY));
+        case INET:
+            return YSQLConstant.createInetConstant(getRandomInet(r));
+        case BIT:
+            return YSQLConstant.createBitConstant(r.getInteger());
+        case BYTEA:
+            return YSQLConstant.createByteConstant(String.valueOf(r.getInteger()));
+        default:
+            throw new AssertionError(type);
+        }
+    }
+
+    private static String getRandomInet(Randomly r) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 4; i++) {
+            if (i != 0) {
+                sb.append('.');
+            }
+            sb.append(r.getInteger() & 255);
+        }
+        return sb.toString();
+    }
+
+    public static YSQLExpression generateExpression(YSQLGlobalState globalState, List<YSQLColumn> columns,
+            YSQLDataType type) {
+        return new YSQLExpressionGenerator(globalState).setColumns(columns).generateExpression(0, type);
+    }
+
+    public static YSQLExpression generateExpression(YSQLGlobalState globalState, List<YSQLColumn> columns) {
+        return new YSQLExpressionGenerator(globalState).setColumns(columns).generateExpression(0);
+
+    }
+
+    public YSQLExpressionGenerator setColumns(List<YSQLColumn> columns) {
+        this.columns = columns;
+        return this;
+    }
+
+    public YSQLExpressionGenerator setRowValue(YSQLRowValue rw) {
+        this.rw = rw;
+        return this;
+    }
+
+    public YSQLExpression generateExpression(int depth) {
+        return generateExpression(depth, YSQLDataType.getRandomType());
+    }
+
+    public List<YSQLExpression> generateOrderBy() {
+        List<YSQLExpression> orderBys = new ArrayList<>();
+        for (int i = 0; i < Randomly.smallNumber(); i++) {
+            orderBys.add(new YSQLOrderByTerm(YSQLColumnValue.create(Randomly.fromList(columns), null),
+                    YSQLOrderByTerm.YSQLOrder.getRandomOrder()));
+        }
+        return orderBys;
+    }
+
+    private YSQLExpression generateFunctionWithUnknownResult(int depth, YSQLDataType type) {
+        List<YSQLFunctionWithUnknownResult> supportedFunctions = YSQLFunctionWithUnknownResult
+                .getSupportedFunctions(type);
+        // filters functions by allowed type (STABLE 's', IMMUTABLE 'i', VOLATILE 'v')
+        supportedFunctions = supportedFunctions.stream()
+                .filter(f -> allowedFunctionTypes.contains(functionsAndTypes.get(f.getName())))
+                .collect(Collectors.toList());
+        if (supportedFunctions.isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        YSQLFunctionWithUnknownResult randomFunction = Randomly.fromList(supportedFunctions);
+        return new YSQLFunction(randomFunction, type, randomFunction.getArguments(type, this, depth + 1));
+    }
+
+    private YSQLExpression generateFunctionWithKnownResult(int depth, YSQLDataType type) {
+        List<YSQLFunction.YSQLFunctionWithResult> functions = Stream.of(YSQLFunction.YSQLFunctionWithResult.values())
+                .filter(f -> f.supportsReturnType(type)).collect(Collectors.toList());
+        // filters functions by allowed type (STABLE 's', IMMUTABLE 'i', VOLATILE 'v')
+        functions = functions.stream().filter(f -> allowedFunctionTypes.contains(functionsAndTypes.get(f.getName())))
+                .collect(Collectors.toList());
+        if (functions.isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        YSQLFunction.YSQLFunctionWithResult randomFunction = Randomly.fromList(functions);
+        int nrArgs = randomFunction.getNrArgs();
+        if (randomFunction.isVariadic()) {
+            nrArgs += Randomly.smallNumber();
+        }
+        YSQLDataType[] argTypes = randomFunction.getInputTypesForReturnType(type, nrArgs);
+        YSQLExpression[] args = new YSQLExpression[nrArgs];
+        do {
+            for (int i = 0; i < args.length; i++) {
+                args[i] = generateExpression(depth + 1, argTypes[i]);
+            }
+        } while (!randomFunction.checkArguments(args));
+        return new YSQLFunction(randomFunction, type, args);
+    }
+
+    private YSQLExpression generateBooleanExpression(int depth) {
+        List<BooleanExpression> validOptions = new ArrayList<>(Arrays.asList(BooleanExpression.values()));
+        if (YSQLProvider.generateOnlyKnown) {
+            validOptions.remove(BooleanExpression.SIMILAR_TO);
+            validOptions.remove(BooleanExpression.POSIX_REGEX);
+            validOptions.remove(BooleanExpression.BINARY_RANGE_COMPARISON);
+        }
+        BooleanExpression option = Randomly.fromList(validOptions);
+        switch (option) {
+        case POSTFIX_OPERATOR:
+            YSQLPostfixOperation.PostfixOperator random = YSQLPostfixOperation.PostfixOperator.getRandom();
+            return YSQLPostfixOperation
+                    .create(generateExpression(depth + 1, Randomly.fromOptions(random.getInputDataTypes())), random);
+        case IN_OPERATION:
+            return inOperation(depth + 1);
+        case NOT:
+            return new YSQLPrefixOperation(generateExpression(depth + 1, YSQLDataType.BOOLEAN),
+                    YSQLPrefixOperation.PrefixOperator.NOT);
+        case BINARY_LOGICAL_OPERATOR:
+            YSQLExpression first = generateExpression(depth + 1, YSQLDataType.BOOLEAN);
+            int nr = Randomly.smallNumber() + 1;
+            for (int i = 0; i < nr; i++) {
+                first = new YSQLBinaryLogicalOperation(first, generateExpression(depth + 1, YSQLDataType.BOOLEAN),
+                        YSQLBinaryLogicalOperation.BinaryLogicalOperator.getRandom());
+            }
+            return first;
+        case BINARY_COMPARISON:
+            YSQLDataType dataType = getMeaningfulType();
+            return generateComparison(depth, dataType);
+        case CAST:
+            return new YSQLCastOperation(generateExpression(depth + 1), getCompoundDataType(YSQLDataType.BOOLEAN));
+        case FUNCTION:
+            return generateFunction(depth + 1, YSQLDataType.BOOLEAN);
+        case BETWEEN:
+            YSQLDataType type = getMeaningfulType();
+            return new YSQLBetweenOperation(generateExpression(depth + 1, type), generateExpression(depth + 1, type),
+                    generateExpression(depth + 1, type), Randomly.getBoolean());
+        case SIMILAR_TO:
+            assert !expectedResult;
+            // TODO also generate the escape character
+            return new YSQLSimilarTo(generateExpression(depth + 1, YSQLDataType.TEXT),
+                    generateExpression(depth + 1, YSQLDataType.TEXT), null);
+        case POSIX_REGEX:
+            assert !expectedResult;
+            return new YSQLPOSIXRegularExpression(generateExpression(depth + 1, YSQLDataType.TEXT),
+                    generateExpression(depth + 1, YSQLDataType.TEXT),
+                    YSQLPOSIXRegularExpression.POSIXRegex.getRandom());
+        case BINARY_RANGE_COMPARISON:
+            // TODO element check
+            return new YSQLBinaryRangeOperation(YSQLBinaryRangeOperation.YSQLBinaryRangeComparisonOperator.getRandom(),
+                    generateExpression(depth + 1, YSQLDataType.RANGE),
+                    generateExpression(depth + 1, YSQLDataType.RANGE));
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    private YSQLDataType getMeaningfulType() {
+        // make it more likely that the expression does not only consist of constant
+        // expressions
+        if (Randomly.getBooleanWithSmallProbability() || columns == null || columns.isEmpty()) {
+            return YSQLDataType.getRandomType();
+        } else {
+            return Randomly.fromList(columns).getType();
+        }
+    }
+
+    private YSQLExpression generateFunction(int depth, YSQLDataType type) {
+        if (YSQLProvider.generateOnlyKnown || Randomly.getBoolean()) {
+            return generateFunctionWithKnownResult(depth, type);
+        } else {
+            return generateFunctionWithUnknownResult(depth, type);
+        }
+    }
+
+    private YSQLExpression generateComparison(int depth, YSQLDataType dataType) {
+        YSQLExpression leftExpr = generateExpression(depth + 1, dataType);
+        YSQLExpression rightExpr = generateExpression(depth + 1, dataType);
+        return getComparison(leftExpr, rightExpr);
+    }
+
+    private YSQLExpression getComparison(YSQLExpression leftExpr, YSQLExpression rightExpr) {
+        return new YSQLBinaryComparisonOperation(leftExpr, rightExpr,
+                YSQLBinaryComparisonOperation.YSQLBinaryComparisonOperator.getRandom());
+    }
+
+    private YSQLExpression inOperation(int depth) {
+        YSQLDataType type = YSQLDataType.getRandomType();
+        YSQLExpression leftExpr = generateExpression(depth + 1, type);
+        List<YSQLExpression> rightExpr = new ArrayList<>();
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            rightExpr.add(generateExpression(depth + 1, type));
+        }
+        return new YSQLInOperation(leftExpr, rightExpr, Randomly.getBoolean());
+    }
+
+    public YSQLExpression generateExpression(int depth, YSQLDataType originalType) {
+        YSQLDataType dataType = originalType;
+        if (dataType == YSQLDataType.REAL && Randomly.getBoolean()) {
+            dataType = Randomly.fromOptions(YSQLDataType.INT, YSQLDataType.FLOAT);
+        }
+        if (dataType == YSQLDataType.FLOAT && Randomly.getBoolean()) {
+            dataType = YSQLDataType.INT;
+        }
+        return generateExpressionInternal(depth, dataType);
+    }
+
+    private YSQLExpression generateExpressionInternal(int depth, YSQLDataType dataType) throws AssertionError {
+        if (allowAggregateFunctions && Randomly.getBoolean()) {
+            allowAggregateFunctions = false; // aggregate function calls cannot be nested
+            return getAggregate(dataType);
+        }
+        if (Randomly.getBooleanWithRatherLowProbability() || depth > maxDepth) {
+            // generic expression
+            if (Randomly.getBoolean() || depth > maxDepth) {
+                if (Randomly.getBooleanWithRatherLowProbability()) {
+                    return generateConstant(r, dataType);
+                } else {
+                    if (filterColumns(dataType).isEmpty()) {
+                        return generateConstant(r, dataType);
+                    } else {
+                        return createColumnOfType(dataType);
+                    }
+                }
+            } else {
+                if (Randomly.getBoolean()) {
+                    return new YSQLCastOperation(generateExpression(depth + 1), getCompoundDataType(dataType));
+                } else {
+                    return generateFunctionWithUnknownResult(depth, dataType);
+                }
+            }
+        } else {
+            switch (dataType) {
+            case BOOLEAN:
+                return generateBooleanExpression(depth);
+            case INT:
+                return generateIntExpression(depth);
+            case TEXT:
+                return generateTextExpression(depth);
+            case DECIMAL:
+            case REAL:
+            case FLOAT:
+            case MONEY:
+            case INET:
+                return generateConstant(r, dataType);
+            case BYTEA:
+                return generateByteExpression();
+            case BIT:
+                return generateBitExpression(depth);
+            case RANGE:
+                return generateRangeExpression(depth);
+            default:
+                throw new AssertionError(dataType);
+            }
+        }
+    }
+
+    private YSQLExpression generateRangeExpression(int depth) {
+        RangeExpression option;
+        List<RangeExpression> validOptions = new ArrayList<>(Arrays.asList(RangeExpression.values()));
+        option = Randomly.fromList(validOptions);
+        switch (option) {
+        case BINARY_OP:
+            return new YSQLBinaryRangeOperation(YSQLBinaryRangeOperation.YSQLBinaryRangeOperator.getRandom(),
+                    generateExpression(depth + 1, YSQLDataType.RANGE),
+                    generateExpression(depth + 1, YSQLDataType.RANGE));
+        default:
+            throw new AssertionError(option);
+        }
+    }
+
+    private YSQLExpression generateTextExpression(int depth) {
+        TextExpression option;
+        List<TextExpression> validOptions = new ArrayList<>(Arrays.asList(TextExpression.values()));
+        option = Randomly.fromList(validOptions);
+
+        switch (option) {
+        case CAST:
+            return new YSQLCastOperation(generateExpression(depth + 1), getCompoundDataType(YSQLDataType.TEXT));
+        case FUNCTION:
+            return generateFunction(depth + 1, YSQLDataType.TEXT);
+        case CONCAT:
+            return generateConcat(depth);
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    private YSQLExpression generateConcat(int depth) {
+        YSQLExpression left = generateExpression(depth + 1, YSQLDataType.TEXT);
+        YSQLExpression right = generateExpression(depth + 1);
+        return new YSQLConcatOperation(left, right);
+    }
+
+    private YSQLExpression generateByteExpression() {
+        return YSQLConstant.createByteConstant("Th\\000omas");
+    }
+
+    private YSQLExpression generateBitExpression(int depth) {
+        BitExpression option;
+        option = Randomly.fromOptions(BitExpression.values());
+        switch (option) {
+        case BINARY_OPERATION:
+            return new YSQLBinaryBitOperation(YSQLBinaryBitOperation.YSQLBinaryBitOperator.getRandom(),
+                    generateExpression(depth + 1, YSQLDataType.BIT), generateExpression(depth + 1, YSQLDataType.BIT));
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    private YSQLExpression generateIntExpression(int depth) {
+        IntExpression option;
+        option = Randomly.fromOptions(IntExpression.values());
+        switch (option) {
+        case CAST:
+            return new YSQLCastOperation(generateExpression(depth + 1), getCompoundDataType(YSQLDataType.INT));
+        case UNARY_OPERATION:
+            YSQLExpression intExpression = generateExpression(depth + 1, YSQLDataType.INT);
+            return new YSQLPrefixOperation(intExpression, Randomly.getBoolean()
+                    ? YSQLPrefixOperation.PrefixOperator.UNARY_PLUS : YSQLPrefixOperation.PrefixOperator.UNARY_MINUS);
+        case FUNCTION:
+            return generateFunction(depth + 1, YSQLDataType.INT);
+        case BINARY_ARITHMETIC_EXPRESSION:
+            return new YSQLBinaryArithmeticOperation(generateExpression(depth + 1, YSQLDataType.INT),
+                    generateExpression(depth + 1, YSQLDataType.INT),
+                    YSQLBinaryArithmeticOperation.YSQLBinaryOperator.getRandom());
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    private YSQLExpression createColumnOfType(YSQLDataType type) {
+        List<YSQLColumn> columns = filterColumns(type);
+        YSQLColumn fromList = Randomly.fromList(columns);
+        YSQLConstant value = rw == null ? null : rw.getValues().get(fromList);
+        return YSQLColumnValue.create(fromList, value);
+    }
+
+    final List<YSQLColumn> filterColumns(YSQLDataType type) {
+        if (columns == null) {
+            return Collections.emptyList();
+        } else {
+            return columns.stream().filter(c -> c.getType() == type).collect(Collectors.toList());
+        }
+    }
+
+    public YSQLExpression generateExpressionWithExpectedResult(YSQLDataType type) {
+        this.expectedResult = true;
+        YSQLExpressionGenerator gen = new YSQLExpressionGenerator(globalState).setColumns(columns).setRowValue(rw);
+        YSQLExpression expr;
+        do {
+            expr = gen.generateExpression(type);
+        } while (expr.getExpectedValue() == null);
+        return expr;
+    }
+
+    public List<YSQLExpression> generateExpressions(int nr) {
+        List<YSQLExpression> expressions = new ArrayList<>();
+        for (int i = 0; i < nr; i++) {
+            expressions.add(generateExpression(0));
+        }
+        return expressions;
+    }
+
+    public YSQLExpression generateExpression(YSQLDataType dataType) {
+        return generateExpression(0, dataType);
+    }
+
+    public YSQLExpressionGenerator setGlobalState(YSQLGlobalState globalState) {
+        this.globalState = globalState;
+        return this;
+    }
+
+    public YSQLExpression generateHavingClause() {
+        this.allowAggregateFunctions = true;
+        YSQLExpression expression = generateExpression(YSQLDataType.BOOLEAN);
+        this.allowAggregateFunctions = false;
+        return expression;
+    }
+
+    public YSQLExpression generateAggregate() {
+        return getAggregate(YSQLDataType.getRandomType());
+    }
+
+    private YSQLExpression getAggregate(YSQLDataType dataType) {
+        List<YSQLAggregate.YSQLAggregateFunction> aggregates = YSQLAggregate.YSQLAggregateFunction
+                .getAggregates(dataType);
+        YSQLAggregate.YSQLAggregateFunction agg = Randomly.fromList(aggregates);
+        return generateArgsForAggregate(dataType, agg);
+    }
+
+    public YSQLAggregate generateArgsForAggregate(YSQLDataType dataType, YSQLAggregate.YSQLAggregateFunction agg) {
+        List<YSQLDataType> types = agg.getTypes(dataType);
+        List<YSQLExpression> args = new ArrayList<>();
+        for (YSQLDataType argType : types) {
+            args.add(generateExpression(argType));
+        }
+        return new YSQLAggregate(args, agg);
+    }
+
+    public YSQLExpressionGenerator allowAggregates(boolean value) {
+        allowAggregateFunctions = value;
+        return this;
+    }
+
+    @Override
+    public YSQLExpression generatePredicate() {
+        return generateExpression(YSQLDataType.BOOLEAN);
+    }
+
+    @Override
+    public YSQLExpression negatePredicate(YSQLExpression predicate) {
+        return new YSQLPrefixOperation(predicate, YSQLPrefixOperation.PrefixOperator.NOT);
+    }
+
+    @Override
+    public YSQLExpression isNull(YSQLExpression expr) {
+        return new YSQLPostfixOperation(expr, YSQLPostfixOperation.PostfixOperator.IS_NULL);
+    }
+
+    private enum BooleanExpression {
+        POSTFIX_OPERATOR, NOT, BINARY_LOGICAL_OPERATOR, BINARY_COMPARISON, FUNCTION, CAST, BETWEEN, IN_OPERATION,
+        SIMILAR_TO, POSIX_REGEX, BINARY_RANGE_COMPARISON
+    }
+
+    private enum RangeExpression {
+        BINARY_OP
+    }
+
+    private enum TextExpression {
+        CAST, FUNCTION, CONCAT
+    }
+
+    private enum BitExpression {
+        BINARY_OPERATION
+    }
+
+    private enum IntExpression {
+        UNARY_OPERATION, FUNCTION, CAST, BINARY_ARITHMETIC_EXPRESSION
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
@@ -1,0 +1,153 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLIndex;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+
+public final class YSQLIndexGenerator {
+
+    private YSQLIndexGenerator() {
+    }
+
+    public static SQLQueryAdapter generate(YSQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE");
+        if (Randomly.getBoolean()) {
+            sb.append(" UNIQUE");
+        }
+        sb.append(" INDEX ");
+        /*
+         * Commented out as a workaround for https://www.postgresql.org/message-id/CA%2Bu7OA4XYhc-
+         * qyCgJqwwgMGZDWAyeH821oa5oMzm_HEifZ4BeA%40mail.gmail.com
+         */
+        // if (Randomly.getBoolean()) {
+        // sb.append("CONCURRENTLY ");
+        // }
+        YSQLTable randomTable = globalState.getSchema().getRandomTable(t -> !t.isView()); // TODO: materialized
+        // views
+        String indexName = getNewIndexName(randomTable);
+        sb.append(indexName);
+        sb.append(" ON ");
+        if (Randomly.getBoolean()) {
+            sb.append("ONLY ");
+        }
+        sb.append(randomTable.getName());
+        IndexType method;
+        if (Randomly.getBoolean()) {
+            sb.append(" USING ");
+            method = Randomly.fromOptions(IndexType.values());
+            sb.append(method);
+        } else {
+            method = IndexType.BTREE;
+        }
+
+        sb.append("(");
+        if (method == IndexType.HASH) {
+            sb.append(randomTable.getRandomColumn().getName());
+        } else {
+            for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+                if (i != 0) {
+                    sb.append(", ");
+                }
+                if (Randomly.getBoolean()) {
+                    sb.append(randomTable.getRandomColumn().getName());
+                } else {
+                    sb.append("(");
+                    YSQLExpression expression = YSQLExpressionGenerator.generateExpression(globalState,
+                            randomTable.getColumns());
+                    sb.append(YSQLVisitor.asString(expression));
+                    sb.append(")");
+                }
+
+                // if (Randomly.getBoolean()) {
+                // sb.append(" ");
+                // sb.append("COLLATE ");
+                // sb.append(Randomly.fromOptions("C", "POSIX"));
+                // }
+                if (Randomly.getBooleanWithRatherLowProbability()) {
+                    sb.append(" ");
+                    sb.append(globalState.getRandomOpclass());
+                    errors.add("does not accept");
+                    errors.add("does not exist for access method");
+                }
+                if (Randomly.getBoolean()) {
+                    sb.append(" ");
+                    sb.append(Randomly.fromOptions("ASC", "DESC"));
+                }
+                if (Randomly.getBooleanWithRatherLowProbability()) {
+                    sb.append(" NULLS ");
+                    sb.append(Randomly.fromOptions("FIRST", "LAST"));
+                }
+            }
+        }
+
+        sb.append(")");
+        if (Randomly.getBoolean() && method != IndexType.HASH) {
+            sb.append(" INCLUDE(");
+            List<YSQLColumn> columns = randomTable.getRandomNonEmptyColumnSubset();
+            sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
+            sb.append(")");
+        }
+        if (Randomly.getBoolean()) {
+            sb.append(" WHERE ");
+            YSQLExpression expr = new YSQLExpressionGenerator(globalState).setColumns(randomTable.getColumns())
+                    .setGlobalState(globalState).generateExpression(YSQLDataType.BOOLEAN);
+            sb.append(YSQLVisitor.asString(expr));
+        }
+        errors.add("already contains data"); // CONCURRENT INDEX failed
+        errors.add("You might need to add explicit type casts");
+        errors.add("INDEX on column of type");
+        errors.add("collations are not supported"); // TODO check
+        errors.add("because it has pending trigger events");
+        errors.add("duplicate key value violates unique constraint");
+        errors.add("could not determine which collation to use for");
+        errors.add("index method \"gist\" not supported yet");
+        errors.add("is duplicated");
+        errors.add("already exists");
+        errors.add("could not create unique index");
+        errors.add("has no default operator class");
+        errors.add("does not support");
+        errors.add("cannot cast");
+        errors.add("unsupported UNIQUE constraint with partition key definition");
+        errors.add("insufficient columns in UNIQUE constraint definition");
+        errors.add("invalid input syntax for");
+        errors.add("must be type ");
+        errors.add("integer out of range");
+        errors.add("division by zero");
+        errors.add("out of range");
+        errors.add("functions in index predicate must be marked IMMUTABLE");
+        errors.add("functions in index expression must be marked IMMUTABLE");
+        errors.add("result of range difference would not be contiguous");
+        errors.add("which is part of the partition key");
+        YSQLCommon.addCommonExpressionErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+    private static String getNewIndexName(YSQLTable randomTable) {
+        List<YSQLIndex> indexes = randomTable.getIndexes();
+        int indexI = 0;
+        while (true) {
+            String indexName = DBMSCommon.createIndexName(indexI++);
+            if (indexes.stream().noneMatch(i -> i.getIndexName().equals(indexName))) {
+                return indexName;
+            }
+        }
+    }
+
+    public enum IndexType {
+        BTREE, HASH, GIST, GIN
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLInsertGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLInsertGenerator.java
@@ -1,0 +1,127 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+
+public final class YSQLInsertGenerator {
+
+    private YSQLInsertGenerator() {
+    }
+
+    public static SQLQueryAdapter insert(YSQLGlobalState globalState) {
+        YSQLTable table = globalState.getSchema().getRandomTable(YSQLTable::isInsertable);
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("cannot insert into column");
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonInsertUpdateErrors(errors);
+        YSQLCommon.addCommonExpressionErrors(errors);
+        errors.add("multiple assignments to same column");
+        errors.add("violates foreign key constraint");
+        errors.add("value too long for type character varying");
+        errors.add("conflicting key value violates exclusion constraint");
+        errors.add("violates not-null constraint");
+        errors.add("current transaction is aborted");
+        errors.add("bit string too long");
+        errors.add("new row violates check option for view");
+        errors.add("reached maximum value of sequence");
+        errors.add("but expression is of type");
+        StringBuilder sb = new StringBuilder();
+        sb.append("INSERT INTO ");
+        sb.append(table.getName());
+        List<YSQLColumn> columns = table.getRandomNonEmptyColumnSubset();
+        sb.append("(");
+        sb.append(columns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
+        sb.append(")");
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" OVERRIDING");
+            sb.append(" ");
+            sb.append(Randomly.fromOptions("SYSTEM", "USER"));
+            sb.append(" VALUE");
+        }
+        sb.append(" VALUES");
+
+        if (globalState.getDbmsSpecificOptions().allowBulkInsert && Randomly.getBooleanWithSmallProbability()) {
+            StringBuilder sbRowValue = new StringBuilder();
+            sbRowValue.append("(");
+            for (int i = 0; i < columns.size(); i++) {
+                if (i != 0) {
+                    sbRowValue.append(", ");
+                }
+                sbRowValue.append(YSQLVisitor.asString(
+                        YSQLExpressionGenerator.generateConstant(globalState.getRandomly(), columns.get(i).getType())));
+            }
+            sbRowValue.append(")");
+
+            int n = (int) Randomly.getNotCachedInteger(100, 1000);
+            for (int i = 0; i < n; i++) {
+                if (i != 0) {
+                    sb.append(", ");
+                }
+                sb.append(sbRowValue);
+            }
+        } else {
+            int n = Randomly.smallNumber() + 1;
+            for (int i = 0; i < n; i++) {
+                if (i != 0) {
+                    sb.append(", ");
+                }
+                insertRow(globalState, sb, columns, n == 1);
+            }
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" ON CONFLICT ");
+            if (Randomly.getBoolean()) {
+                sb.append("(");
+                sb.append(table.getRandomColumn().getName());
+                sb.append(")");
+                errors.add("there is no unique or exclusion constraint matching the ON CONFLICT specification");
+            }
+            sb.append(" DO NOTHING");
+        }
+        errors.add("duplicate key value violates unique constraint");
+        errors.add("identity column defined as GENERATED ALWAYS");
+        errors.add("out of range");
+        errors.add("violates check constraint");
+        errors.add("no partition of relation");
+        errors.add("invalid input syntax");
+        errors.add("division by zero");
+        errors.add("violates foreign key constraint");
+        errors.add("data type unknown");
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+    private static void insertRow(YSQLGlobalState globalState, StringBuilder sb, List<YSQLColumn> columns,
+            boolean canBeDefault) {
+        sb.append("(");
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            if (!Randomly.getBooleanWithSmallProbability() || !canBeDefault) {
+                YSQLExpression generateConstant;
+                if (Randomly.getBoolean()) {
+                    generateConstant = YSQLExpressionGenerator.generateConstant(globalState.getRandomly(),
+                            columns.get(i).getType());
+                } else {
+                    generateConstant = new YSQLExpressionGenerator(globalState)
+                            .generateExpression(columns.get(i).getType());
+                }
+                sb.append(YSQLVisitor.asString(generateConstant));
+            } else {
+                sb.append("DEFAULT");
+            }
+        }
+        sb.append(")");
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLNotifyGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLNotifyGenerator.java
@@ -1,0 +1,45 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+
+public final class YSQLNotifyGenerator {
+
+    private YSQLNotifyGenerator() {
+    }
+
+    private static String getChannel() {
+        return Randomly.fromOptions("asdf", "test");
+    }
+
+    public static SQLQueryAdapter createNotify(YSQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("NOTIFY ");
+        sb.append(getChannel());
+        if (Randomly.getBoolean()) {
+            sb.append(", ");
+            sb.append("'");
+            sb.append(globalState.getRandomly().getString().replace("'", "''"));
+            sb.append("'");
+        }
+        return new SQLQueryAdapter(sb.toString());
+    }
+
+    public static SQLQueryAdapter createListen() {
+        String sb = "LISTEN " + getChannel();
+        return new SQLQueryAdapter(sb);
+    }
+
+    public static SQLQueryAdapter createUnlisten() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("UNLISTEN ");
+        if (Randomly.getBoolean()) {
+            sb.append(getChannel());
+        } else {
+            sb.append("*");
+        }
+        return new SQLQueryAdapter(sb.toString());
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLRandomQueryGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLRandomQueryGenerator.java
@@ -1,0 +1,62 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTables;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.ForClause;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.SelectType;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect.YSQLFromTable;
+
+public final class YSQLRandomQueryGenerator {
+
+    private YSQLRandomQueryGenerator() {
+    }
+
+    public static YSQLSelect createRandomQuery(int nrColumns, YSQLGlobalState globalState) {
+        List<YSQLExpression> columns = new ArrayList<>();
+        YSQLTables tables = globalState.getSchema().getRandomTableNonEmptyTables();
+        YSQLExpressionGenerator gen = new YSQLExpressionGenerator(globalState).setColumns(tables.getColumns());
+        for (int i = 0; i < nrColumns; i++) {
+            columns.add(gen.generateExpression(0));
+        }
+        YSQLSelect select = new YSQLSelect();
+        select.setSelectType(SelectType.getRandom());
+        if (select.getSelectOption() == SelectType.DISTINCT && Randomly.getBoolean()) {
+            select.setDistinctOnClause(gen.generateExpression(0));
+        }
+        select.setFromList(tables.getTables().stream().map(t -> new YSQLFromTable(t, Randomly.getBoolean()))
+                .collect(Collectors.toList()));
+        select.setFetchColumns(columns);
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression(0, YSQLDataType.BOOLEAN));
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
+            if (Randomly.getBoolean()) {
+                select.setHavingClause(gen.generateHavingClause());
+            }
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByExpressions(gen.generateOrderBy());
+        }
+        if (Randomly.getBoolean()) {
+            select.setLimitClause(YSQLConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
+            if (Randomly.getBoolean()) {
+                select.setOffsetClause(YSQLConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
+            }
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setForClause(ForClause.getRandom());
+        }
+        return select;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLReindexGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLReindexGenerator.java
@@ -1,0 +1,58 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLIndex;
+
+public final class YSQLReindexGenerator {
+
+    private YSQLReindexGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("could not create unique index"); // CONCURRENT INDEX
+        StringBuilder sb = new StringBuilder();
+        sb.append("REINDEX");
+        // if (Randomly.getBoolean()) {
+        // sb.append(" VERBOSE");
+        // }
+        sb.append(" ");
+        Scope scope = Randomly.fromOptions(Scope.values());
+        switch (scope) {
+        case INDEX:
+            sb.append("INDEX ");
+            List<YSQLIndex> indexes = globalState.getSchema().getRandomTable().getIndexes();
+            if (indexes.isEmpty()) {
+                throw new IgnoreMeException();
+            }
+            sb.append(indexes.stream().map(YSQLIndex::getIndexName).collect(Collectors.joining()));
+            break;
+        case TABLE:
+            sb.append("TABLE ");
+            sb.append(globalState.getSchema().getRandomTable(t -> !t.isView()).getName());
+            break;
+        case DATABASE:
+            sb.append("DATABASE ");
+            sb.append(globalState.getSchema().getDatabaseName());
+            break;
+        default:
+            throw new AssertionError(scope);
+        }
+        errors.add("already contains data"); // FIXME bug report
+        errors.add("does not exist"); // internal index
+        errors.add("REINDEX is not yet implemented for partitioned indexes");
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+    private enum Scope {
+        INDEX, TABLE, DATABASE
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLSequenceGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLSequenceGenerator.java
@@ -1,0 +1,90 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+
+public final class YSQLSequenceGenerator {
+
+    private YSQLSequenceGenerator() {
+    }
+
+    public static SQLQueryAdapter createSequence(YSQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder("CREATE");
+        if (Randomly.getBoolean()) {
+            sb.append(" ");
+            sb.append(Randomly.fromOptions("TEMPORARY", "TEMP"));
+        }
+        sb.append(" SEQUENCE");
+        // TODO keep track of sequences
+        sb.append(" IF NOT EXISTS");
+        // TODO generate sequence names
+        sb.append(" seq");
+        if (Randomly.getBoolean()) {
+            sb.append(" AS ");
+            sb.append(Randomly.fromOptions("smallint", "integer", "bigint"));
+        }
+        if (Randomly.getBoolean()) {
+            sb.append(" INCREMENT");
+            if (Randomly.getBoolean()) {
+                sb.append(" BY");
+            }
+            sb.append(" ");
+            sb.append(globalState.getRandomly().getInteger());
+            errors.add("INCREMENT must not be zero");
+        }
+        if (Randomly.getBoolean()) {
+            if (Randomly.getBoolean()) {
+                sb.append(" MINVALUE");
+                sb.append(" ");
+                sb.append(globalState.getRandomly().getInteger());
+            } else {
+                sb.append(" NO MINVALUE");
+            }
+            errors.add("must be less than MAXVALUE");
+        }
+        if (Randomly.getBoolean()) {
+            if (Randomly.getBoolean()) {
+                sb.append(" MAXVALUE");
+                sb.append(" ");
+                sb.append(globalState.getRandomly().getInteger());
+            } else {
+                sb.append(" NO MAXVALUE");
+            }
+            errors.add("must be less than MAXVALUE");
+        }
+        if (Randomly.getBoolean()) {
+            sb.append(" START");
+            if (Randomly.getBoolean()) {
+                sb.append(" WITH");
+            }
+            sb.append(" ");
+            sb.append(globalState.getRandomly().getInteger());
+            errors.add("cannot be less than MINVALUE");
+            errors.add("cannot be greater than MAXVALUE");
+        }
+        if (Randomly.getBoolean()) {
+            sb.append(" CACHE ");
+            sb.append(globalState.getRandomly().getPositiveIntegerNotNull());
+        }
+        errors.add("is out of range");
+        if (Randomly.getBoolean()) {
+            if (Randomly.getBoolean()) {
+                sb.append(" NO");
+            }
+            sb.append(" CYCLE");
+        }
+        if (Randomly.getBoolean()) {
+            sb.append(" OWNED BY ");
+            // if (Randomly.getBoolean()) {
+            sb.append("NONE");
+            // } else {
+            // sb.append(s.getRandomTable().getRandomColumn().getFullQualifiedName());
+            // }
+        }
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLSetGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLSetGenerator.java
@@ -1,0 +1,196 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Function;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+
+public final class YSQLSetGenerator {
+
+    private YSQLSetGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder();
+        ArrayList<ConfigurationOption> options = new ArrayList<>(Arrays.asList(ConfigurationOption.values()));
+        options.remove(ConfigurationOption.DEFAULT_WITH_OIDS);
+        ConfigurationOption option = Randomly.fromList(options);
+        sb.append("SET ");
+        if (Randomly.getBoolean()) {
+            sb.append(Randomly.fromOptions("SESSION", "LOCAL"));
+            sb.append(" ");
+        }
+        sb.append(option.getOptionName());
+        sb.append("=");
+        if (Randomly.getBoolean()) {
+            sb.append("DEFAULT");
+        } else {
+            sb.append(option.op.apply(globalState.getRandomly()));
+        }
+        // todo avoiding props that are not represented in YSQL
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("unrecognized configuration parameter");
+        errors.add("cannot be changed");
+
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+    private enum ConfigurationOption {
+        // YUGABYTE
+        YB_DEBUG_REPORT_ERROR_STACKTRACE("yb_debug_report_error_stacktrace",
+                (r) -> Randomly.fromOptions("false", "true")),
+        YB_DEBUG_LOG_CATCACHE_EVENTS("yb_debug_log_catcache_events", (r) -> Randomly.fromOptions("false", "true")),
+        YB_DEBUG_LOG_INTERNAL_RESTARTS("yb_debug_log_internal_restarts", (r) -> Randomly.fromOptions("false", "true")),
+        YB_DEBUG_LOG_DOCDB_REQUESTS("yb_debug_log_docdb_requests", (r) -> Randomly.fromOptions("false", "true")),
+        // YB_READ_FROM_FOLLOWERS("yb_read_from_followers", (r) -> Randomly.fromOptions("false", "true")),
+        YB_NON_DDL_TXN_FOR_SYS_TABLES_ALLOWED("yb_non_ddl_txn_for_sys_tables_allowed",
+                (r) -> Randomly.fromOptions("false", "true")),
+        YB_TRANSACTION_PRIORITY("yb_transaction_priority",
+                (r) -> Randomly.fromOptions(0, 0.1, 0.2, 0.3, 0.4, 1, 0.9, 0.8, 0.7, 0.6)),
+        YB_TRANSACTION_PRIORITY_LOWER_BOUND("yb_transaction_priority_lower_bound",
+                (r) -> Randomly.fromOptions(0, 0.1, 0.2, 0.3, 0.4)),
+        YB_TRANSACTION_PRIORITY_UPPER_BOUND("yb_transaction_priority_upper_bound",
+                (r) -> Randomly.fromOptions(1, 0.9, 0.8, 0.7, 0.6)),
+        YB_FORMAT_FUNCS_INCLUDE_YB_METADATA("yb_format_funcs_include_yb_metadata",
+                (r) -> Randomly.fromOptions("false", "true")),
+        YB_ENABLE_GEOLOCATION_COSTING("yb_enable_geolocation_costing", (r) -> Randomly.fromOptions("false", "true")),
+        YB_BINARY_RESTORE("yb_binary_restore", (r) -> Randomly.fromOptions("false", "true")),
+        YB_TEST_SYSTEM_CATALOGS_CREATION("yb_test_system_catalogs_creation",
+                (r) -> Randomly.fromOptions("false", "true")),
+        YB_TEST_FAIL_NEXT_DDL("yb_test_fail_next_ddl", (r) -> Randomly.fromOptions("false", "true")),
+        YB_DISABLE_TRANSACTIONAL_WRITES("yb_disable_transactional_writes",
+                (r) -> Randomly.fromOptions("false", "true")),
+        YB_ENABLE_OPTIMIZER_STATISTICS("yb_enable_optimizer_statistics", (r) -> Randomly.fromOptions("false", "true")),
+        YB_ENABLE_EXPRESSION_PUSHDOWN("yb_enable_expression_pushdown", (r) -> Randomly.fromOptions("false", "true")),
+        YB_ENABLE_UPSERT_MODE("yb_enable_upsert_mode", (r) -> Randomly.fromOptions("false", "true")),
+        YB_PLANNER_CUSTOM_PLAN_FOR_PARTITION_PRUNING("yb_planner_custom_plan_for_partition_pruning",
+                (r) -> Randomly.fromOptions("false", "true")),
+        YB_INDEX_STATE_FLAGS_UPDATE_DELAY("yb_index_state_flags_update_delay",
+                (r) -> Randomly.getNotCachedInteger(200, 1000)),
+        YB_TEST_PLANNER_CUSTOM_PLAN_THRESHOLD("yb_test_planner_custom_plan_threshold",
+                (r) -> Randomly.getNotCachedInteger(1, Integer.MAX_VALUE)),
+        // YSQL values
+        YSQL_UPGRADE_MODE("ysql_upgrade_mode", (r) -> Randomly.fromOptions("false", "true")),
+        YSQL_SESSION_MAX_BATCH_SIZE("ysql_session_max_batch_size",
+                (r) -> Randomly.getNotCachedInteger(1, Integer.MAX_VALUE)),
+        YSQL_MAX_IN_FLIGHT_OPS("ysql_max_in_flight_ops", (r) -> Randomly.getNotCachedInteger(1, Integer.MAX_VALUE)),
+        // https://www.postgresql.org/docs/11/runtime-config-wal.html
+        // This parameter can only be set at server start.
+        // WAL_LEVEL("wal_level", (r) -> Randomly.fromOptions("replica", "minimal", "logical")),
+        // FSYNC("fsync", (r) -> Randomly.fromOptions(1, 0)),
+        SYNCHRONOUS_COMMIT("synchronous_commit",
+                (r) -> Randomly.fromOptions("remote_apply", "remote_write", "local", "off")),
+        WAL_COMPRESSION("wal_compression", (r) -> Randomly.fromOptions(1, 0)),
+        // wal_buffer: server start
+        // wal_writer_delay: server start
+        // wal_writer_flush_after
+        COMMIT_DELAY("commit_delay", (r) -> r.getInteger(0, 100000)),
+        COMMIT_SIBLINGS("commit_siblings", (r) -> r.getInteger(0, 1000)),
+        // 19.5.2. Checkpoints
+        // checkpoint_timeout
+        // checkpoint_completion_target
+        // checkpoint_flush_after
+        // checkpoint_warning
+        // max_wal_size
+        // min_wal_size
+        // 19.5.3. Archiving
+        // archive_mode
+        // archive_command
+        // archive_timeout
+        // https://www.postgresql.org/docs/11/runtime-config-statistics.html
+        // 19.9.1. Query and Index Statistics Collector
+        TRACK_ACTIVITIES("track_activities", (r) -> Randomly.fromOptions(1, 0)),
+        // track_activity_query_size
+        TRACK_COUNTS("track_counts", (r) -> Randomly.fromOptions(1, 0)),
+        TRACK_IO_TIMING("track_io_timing", (r) -> Randomly.fromOptions(1, 0)),
+        TRACK_FUNCTIONS("track_functions", (r) -> Randomly.fromOptions("'none'", "'pl'", "'all'")),
+        // stats_temp_directory
+        // TODO 19.9.2. Statistics Monitoring
+        // https://www.postgresql.org/docs/11/runtime-config-autovacuum.html
+        // all can only be set at server-conf time
+        // 19.11. Client Connection Defaults
+        VACUUM_FREEZE_TABLE_AGE("vacuum_freeze_table_age", (r) -> Randomly.fromOptions(0, 5, 10, 100, 500, 2000000000)),
+        VACUUM_FREEZE_MIN_AGE("vacuum_freeze_min_age", (r) -> Randomly.fromOptions(0, 5, 10, 100, 500, 1000000000)),
+        VACUUM_MULTIXACT_FREEZE_TABLE_AGE("vacuum_multixact_freeze_table_age",
+                (r) -> Randomly.fromOptions(0, 5, 10, 100, 500, 2000000000)),
+        VACUUM_MULTIXACT_FREEZE_MIN_AGE("vacuum_multixact_freeze_min_age",
+                (r) -> Randomly.fromOptions(0, 5, 10, 100, 500, 1000000000)),
+        VACUUM_CLEANUP_INDEX_SCALE_FACTOR("vacuum_cleanup_index_scale_factor",
+                (r) -> Randomly.fromOptions(0.0, 0.0000001, 0.00001, 0.01, 0.1, 1, 10, 100, 100000, 10000000000.0)),
+        // TODO others
+        GIN_FUZZY_SEARCH_LIMIT("gin_fuzzy_search_limit", (r) -> r.getInteger(0, 2147483647)),
+        // 19.13. Version and Platform Compatibility
+        DEFAULT_WITH_OIDS("default_with_oids", (r) -> Randomly.fromOptions(0, 1)),
+        SYNCHRONIZED_SEQSCANS("synchronize_seqscans", (r) -> Randomly.fromOptions(0, 1)),
+        // https://www.postgresql.org/docs/devel/runtime-config-query.html
+        ENABLE_BITMAPSCAN("enable_bitmapscan", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_GATHERMERGE("enable_gathermerge", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_HASHJOIN("enable_hashjoin", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_INDEXSCAN("enable_indexscan", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_INDEXONLYSCAN("enable_indexonlyscan", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_MATERIAL("enable_material", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_MERGEJOIN("enable_mergejoin", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_NESTLOOP("enable_nestloop", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_PARALLEL_APPEND("enable_parallel_append", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_PARALLEL_HASH("enable_parallel_hash", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_PARTITION_PRUNING("enable_partition_pruning", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_PARTITIONWISE_JOIN("enable_partitionwise_join", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_PARTITIONWISE_AGGREGATE("enable_partitionwise_aggregate", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_SEGSCAN("enable_seqscan", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_SORT("enable_sort", (r) -> Randomly.fromOptions(1, 0)),
+        ENABLE_TIDSCAN("enable_tidscan", (r) -> Randomly.fromOptions(1, 0)),
+        // 19.7.2. Planner Cost Constants (complete as of March 2020)
+        // https://www.postgresql.org/docs/current/runtime-config-query.html#RUNTIME-CONFIG-QUERY-CONSTANTS
+        SEQ_PAGE_COST("seq_page_cost", (r) -> Randomly.fromOptions(0d, 0.00001, 0.05, 0.1, 1, 10, 10000)),
+        RANDOM_PAGE_COST("random_page_cost", (r) -> Randomly.fromOptions(0d, 0.00001, 0.05, 0.1, 1, 10, 10000)),
+        CPU_TUPLE_COST("cpu_tuple_cost", (r) -> Randomly.fromOptions(0d, 0.00001, 0.05, 0.1, 1, 10, 10000)),
+        CPU_INDEX_TUPLE_COST("cpu_index_tuple_cost", (r) -> Randomly.fromOptions(0d, 0.00001, 0.05, 0.1, 1, 10, 10000)),
+        CPU_OPERATOR_COST("cpu_operator_cost", (r) -> Randomly.fromOptions(0d, 0.000001, 0.0025, 0.1, 1, 10, 10000)),
+        PARALLEL_SETUP_COST("parallel_setup_cost", (r) -> r.getLong(0, Long.MAX_VALUE)),
+        PARALLEL_TUPLE_COST("parallel_tuple_cost", (r) -> r.getLong(0, Long.MAX_VALUE)),
+        MIN_PARALLEL_TABLE_SCAN_SIZE("min_parallel_table_scan_size", (r) -> r.getInteger(0, 715827882)),
+        MIN_PARALLEL_INDEX_SCAN_SIZE("min_parallel_index_scan_size", (r) -> r.getInteger(0, 715827882)),
+        EFFECTIVE_CACHE_SIZE("effective_cache_size", (r) -> r.getInteger(1, 2147483647)),
+        JIT_ABOVE_COST("jit_above_cost", (r) -> Randomly.fromOptions(0, r.getLong(-1, Long.MAX_VALUE - 1))),
+        JIT_INLINE_ABOVE_COST("jit_inline_above_cost", (r) -> Randomly.fromOptions(0, r.getLong(-1, Long.MAX_VALUE))),
+        JIT_OPTIMIZE_ABOVE_COST("jit_optimize_above_cost",
+                (r) -> Randomly.fromOptions(0, r.getLong(-1, Long.MAX_VALUE))),
+        // 19.7.3. Genetic Query Optimizer (complete as of March 2020)
+        // https://www.postgresql.org/docs/current/runtime-config-query.html#RUNTIME-CONFIG-QUERY-GEQO
+        GEQO("geqo", (r) -> Randomly.fromOptions(1, 0)),
+        GEQO_THRESHOLD("geqo_threshold", (r) -> r.getInteger(2, 2147483647)),
+        GEQO_EFFORT("geqo_effort", (r) -> r.getInteger(1, 10)),
+        GEQO_POO_SIZE("geqo_pool_size", (r) -> r.getInteger(0, 2147483647)),
+        GEQO_GENERATIONS("geqo_generations", (r) -> r.getInteger(0, 2147483647)),
+        GEQO_SELECTION_BIAS("geqo_selection_bias", (r) -> Randomly.fromOptions(1.5, 1.8, 2.0)),
+        GEQO_SEED("geqo_seed", (r) -> Randomly.fromOptions(0, 0.5, 1)),
+        // 19.7.4. Other Planner Options (complete as of March 2020)
+        // https://www.postgresql.org/docs/current/runtime-config-query.html#RUNTIME-CONFIG-QUERY-OTHER
+        DEFAULT_STATISTICS_TARGET("default_statistics_target", (r) -> r.getInteger(1, 10000)),
+        CONSTRAINT_EXCLUSION("constraint_exclusion", (r) -> Randomly.fromOptions("on", "off", "partition")),
+        CURSOR_TUPLE_FRACTION("cursor_tuple_fraction",
+                (r) -> Randomly.fromOptions(0.0, 0.1, 0.000001, 1, 0.5, 0.9999999)),
+        FROM_COLLAPSE_LIMIT("from_collapse_limit", (r) -> r.getInteger(1, Integer.MAX_VALUE)),
+        JIT("jit", (r) -> Randomly.fromOptions(1, 0)),
+        JOIN_COLLAPSE_LIMIT("join_collapse_limit", (r) -> r.getInteger(1, Integer.MAX_VALUE)),
+        PARALLEL_LEADER_PARTICIPATION("parallel_leader_participation", (r) -> Randomly.fromOptions(1, 0)),
+        FORCE_PARALLEL_MODE("force_parallel_mode", (r) -> Randomly.fromOptions("off", "on", "regress"));
+
+        private final String optionName;
+        private final Function<Randomly, Object> op;
+
+        ConfigurationOption(String optionName, Function<Randomly, Object> op) {
+            this.optionName = optionName;
+            this.op = op;
+        }
+
+        public String getOptionName() {
+            return optionName;
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLStatisticsGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLStatisticsGenerator.java
@@ -1,0 +1,74 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLStatisticsObject;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+
+public final class YSQLStatisticsGenerator {
+
+    private YSQLStatisticsGenerator() {
+    }
+
+    public static SQLQueryAdapter insert(YSQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE STATISTICS ");
+        if (Randomly.getBoolean()) {
+            sb.append(" IF NOT EXISTS");
+        }
+        YSQLTable randomTable = globalState.getSchema().getRandomTable(t -> !t.isView()); // TODO materialized view
+        if (randomTable.getColumns().size() < 2) {
+            throw new IgnoreMeException();
+        }
+        sb.append(" ");
+        sb.append(getNewStatisticsName(randomTable));
+        if (Randomly.getBoolean()) {
+            sb.append(" (");
+            List<String> statsSubset;
+            statsSubset = Randomly.nonEmptySubset("ndistinct", "dependencies", "mcv");
+            sb.append(String.join(", ", statsSubset));
+            sb.append(")");
+        }
+
+        List<YSQLColumn> randomColumns = randomTable.getRandomNonEmptyColumnSubset(
+                globalState.getRandomly().getInteger(2, randomTable.getColumns().size()));
+        sb.append(" ON ");
+        sb.append(randomColumns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
+        sb.append(" FROM ");
+        sb.append(randomTable.getName());
+        return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("cannot have more than 8 columns in statistics"),
+                true);
+    }
+
+    public static SQLQueryAdapter remove(YSQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder("DROP STATISTICS ");
+        YSQLTable randomTable = globalState.getSchema().getRandomTable();
+        List<YSQLStatisticsObject> statistics = randomTable.getStatistics();
+        if (statistics.isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        sb.append(Randomly.fromList(statistics).getName());
+        return new SQLQueryAdapter(sb.toString(), true);
+    }
+
+    private static String getNewStatisticsName(YSQLTable randomTable) {
+        List<YSQLStatisticsObject> statistics = randomTable.getStatistics();
+        int i = 0;
+        while (true) {
+            String candidateName = "s" + i;
+            if (statistics.stream().noneMatch(stat -> stat.getName().contentEquals(candidateName))) {
+                return candidateName;
+            }
+            i++;
+        }
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLTableGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLTableGenerator.java
@@ -1,0 +1,247 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+
+public class YSQLTableGenerator {
+
+    protected final ExpectedErrors errors = new ExpectedErrors();
+    private final String tableName;
+    private final StringBuilder sb = new StringBuilder();
+    private final List<YSQLColumn> columnsToBeAdded = new ArrayList<>();
+    private final YSQLTable table;
+    private final boolean generateOnlyKnown;
+    private final YSQLGlobalState globalState;
+    private boolean columnCanHavePrimaryKey;
+    private boolean columnHasPrimaryKey;
+    private boolean isTemporaryTable;
+
+    public YSQLTableGenerator(String tableName, boolean generateOnlyKnown, YSQLGlobalState globalState) {
+        this.tableName = tableName;
+        this.generateOnlyKnown = generateOnlyKnown;
+        this.globalState = globalState;
+        table = new YSQLTable(tableName, columnsToBeAdded, null, null, null, false, false);
+        // YB catalog specific messages
+        errors.add("The catalog snapshot used for this transaction has been invalidated");
+
+        errors.add("PRIMARY KEY containing column of type");
+        errors.add("specified value cannot be cast to type boolean for column");
+        errors.add("already exists");
+        errors.add("invalid input syntax for");
+        errors.add("is not unique");
+        errors.add("integer out of range");
+        errors.add("division by zero");
+        errors.add("cannot create partitioned table as inheritance child");
+        errors.add("cannot cast");
+        errors.add("ERROR: functions in index expression must be marked IMMUTABLE");
+        errors.add("functions in partition key expression must be marked IMMUTABLE");
+        errors.add("functions in index predicate must be marked IMMUTABLE");
+        errors.add("has no default operator class for access method");
+        errors.add("does not exist for access method");
+        errors.add("does not accept data type");
+        errors.add("but default expression is of type text");
+        errors.add("has pseudo-type unknown");
+        errors.add("no collation was derived for partition key column");
+        errors.add("cannot set colocated true on a non-colocated database");
+        errors.add("Cannot split table that does not have primary key");
+        errors.add("inherits from generated column but specifies identity");
+        errors.add("inherits from generated column but specifies default");
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonTableErrors(errors);
+    }
+
+    public static SQLQueryAdapter generate(String tableName, boolean generateOnlyKnown, YSQLGlobalState globalState) {
+        return new YSQLTableGenerator(tableName, generateOnlyKnown, globalState).generate();
+    }
+
+    private SQLQueryAdapter generate() {
+        columnCanHavePrimaryKey = true;
+        sb.append("CREATE");
+        if (Randomly.getBooleanWithSmallProbability()) {
+            sb.append(" ");
+            isTemporaryTable = true;
+            sb.append(Randomly.fromOptions("TEMPORARY", "TEMP"));
+        }
+        sb.append(" TABLE");
+        if (Randomly.getBoolean()) {
+            sb.append(" IF NOT EXISTS");
+        }
+        sb.append(" ");
+        sb.append(tableName);
+        createStandard();
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+    private void createStandard() throws AssertionError {
+        sb.append("(");
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            String name = DBMSCommon.createColumnName(i);
+            createColumn(name);
+        }
+        if (Randomly.getBoolean()) {
+            errors.add("constraints on temporary tables may reference only temporary tables");
+            errors.add("constraints on unlogged tables may reference only permanent or unlogged tables");
+            errors.add("constraints on permanent tables may reference only permanent tables");
+            errors.add("cannot be implemented");
+            errors.add("there is no unique constraint matching given keys for referenced table");
+            errors.add("cannot reference partitioned table");
+            errors.add("unsupported ON COMMIT and foreign key combination");
+            errors.add("ERROR: invalid ON DELETE action for foreign key constraint containing generated column");
+            errors.add("exclusion constraints are not supported on partitioned tables");
+            errors.add("option is not yet supported for hash partitioned tables");
+            YSQLCommon.addTableConstraints(columnHasPrimaryKey, sb, table, globalState, errors);
+        }
+        sb.append(")");
+        generatePartitionBy();
+        YSQLCommon.generateWith(sb, globalState, errors, columnsToBeAdded, isTemporaryTable);
+        if (Randomly.getBoolean() && isTemporaryTable) {
+            sb.append(" ON COMMIT ");
+            // todo ON COMMIT DROP fails and it's known issue
+            // sb.append(Randomly.fromOptions("PRESERVE ROWS", "DELETE ROWS", "DROP"));
+            sb.append(Randomly.fromOptions("PRESERVE ROWS", "DELETE ROWS"));
+            sb.append(" ");
+        }
+    }
+
+    private void createColumn(String name) throws AssertionError {
+        sb.append(name);
+        sb.append(" ");
+        YSQLDataType type = YSQLDataType.getRandomType();
+        boolean serial = YSQLCommon.appendDataType(type, sb, true, generateOnlyKnown, globalState.getCollates());
+        YSQLColumn c = new YSQLColumn(name, type);
+        c.setTable(table);
+        columnsToBeAdded.add(c);
+        sb.append(" ");
+        if (Randomly.getBoolean()) {
+            createColumnConstraint(type, serial);
+        }
+    }
+
+    private void generatePartitionBy() {
+        if (Randomly.getBoolean()) {
+            return;
+        }
+        sb.append(" PARTITION BY ");
+        // TODO "RANGE",
+        String partitionOption = Randomly.fromOptions("RANGE", "LIST", "HASH");
+        sb.append(partitionOption);
+        sb.append("(");
+        errors.add("unrecognized parameter");
+        errors.add("cannot use constant expression");
+        errors.add("unrecognized parameter");
+        errors.add("unsupported PRIMARY KEY constraint with partition key definition");
+        errors.add("which is part of the partition key.");
+        errors.add("unsupported UNIQUE constraint with partition key definition");
+        errors.add("does not accept data type");
+        int n = partitionOption.contentEquals("LIST") ? 1 : Randomly.smallNumber() + 1;
+        YSQLCommon.addCommonExpressionErrors(errors);
+        for (int i = 0; i < n; i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append("(");
+            YSQLExpression expr = YSQLExpressionGenerator.generateExpression(globalState, columnsToBeAdded);
+            sb.append(YSQLVisitor.asString(expr));
+            sb.append(")");
+            if (Randomly.getBoolean()) {
+                sb.append(globalState.getRandomOpclass());
+                errors.add("does not exist for access method");
+            }
+        }
+        sb.append(")");
+    }
+
+    private void createColumnConstraint(YSQLDataType type, boolean serial) {
+        List<ColumnConstraint> constraintSubset = Randomly.nonEmptySubset(ColumnConstraint.values());
+        if (Randomly.getBoolean()) {
+            // make checks constraints less likely
+            constraintSubset.remove(ColumnConstraint.CHECK);
+        }
+        if (!columnCanHavePrimaryKey || columnHasPrimaryKey) {
+            constraintSubset.remove(ColumnConstraint.PRIMARY_KEY);
+        }
+        if (constraintSubset.contains(ColumnConstraint.GENERATED)
+                && constraintSubset.contains(ColumnConstraint.DEFAULT)) {
+            // otherwise: ERROR: both default and identity specified for column
+            constraintSubset.remove(Randomly.fromOptions(ColumnConstraint.GENERATED, ColumnConstraint.DEFAULT));
+        }
+        if (constraintSubset.contains(ColumnConstraint.GENERATED) && type != YSQLDataType.INT) {
+            // otherwise: ERROR: identity column type must be smallint, integer, or bigint
+            constraintSubset.remove(ColumnConstraint.GENERATED);
+        }
+        if (serial) {
+            constraintSubset.remove(ColumnConstraint.GENERATED);
+            constraintSubset.remove(ColumnConstraint.DEFAULT);
+            constraintSubset.remove(ColumnConstraint.NULL_OR_NOT_NULL);
+
+        }
+        for (ColumnConstraint c : constraintSubset) {
+            sb.append(" ");
+            switch (c) {
+            case NULL_OR_NOT_NULL:
+                sb.append(Randomly.fromOptions("NOT NULL", "NULL"));
+                errors.add("conflicting NULL/NOT NULL declarations");
+                break;
+            case UNIQUE:
+                sb.append("UNIQUE");
+                break;
+            case PRIMARY_KEY:
+                sb.append("PRIMARY KEY");
+                columnHasPrimaryKey = true;
+                break;
+            case DEFAULT:
+                sb.append("DEFAULT");
+                sb.append(" (");
+                sb.append(YSQLVisitor.asString(YSQLExpressionGenerator.generateExpression(globalState, type)));
+                sb.append(")");
+                errors.add("out of range");
+                errors.add("is a generated column");
+                break;
+            case CHECK:
+                sb.append("CHECK (");
+                sb.append(YSQLVisitor.asString(YSQLExpressionGenerator.generateExpression(globalState, columnsToBeAdded,
+                        YSQLDataType.BOOLEAN)));
+                sb.append(")");
+                errors.add("out of range");
+                break;
+            case GENERATED:
+                sb.append("GENERATED ");
+                if (Randomly.getBoolean()) {
+                    sb.append(" ALWAYS AS (");
+                    sb.append(YSQLVisitor
+                            .asString(YSQLExpressionGenerator.generateExpression(globalState, columnsToBeAdded, type)));
+                    sb.append(") STORED");
+                    errors.add("A generated column cannot reference another generated column.");
+                    errors.add("cannot use generated column in partition key");
+                    errors.add("generation expression is not immutable");
+                    errors.add("cannot use column reference in DEFAULT expression");
+                } else {
+                    sb.append(Randomly.fromOptions("ALWAYS", "BY DEFAULT"));
+                    sb.append(" AS IDENTITY");
+                }
+                break;
+            default:
+                throw new AssertionError(sb);
+            }
+        }
+    }
+
+    private enum ColumnConstraint {
+        NULL_OR_NOT_NULL, UNIQUE, PRIMARY_KEY, DEFAULT, CHECK, GENERATED
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLTableGroupGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLTableGroupGenerator.java
@@ -1,0 +1,24 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+
+public final class YSQLTableGroupGenerator {
+
+    // TODO rework
+    public static final AtomicLong UNIQUE_TABLEGROUP_COUNTER = new AtomicLong(1);
+
+    private YSQLTableGroupGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder("CREATE TABLEGROUP ");
+        String tableGroupName = "tg" + UNIQUE_TABLEGROUP_COUNTER.incrementAndGet();
+        sb.append(tableGroupName);
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLTransactionGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLTransactionGenerator.java
@@ -1,0 +1,27 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+
+public final class YSQLTransactionGenerator {
+
+    private YSQLTransactionGenerator() {
+    }
+
+    public static SQLQueryAdapter executeBegin() {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder("BEGIN");
+        if (Randomly.getBoolean()) {
+            errors.add("SET TRANSACTION ISOLATION LEVEL must be called before any query");
+            sb.append(" ISOLATION LEVEL ");
+            sb.append(Randomly.fromOptions("SERIALIZABLE", "REPEATABLE READ", "READ COMMITTED"));
+            // if (Randomly.getBoolean()) {
+            // sb.append(" ");
+            // sb.append(Randomly.fromOptions("READ WRITE", "READ ONLY"));
+            // }
+        }
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLTruncateGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLTruncateGenerator.java
@@ -1,0 +1,41 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+
+public final class YSQLTruncateGenerator {
+
+    private YSQLTruncateGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("TRUNCATE");
+        if (Randomly.getBoolean()) {
+            sb.append(" TABLE");
+        }
+        // TODO partitions
+        // if (Randomly.getBoolean()) {
+        // sb.append(" ONLY");
+        // }
+        sb.append(" ");
+        sb.append(globalState.getSchema().getDatabaseTablesRandomSubsetNotEmpty().stream().map(AbstractTable::getName)
+                .collect(Collectors.joining(", ")));
+        // if (Randomly.getBoolean()) {
+        // sb.append(" ");
+        // sb.append(Randomly.fromOptions("RESTART IDENTITY", "CONTINUE IDENTITY"));
+        // }
+        // if (Randomly.getBoolean()) {
+        // sb.append(" ");
+        // sb.append(Randomly.fromOptions("CASCADE", "RESTRICT"));
+        // }
+        return new SQLQueryAdapter(sb.toString(), ExpectedErrors
+                .from("cannot truncate a table referenced in a foreign key constraint", "is not a table"));
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLUpdateGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLUpdateGenerator.java
@@ -1,0 +1,76 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+
+public final class YSQLUpdateGenerator {
+
+    private YSQLUpdateGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        YSQLTable randomTable = globalState.getSchema().getRandomTable(YSQLTable::isInsertable);
+        StringBuilder sb = new StringBuilder();
+        sb.append("UPDATE ");
+        sb.append(randomTable.getName());
+        sb.append(" SET ");
+        ExpectedErrors errors = ExpectedErrors.from("conflicting key value violates exclusion constraint",
+                "reached maximum value of sequence", "violates foreign key constraint", "violates not-null constraint",
+                "violates unique constraint", "out of range", "cannot cast", "must be type boolean", "is not unique",
+                " bit string too long", "can only be updated to DEFAULT", "division by zero",
+                "You might need to add explicit type casts.", "invalid regular expression",
+                "View columns that are not columns of their base relation are not updatable");
+        errors.add("multiple assignments to same column"); // view whose columns refer to a column in the referenced
+        // table multiple times
+        errors.add("new row violates check option for view");
+        List<YSQLColumn> columns = randomTable.getRandomNonEmptyColumnSubset();
+        YSQLCommon.addCommonInsertUpdateErrors(errors);
+
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            YSQLColumn column = columns.get(i);
+            sb.append(column.getName());
+            sb.append(" = ");
+            if (!Randomly.getBoolean()) {
+                YSQLExpression constant = YSQLExpressionGenerator.generateConstant(globalState.getRandomly(),
+                        column.getType());
+                sb.append(YSQLVisitor.asString(constant));
+            } else if (Randomly.getBoolean()) {
+                sb.append("DEFAULT");
+            } else {
+                sb.append("(");
+                YSQLExpression expr = YSQLExpressionGenerator.generateExpression(globalState, randomTable.getColumns(),
+                        column.getType());
+                // caused by casts
+                sb.append(YSQLVisitor.asString(expr));
+                sb.append(")");
+            }
+        }
+        errors.add("invalid input syntax for ");
+        errors.add("operator does not exist: text = boolean");
+        errors.add("violates check constraint");
+        errors.add("could not determine which collation to use for string comparison");
+        errors.add("but expression is of type");
+        YSQLCommon.addCommonExpressionErrors(errors);
+        if (!Randomly.getBooleanWithSmallProbability()) {
+            sb.append(" WHERE ");
+            YSQLExpression where = YSQLExpressionGenerator.generateExpression(globalState, randomTable.getColumns(),
+                    YSQLDataType.BOOLEAN);
+            sb.append(YSQLVisitor.asString(where));
+        }
+
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLVacuumGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLVacuumGenerator.java
@@ -1,0 +1,19 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+
+public final class YSQLVacuumGenerator {
+
+    private YSQLVacuumGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        String sb = "VACUUM";
+        ExpectedErrors errors = new ExpectedErrors();
+        errors.add("VACUUM cannot run inside a transaction block");
+        return new SQLQueryAdapter(sb, errors);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLViewGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLViewGenerator.java
@@ -1,0 +1,73 @@
+package sqlancer.yugabyte.ysql.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+
+public final class YSQLViewGenerator {
+
+    private YSQLViewGenerator() {
+    }
+
+    public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder("CREATE");
+        // boolean materialized;
+        // boolean recursive = false;
+        if (Randomly.getBoolean()) {
+            sb.append(" MATERIALIZED");
+            // materialized = true;
+        } else {
+            if (Randomly.getBoolean()) {
+                sb.append(" OR REPLACE");
+            }
+            if (Randomly.getBoolean()) {
+                sb.append(Randomly.fromOptions(" TEMP", " TEMPORARY"));
+            }
+            // if (Randomly.getBoolean()) {
+            // sb.append(" RECURSIVE");
+            // recursive = true;
+            // }
+            // materialized = false;
+        }
+        sb.append(" VIEW ");
+        int i = 0;
+        String[] name = new String[1];
+        while (true) {
+            name[0] = "v" + i++;
+            if (globalState.getSchema().getDatabaseTables().stream()
+                    .noneMatch(tab -> tab.getName().contentEquals(name[0]))) {
+                break;
+            }
+        }
+        sb.append(name[0]);
+        sb.append("(");
+        int nrColumns = Randomly.smallNumber() + 1;
+        for (i = 0; i < nrColumns; i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(DBMSCommon.createColumnName(i));
+        }
+        sb.append(")");
+        // if (Randomly.getBoolean() && !materialized && !recursive) {
+        // sb.append(" WITH ");
+        // sb.append(Randomly.fromOptions("CASCADED", "LOCAL"));
+        // sb.append(" CHECK OPTION");
+        // errors.add("WITH CHECK OPTION is supported only on automatically updatable views");
+        // }
+        sb.append(" AS (");
+        YSQLSelect select = YSQLRandomQueryGenerator.createRandomQuery(nrColumns, globalState);
+        sb.append(YSQLVisitor.asString(select));
+        sb.append(")");
+        YSQLCommon.addGroupingErrors(errors);
+        YSQLCommon.addViewErrors(errors);
+        YSQLCommon.addCommonExpressionErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLCatalog.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLCatalog.java
@@ -1,0 +1,94 @@
+package sqlancer.yugabyte.ysql.oracle;
+
+import static sqlancer.yugabyte.ysql.YSQLProvider.CREATION_LOCK;
+
+import java.util.Arrays;
+import java.util.List;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Main;
+import sqlancer.MainOptions;
+import sqlancer.SQLConnection;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLProvider;
+import sqlancer.yugabyte.ysql.gen.YSQLCommon;
+import sqlancer.yugabyte.ysql.gen.YSQLTableGenerator;
+
+public class YSQLCatalog implements TestOracle {
+    protected final YSQLGlobalState state;
+
+    protected final ExpectedErrors errors = new ExpectedErrors();
+    protected final Main.StateLogger logger;
+    protected final MainOptions options;
+    protected final SQLConnection con;
+
+    private final List<YSQLProvider.Action> dmlActions = Arrays.asList(YSQLProvider.Action.INSERT,
+            YSQLProvider.Action.UPDATE, YSQLProvider.Action.DELETE);
+    private final List<YSQLProvider.Action> catalogActions = Arrays.asList(YSQLProvider.Action.CREATE_VIEW,
+            YSQLProvider.Action.CREATE_SEQUENCE, YSQLProvider.Action.ALTER_TABLE, YSQLProvider.Action.SET_CONSTRAINTS,
+            YSQLProvider.Action.DISCARD, YSQLProvider.Action.DROP_INDEX, YSQLProvider.Action.COMMENT_ON,
+            YSQLProvider.Action.RESET_ROLE, YSQLProvider.Action.RESET);
+    private final List<YSQLProvider.Action> diskActions = Arrays.asList(YSQLProvider.Action.TRUNCATE,
+            YSQLProvider.Action.VACUUM);
+
+    public YSQLCatalog(YSQLGlobalState globalState) {
+        this.state = globalState;
+        this.con = state.getConnection();
+        this.logger = state.getLogger();
+        this.options = state.getOptions();
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonFetchErrors(errors);
+    }
+
+    private YSQLProvider.Action getRandomAction(List<YSQLProvider.Action> actions) {
+        return actions.get(state.getRandomly().getInteger(0, actions.size()));
+    }
+
+    protected void createTables(YSQLGlobalState globalState, int numTables) throws Exception {
+        synchronized (CREATION_LOCK) {
+            while (globalState.getSchema().getDatabaseTables().size() < numTables) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+
+                try {
+                    String tableName = DBMSCommon.createTableName(globalState.getSchema().getDatabaseTables().size());
+                    SQLQueryAdapter createTable = YSQLTableGenerator.generate(tableName, true, globalState);
+                    globalState.executeStatement(createTable);
+                    globalState.getManager().incrementSelectQueryCount();
+                    globalState.executeStatement(new SQLQueryAdapter("COMMIT", true));
+                } catch (IgnoreMeException e) {
+                    // do nothing
+                }
+            }
+        }
+    }
+
+    @Override
+    public void check() throws Exception {
+        // create table or evaluate catalog test
+        int seed = state.getRandomly().getInteger(1, 100);
+        if (seed > 95) {
+            createTables(state, 1);
+        } else {
+            YSQLProvider.Action randomAction;
+
+            if (seed > 40) {
+                randomAction = getRandomAction(dmlActions);
+            } else if (seed > 10) {
+                randomAction = getRandomAction(catalogActions);
+            } else {
+                randomAction = getRandomAction(diskActions);
+            }
+
+            state.executeStatement(randomAction.getQuery(state));
+        }
+        state.getManager().incrementSelectQueryCount();
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLFuzzer.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLFuzzer.java
@@ -1,0 +1,108 @@
+package sqlancer.yugabyte.ysql.oracle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import sqlancer.Randomly;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLProvider;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.gen.YSQLCommon;
+import sqlancer.yugabyte.ysql.gen.YSQLRandomQueryGenerator;
+
+public class YSQLFuzzer implements TestOracle {
+    private final YSQLGlobalState globalState;
+    private final List<Query> testQueries;
+    private final ExpectedErrors errors = new ExpectedErrors();
+
+    public YSQLFuzzer(YSQLGlobalState globalState) {
+        this.globalState = globalState;
+
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonFetchErrors(errors);
+        YSQLCommon.addGroupingErrors(errors);
+        YSQLCommon.addViewErrors(errors);
+
+        // remove timeout error from scope
+        errors.add("canceling statement due to statement timeout");
+
+        // exclude nemesis exceptions
+        errors.add("terminating connection due to administrator command");
+        errors.add("Java heap space");
+        errors.add("Connection refused");
+        errors.add("Connection to");
+
+        // get config from -Dconfig.file="path/to/fuzzer.conf"
+        testQueries = new ArrayList<>();
+        try {
+            Config config = ConfigFactory.load();
+            ArrayList<Object> queriesList = (ArrayList<Object>) config.getList("queries").unwrapped();
+            for (Object configValue : queriesList) {
+                String type = ((String) ((Map<?, ?>) configValue).get("type")).toUpperCase(Locale.ROOT);
+                Integer weight = (Integer) ((Map<?, ?>) configValue).get("weight");
+
+                Query query = type.equalsIgnoreCase("SELECT") ? new SelectQuery()
+                        : new ActionQuery(YSQLProvider.Action.valueOf(type));
+
+                for (int i = 0; i < weight; i++) {
+                    testQueries.add(query);
+                }
+            }
+        } catch (Exception e) {
+            // do nothing
+        } finally {
+            if (testQueries.isEmpty()) {
+                System.out.println("No configuration found. Using just random select statements");
+                testQueries.add(new SelectQuery());
+                testQueries.add(new ActionQuery(YSQLProvider.Action.UPDATE));
+                testQueries.add(new ActionQuery(YSQLProvider.Action.DELETE));
+                testQueries.add(new ActionQuery(YSQLProvider.Action.INSERT));
+            }
+        }
+    }
+
+    @Override
+    public void check() throws Exception {
+        Query s = testQueries.get(globalState.getRandomly().getInteger(0, testQueries.size()));
+        globalState.executeStatement(s.getQuery(globalState, errors));
+        globalState.getManager().incrementSelectQueryCount();
+    }
+
+    private static class Query {
+        public SQLQueryAdapter getQuery(YSQLGlobalState state, ExpectedErrors errors) throws Exception {
+            throw new IllegalAccessException("Should be implemented");
+        };
+    }
+
+    private static class ActionQuery extends Query {
+        private final YSQLProvider.Action action;
+
+        ActionQuery(YSQLProvider.Action action) {
+            this.action = action;
+        }
+
+        @Override
+        public SQLQueryAdapter getQuery(YSQLGlobalState state, ExpectedErrors errors) throws Exception {
+            return action.getQuery(state);
+        }
+    }
+
+    private static class SelectQuery extends Query {
+
+        @Override
+        public SQLQueryAdapter getQuery(YSQLGlobalState state, ExpectedErrors errors) throws Exception {
+            return new SQLQueryAdapter(
+                    YSQLVisitor.asString(YSQLRandomQueryGenerator.createRandomQuery(Randomly.smallNumber() + 1, state))
+                            + ";",
+                    errors);
+        }
+    }
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLNoRECOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLNoRECOracle.java
@@ -1,0 +1,165 @@
+package sqlancer.yugabyte.ysql.oracle;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.oracle.NoRECBase;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.yugabyte.ysql.YSQLCompoundDataType;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTables;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLCastOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLColumnValue;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLJoin;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixText;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.gen.YSQLCommon;
+import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
+import sqlancer.yugabyte.ysql.oracle.tlp.YSQLTLPBase;
+
+public class YSQLNoRECOracle extends NoRECBase<YSQLGlobalState> implements TestOracle {
+
+    private final YSQLSchema s;
+
+    public YSQLNoRECOracle(YSQLGlobalState globalState) {
+        super(globalState);
+        this.s = globalState.getSchema();
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonFetchErrors(errors);
+    }
+
+    public static List<YSQLJoin> getJoinStatements(YSQLGlobalState globalState, List<YSQLColumn> columns,
+            List<YSQLTable> tables) {
+        List<YSQLJoin> joinStatements = new ArrayList<>();
+        YSQLExpressionGenerator gen = new YSQLExpressionGenerator(globalState).setColumns(columns);
+        for (int i = 1; i < tables.size(); i++) {
+            YSQLExpression joinClause = gen.generateExpression(YSQLDataType.BOOLEAN);
+            YSQLTable table = Randomly.fromList(tables);
+            tables.remove(table);
+            YSQLJoin.YSQLJoinType options = YSQLJoin.YSQLJoinType.getRandom();
+            YSQLJoin j = new YSQLJoin(new YSQLSelect.YSQLFromTable(table, Randomly.getBoolean()), joinClause, options);
+            joinStatements.add(j);
+        }
+        // JOIN subqueries
+        for (int i = 0; i < Randomly.smallNumber(); i++) {
+            YSQLTables subqueryTables = globalState.getSchema().getRandomTableNonEmptyTables();
+            YSQLSelect.YSQLSubquery subquery = YSQLTLPBase.createSubquery(globalState, String.format("sub%d", i),
+                    subqueryTables);
+            YSQLExpression joinClause = gen.generateExpression(YSQLDataType.BOOLEAN);
+            YSQLJoin.YSQLJoinType options = YSQLJoin.YSQLJoinType.getRandom();
+            YSQLJoin j = new YSQLJoin(subquery, joinClause, options);
+            joinStatements.add(j);
+        }
+        return joinStatements;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        YSQLTables randomTables = s.getRandomTableNonEmptyTables();
+        List<YSQLColumn> columns = randomTables.getColumns();
+        YSQLExpression randomWhereCondition = getRandomWhereCondition(columns);
+        List<YSQLTable> tables = randomTables.getTables();
+
+        List<YSQLJoin> joinStatements = getJoinStatements(state, columns, tables);
+        List<YSQLExpression> fromTables = tables.stream()
+                .map(t -> new YSQLSelect.YSQLFromTable(t, Randomly.getBoolean())).collect(Collectors.toList());
+        int secondCount = getUnoptimizedQueryCount(fromTables, randomWhereCondition, joinStatements);
+        int firstCount = getOptimizedQueryCount(fromTables, columns, randomWhereCondition, joinStatements);
+        if (firstCount == -1 || secondCount == -1) {
+            throw new IgnoreMeException();
+        }
+        if (firstCount != secondCount) {
+            String queryFormatString = "-- %s;\n-- count: %d";
+            String firstQueryStringWithCount = String.format(queryFormatString, optimizedQueryString, firstCount);
+            String secondQueryStringWithCount = String.format(queryFormatString, unoptimizedQueryString, secondCount);
+            state.getState().getLocalState()
+                    .log(String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount));
+            String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", firstCount, secondCount,
+                    firstQueryStringWithCount, secondQueryStringWithCount);
+            throw new AssertionError(assertionMessage);
+        }
+    }
+
+    private YSQLExpression getRandomWhereCondition(List<YSQLColumn> columns) {
+        return new YSQLExpressionGenerator(state).setColumns(columns).generateExpression(YSQLDataType.BOOLEAN);
+    }
+
+    private int getUnoptimizedQueryCount(List<YSQLExpression> fromTables, YSQLExpression randomWhereCondition,
+            List<YSQLJoin> joinStatements) throws SQLException {
+        YSQLSelect select = new YSQLSelect();
+        YSQLCastOperation isTrue = new YSQLCastOperation(randomWhereCondition,
+                YSQLCompoundDataType.create(YSQLDataType.INT));
+        YSQLPostfixText asText = new YSQLPostfixText(isTrue, " as count", null, YSQLDataType.INT);
+        select.setFetchColumns(Collections.singletonList(asText));
+        select.setFromList(fromTables);
+        select.setSelectType(YSQLSelect.SelectType.ALL);
+        select.setJoinClauses(joinStatements);
+        int secondCount = 0;
+        unoptimizedQueryString = "SELECT SUM(count) FROM (" + YSQLVisitor.asString(select) + ") as res";
+        if (options.logEachSelect()) {
+            logger.writeCurrent(unoptimizedQueryString);
+        }
+        errors.add("canceling statement due to statement timeout");
+        SQLQueryAdapter q = new SQLQueryAdapter(unoptimizedQueryString, errors);
+        SQLancerResultSet rs;
+        try {
+            rs = q.executeAndGet(state);
+        } catch (Exception e) {
+            throw new AssertionError(unoptimizedQueryString, e);
+        }
+        if (rs == null) {
+            return -1;
+        }
+        if (rs.next()) {
+            secondCount += rs.getLong(1);
+        }
+        rs.close();
+        return secondCount;
+    }
+
+    private int getOptimizedQueryCount(List<YSQLExpression> randomTables, List<YSQLColumn> columns,
+            YSQLExpression randomWhereCondition, List<YSQLJoin> joinStatements) throws SQLException {
+        YSQLSelect select = new YSQLSelect();
+        YSQLColumnValue allColumns = new YSQLColumnValue(Randomly.fromList(columns), null);
+        select.setFetchColumns(Arrays.asList(allColumns));
+        select.setFromList(randomTables);
+        select.setWhereClause(randomWhereCondition);
+        if (Randomly.getBooleanWithSmallProbability()) {
+            select.setOrderByExpressions(new YSQLExpressionGenerator(state).setColumns(columns).generateOrderBy());
+        }
+        select.setSelectType(YSQLSelect.SelectType.ALL);
+        select.setJoinClauses(joinStatements);
+        int firstCount = 0;
+        try (Statement stat = con.createStatement()) {
+            optimizedQueryString = YSQLVisitor.asString(select);
+            if (options.logEachSelect()) {
+                logger.writeCurrent(optimizedQueryString);
+            }
+            try (ResultSet rs = stat.executeQuery(optimizedQueryString)) {
+                while (rs.next()) {
+                    firstCount++;
+                }
+            }
+        } catch (SQLException e) {
+            throw new IgnoreMeException();
+        }
+        return firstCount;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLPivotedQuerySynthesisOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLPivotedQuerySynthesisOracle.java
@@ -1,0 +1,147 @@
+package sqlancer.yugabyte.ysql.oracle;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.common.oracle.PivotedQuerySynthesisBase;
+import sqlancer.common.query.Query;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLRowValue;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTables;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLColumnValue;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.gen.YSQLCommon;
+import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
+
+public class YSQLPivotedQuerySynthesisOracle
+        extends PivotedQuerySynthesisBase<YSQLGlobalState, YSQLRowValue, YSQLExpression, SQLConnection> {
+
+    private List<YSQLColumn> fetchColumns;
+
+    public YSQLPivotedQuerySynthesisOracle(YSQLGlobalState globalState) throws SQLException {
+        super(globalState);
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonFetchErrors(errors);
+    }
+
+    /*
+     * Prevent name collisions by aliasing the column.
+     */
+    private YSQLColumn getFetchValueAliasedColumn(YSQLColumn c) {
+        YSQLColumn aliasedColumn = new YSQLColumn(c.getName() + " AS " + c.getTable().getName() + c.getName(),
+                c.getType());
+        aliasedColumn.setTable(c.getTable());
+        return aliasedColumn;
+    }
+
+    private List<YSQLExpression> generateGroupByClause(List<YSQLColumn> columns, YSQLRowValue rw) {
+        if (Randomly.getBoolean()) {
+            return columns.stream().map(c -> YSQLColumnValue.create(c, rw.getValues().get(c)))
+                    .collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private YSQLConstant generateLimit() {
+        if (Randomly.getBoolean()) {
+            return YSQLConstant.createIntConstant(Integer.MAX_VALUE);
+        } else {
+            return null;
+        }
+    }
+
+    private YSQLExpression generateOffset() {
+        if (Randomly.getBoolean()) {
+            return YSQLConstant.createIntConstant(0);
+        } else {
+            return null;
+        }
+    }
+
+    private YSQLExpression generateRectifiedExpression(List<YSQLColumn> columns, YSQLRowValue rw) {
+        YSQLExpression expr = new YSQLExpressionGenerator(globalState).setColumns(columns).setRowValue(rw)
+                .generateExpressionWithExpectedResult(YSQLDataType.BOOLEAN);
+        YSQLExpression result;
+        if (expr.getExpectedValue().isNull()) {
+            result = YSQLPostfixOperation.create(expr, YSQLPostfixOperation.PostfixOperator.IS_NULL);
+        } else {
+            result = YSQLPostfixOperation.create(expr, expr.getExpectedValue().cast(YSQLDataType.BOOLEAN).asBoolean()
+                    ? YSQLPostfixOperation.PostfixOperator.IS_TRUE : YSQLPostfixOperation.PostfixOperator.IS_FALSE);
+        }
+        rectifiedPredicates.add(result);
+        return result;
+    }
+
+    @Override
+    protected Query<SQLConnection> getContainmentCheckQuery(Query<?> query) throws SQLException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT * FROM ("); // ANOTHER SELECT TO USE ORDER BY without restrictions
+        sb.append(query.getUnterminatedQueryString());
+        sb.append(") as result WHERE ");
+        int i = 0;
+        for (YSQLColumn c : fetchColumns) {
+            if (i++ != 0) {
+                sb.append(" AND ");
+            }
+            sb.append("result.");
+            sb.append(c.getTable().getName());
+            sb.append(c.getName());
+            if (pivotRow.getValues().get(c).isNull()) {
+                sb.append(" IS NULL");
+            } else {
+                sb.append(" = ");
+                sb.append(pivotRow.getValues().get(c).getTextRepresentation());
+            }
+        }
+        String resultingQueryString = sb.toString();
+        return new SQLQueryAdapter(resultingQueryString, errors);
+    }
+
+    @Override
+    public SQLQueryAdapter getRectifiedQuery() throws SQLException {
+        YSQLTables randomFromTables = globalState.getSchema().getRandomTableNonEmptyTables();
+
+        YSQLSelect selectStatement = new YSQLSelect();
+        selectStatement.setSelectType(Randomly.fromOptions(YSQLSelect.SelectType.values()));
+        List<YSQLColumn> columns = randomFromTables.getColumns();
+        pivotRow = randomFromTables.getRandomRowValue(globalState.getConnection());
+
+        fetchColumns = columns;
+        selectStatement.setFromList(randomFromTables.getTables().stream()
+                .map(t -> new YSQLSelect.YSQLFromTable(t, false)).collect(Collectors.toList()));
+        selectStatement.setFetchColumns(fetchColumns.stream()
+                .map(c -> new YSQLColumnValue(getFetchValueAliasedColumn(c), pivotRow.getValues().get(c)))
+                .collect(Collectors.toList()));
+        YSQLExpression whereClause = generateRectifiedExpression(columns, pivotRow);
+        selectStatement.setWhereClause(whereClause);
+        List<YSQLExpression> groupByClause = generateGroupByClause(columns, pivotRow);
+        selectStatement.setGroupByExpressions(groupByClause);
+        YSQLExpression limitClause = generateLimit();
+        selectStatement.setLimitClause(limitClause);
+        if (limitClause != null) {
+            YSQLExpression offsetClause = generateOffset();
+            selectStatement.setOffsetClause(offsetClause);
+        }
+        List<YSQLExpression> orderBy = new YSQLExpressionGenerator(globalState).setColumns(columns).generateOrderBy();
+        selectStatement.setOrderByExpressions(orderBy);
+        return new SQLQueryAdapter(YSQLVisitor.asString(selectStatement));
+    }
+
+    @Override
+    protected String getExpectedValues(YSQLExpression expr) {
+        return YSQLVisitor.asExpectedValues(expr);
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
@@ -1,0 +1,194 @@
+package sqlancer.yugabyte.ysql.oracle.tlp;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.postgresql.util.PSQLException;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLAggregate;
+import sqlancer.yugabyte.ysql.ast.YSQLAggregate.YSQLAggregateFunction;
+import sqlancer.yugabyte.ysql.ast.YSQLAlias;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLJoin;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLPostfixOperation.PostfixOperator;
+import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation;
+import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation.PrefixOperator;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.gen.YSQLCommon;
+
+public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle {
+
+    private String firstResult;
+    private String secondResult;
+    private String originalQuery;
+    private String metamorphicQuery;
+
+    public YSQLTLPAggregateOracle(YSQLGlobalState state) {
+        super(state);
+        YSQLCommon.addGroupingErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        aggregateCheck();
+    }
+
+    protected void aggregateCheck() throws SQLException {
+        YSQLAggregateFunction aggregateFunction = Randomly.fromOptions(YSQLAggregateFunction.MAX,
+                YSQLAggregateFunction.MIN, YSQLAggregateFunction.SUM, YSQLAggregateFunction.BIT_AND,
+                YSQLAggregateFunction.BIT_OR, YSQLAggregateFunction.BOOL_AND, YSQLAggregateFunction.BOOL_OR,
+                YSQLAggregateFunction.COUNT);
+        YSQLAggregate aggregate = gen.generateArgsForAggregate(aggregateFunction.getRandomReturnType(),
+                aggregateFunction);
+        List<YSQLExpression> fetchColumns = new ArrayList<>();
+        fetchColumns.add(aggregate);
+        while (Randomly.getBooleanWithRatherLowProbability()) {
+            fetchColumns.add(gen.generateAggregate());
+        }
+        select.setFetchColumns(Arrays.asList(aggregate));
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByExpressions(gen.generateOrderBy());
+        }
+        originalQuery = YSQLVisitor.asString(select);
+        firstResult = getAggregateResult(originalQuery);
+        metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
+        secondResult = getAggregateResult(metamorphicQuery);
+
+        String queryFormatString = "-- %s;\n-- result: %s";
+        String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
+        String secondQueryString = String.format(queryFormatString, metamorphicQuery, secondResult);
+        state.getState().getLocalState().log(String.format("%s\n%s", firstQueryString, secondQueryString));
+        if (firstResult == null && secondResult != null || firstResult != null && secondResult == null
+                || firstResult != null && !firstResult.contentEquals(secondResult)
+                        && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
+            if (secondResult != null && secondResult.contains("Inf")) {
+                throw new IgnoreMeException(); // FIXME: average computation
+            }
+            String assertionMessage = String.format("the results mismatch!\n%s\n%s", firstQueryString,
+                    secondQueryString);
+            throw new AssertionError(assertionMessage);
+        }
+    }
+
+    private String createMetamorphicUnionQuery(YSQLSelect select, YSQLAggregate aggregate, List<YSQLExpression> from) {
+        String metamorphicQuery;
+        YSQLExpression whereClause = gen.generateExpression(YSQLDataType.BOOLEAN);
+        YSQLExpression negatedClause = new YSQLPrefixOperation(whereClause, PrefixOperator.NOT);
+        YSQLExpression notNullClause = new YSQLPostfixOperation(whereClause, PostfixOperator.IS_NULL);
+        List<YSQLExpression> mappedAggregate = mapped(aggregate);
+        YSQLSelect leftSelect = getSelect(mappedAggregate, from, whereClause, select.getJoinClauses());
+        YSQLSelect middleSelect = getSelect(mappedAggregate, from, negatedClause, select.getJoinClauses());
+        YSQLSelect rightSelect = getSelect(mappedAggregate, from, notNullClause, select.getJoinClauses());
+        metamorphicQuery = "SELECT " + getOuterAggregateFunction(aggregate) + " FROM (";
+        metamorphicQuery += YSQLVisitor.asString(leftSelect) + " UNION ALL " + YSQLVisitor.asString(middleSelect)
+                + " UNION ALL " + YSQLVisitor.asString(rightSelect);
+        metamorphicQuery += ") as asdf";
+        return metamorphicQuery;
+    }
+
+    private String getAggregateResult(String queryString) throws SQLException {
+        // log TLP Aggregate SELECT queries on the current log file
+        if (state.getOptions().logEachSelect()) {
+            // TODO: refactor me
+            state.getLogger().writeCurrent(queryString);
+            try {
+                state.getLogger().getCurrentFileWriter().flush();
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+        String resultString;
+        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
+            if (result == null) {
+                throw new IgnoreMeException();
+            }
+            if (!result.next()) {
+                resultString = null;
+            } else {
+                resultString = result.getString(1);
+            }
+        } catch (PSQLException e) {
+            throw new AssertionError(queryString, e);
+        }
+        return resultString;
+    }
+
+    private List<YSQLExpression> mapped(YSQLAggregate aggregate) {
+        switch (aggregate.getFunction()) {
+        case SUM:
+        case COUNT:
+        case BIT_AND:
+        case BIT_OR:
+        case BOOL_AND:
+        case BOOL_OR:
+        case MAX:
+        case MIN:
+            return aliasArgs(Arrays.asList(aggregate));
+        // case AVG:
+        //// List<YSQLExpression> arg = Arrays.asList(new
+        // YSQLCast(aggregate.getExpr().get(0),
+        // YSQLDataType.DECIMAL.get()));
+        // YSQLAggregate sum = new YSQLAggregate(YSQLAggregateFunction.SUM,
+        // aggregate.getExpr());
+        // YSQLCast count = new YSQLCast(
+        // new YSQLAggregate(YSQLAggregateFunction.COUNT, aggregate.getExpr()),
+        // YSQLDataType.DECIMAL.get());
+        //// YSQLBinaryArithmeticOperation avg = new
+        // YSQLBinaryArithmeticOperation(sum, count,
+        // YSQLBinaryArithmeticOperator.DIV);
+        // return aliasArgs(Arrays.asList(sum, count));
+        default:
+            throw new AssertionError(aggregate.getFunction());
+        }
+    }
+
+    private List<YSQLExpression> aliasArgs(List<YSQLExpression> originalAggregateArgs) {
+        List<YSQLExpression> args = new ArrayList<>();
+        int i = 0;
+        for (YSQLExpression expr : originalAggregateArgs) {
+            args.add(new YSQLAlias(expr, "agg" + i++));
+        }
+        return args;
+    }
+
+    private String getOuterAggregateFunction(YSQLAggregate aggregate) {
+        switch (aggregate.getFunction()) {
+        // case AVG:
+        // return "SUM(agg0::DECIMAL)/SUM(agg1)::DECIMAL";
+        case COUNT:
+            return YSQLAggregateFunction.SUM + "(agg0)";
+        default:
+            return aggregate.getFunction().toString() + "(agg0)";
+        }
+    }
+
+    private YSQLSelect getSelect(List<YSQLExpression> aggregates, List<YSQLExpression> from, YSQLExpression whereClause,
+            List<YSQLJoin> joinList) {
+        YSQLSelect leftSelect = new YSQLSelect();
+        leftSelect.setFetchColumns(aggregates);
+        leftSelect.setFromList(from);
+        leftSelect.setWhereClause(whereClause);
+        leftSelect.setJoinClauses(joinList);
+        if (Randomly.getBooleanWithSmallProbability()) {
+            leftSelect.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
+        }
+        return leftSelect;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPBase.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPBase.java
@@ -1,0 +1,117 @@
+package sqlancer.yugabyte.ysql.oracle.tlp;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.gen.ExpressionGenerator;
+import sqlancer.common.oracle.TernaryLogicPartitioningOracleBase;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLColumn;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTables;
+import sqlancer.yugabyte.ysql.ast.YSQLColumnValue;
+import sqlancer.yugabyte.ysql.ast.YSQLConstant;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.ast.YSQLJoin;
+import sqlancer.yugabyte.ysql.ast.YSQLSelect;
+import sqlancer.yugabyte.ysql.gen.YSQLCommon;
+import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
+import sqlancer.yugabyte.ysql.oracle.YSQLNoRECOracle;
+
+public class YSQLTLPBase extends TernaryLogicPartitioningOracleBase<YSQLExpression, YSQLGlobalState>
+        implements TestOracle {
+
+    protected YSQLSchema s;
+    protected YSQLTables targetTables;
+    protected YSQLExpressionGenerator gen;
+    protected YSQLSelect select;
+
+    public YSQLTLPBase(YSQLGlobalState state) {
+        super(state);
+        YSQLCommon.addCommonExpressionErrors(errors);
+        YSQLCommon.addCommonFetchErrors(errors);
+    }
+
+    public static YSQLSelect.YSQLSubquery createSubquery(YSQLGlobalState globalState, String name, YSQLTables tables) {
+        List<YSQLExpression> columns = new ArrayList<>();
+        YSQLExpressionGenerator gen = new YSQLExpressionGenerator(globalState).setColumns(tables.getColumns());
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            columns.add(gen.generateExpression(0));
+        }
+        YSQLSelect select = new YSQLSelect();
+        select.setFromList(tables.getTables().stream().map(t -> new YSQLSelect.YSQLFromTable(t, Randomly.getBoolean()))
+                .collect(Collectors.toList()));
+        select.setFetchColumns(columns);
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression(0, YSQLDataType.BOOLEAN));
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByExpressions(gen.generateOrderBy());
+        }
+        if (Randomly.getBoolean()) {
+            select.setLimitClause(YSQLConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
+            if (Randomly.getBoolean()) {
+                select.setOffsetClause(YSQLConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
+            }
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setForClause(YSQLSelect.ForClause.getRandom());
+        }
+        return new YSQLSelect.YSQLSubquery(select, name);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        s = state.getSchema();
+        targetTables = s.getRandomTableNonEmptyTables();
+        List<YSQLTable> tables = targetTables.getTables();
+        List<YSQLJoin> joins = getJoinStatements(state, targetTables.getColumns(), tables);
+        generateSelectBase(tables, joins);
+    }
+
+    protected List<YSQLJoin> getJoinStatements(YSQLGlobalState globalState, List<YSQLColumn> columns,
+            List<YSQLTable> tables) {
+        return YSQLNoRECOracle.getJoinStatements(state, columns, tables);
+        // TODO joins
+    }
+
+    protected void generateSelectBase(List<YSQLTable> tables, List<YSQLJoin> joins) {
+        List<YSQLExpression> tableList = tables.stream()
+                .map(t -> new YSQLSelect.YSQLFromTable(t, Randomly.getBoolean())).collect(Collectors.toList());
+        gen = new YSQLExpressionGenerator(state).setColumns(targetTables.getColumns());
+        initializeTernaryPredicateVariants();
+        select = new YSQLSelect();
+        select.setFetchColumns(generateFetchColumns());
+        select.setFromList(tableList);
+        select.setWhereClause(null);
+        select.setJoinClauses(joins);
+        if (Randomly.getBoolean()) {
+            select.setForClause(YSQLSelect.ForClause.getRandom());
+        }
+    }
+
+    List<YSQLExpression> generateFetchColumns() {
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            return Arrays.asList(new YSQLColumnValue(YSQLColumn.createDummy("*"), null));
+        }
+        List<YSQLExpression> fetchColumns = new ArrayList<>();
+        List<YSQLColumn> targetColumns = Randomly.nonEmptySubset(targetTables.getColumns());
+        for (YSQLColumn c : targetColumns) {
+            fetchColumns.add(new YSQLColumnValue(c, null));
+        }
+        return fetchColumns;
+    }
+
+    @Override
+    protected ExpressionGenerator<YSQLExpression> getGen() {
+        return gen;
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPHavingOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPHavingOracle.java
@@ -1,0 +1,66 @@
+package sqlancer.yugabyte.ysql.oracle.tlp;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+import sqlancer.yugabyte.ysql.ast.YSQLExpression;
+import sqlancer.yugabyte.ysql.gen.YSQLCommon;
+
+public class YSQLTLPHavingOracle extends YSQLTLPBase {
+
+    public YSQLTLPHavingOracle(YSQLGlobalState state) {
+        super(state);
+        YSQLCommon.addGroupingErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        havingCheck();
+    }
+
+    @Override
+    List<YSQLExpression> generateFetchColumns() {
+        List<YSQLExpression> expressions = gen.allowAggregates(true).generateExpressions(Randomly.smallNumber() + 1);
+        gen.allowAggregates(false);
+        return expressions;
+    }
+
+    protected void havingCheck() throws SQLException {
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression(YSQLDataType.BOOLEAN));
+        }
+        select.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
+        select.setHavingClause(null);
+        String originalQueryString = YSQLVisitor.asString(select);
+        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        boolean orderBy = Randomly.getBoolean();
+        if (orderBy) {
+            select.setOrderByExpressions(gen.generateOrderBy());
+        }
+        select.setHavingClause(predicate);
+        String firstQueryString = YSQLVisitor.asString(select);
+        select.setHavingClause(negatedPredicate);
+        String secondQueryString = YSQLVisitor.asString(select);
+        select.setHavingClause(isNullPredicate);
+        String thirdQueryString = YSQLVisitor.asString(select);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                thirdQueryString, combinedString, !orderBy, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
+                state);
+    }
+
+    @Override
+    protected YSQLExpression generatePredicate() {
+        return gen.generateHavingClause();
+    }
+
+}

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPWhereOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPWhereOracle.java
@@ -1,0 +1,45 @@
+package sqlancer.yugabyte.ysql.oracle.tlp;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.yugabyte.ysql.YSQLGlobalState;
+import sqlancer.yugabyte.ysql.YSQLVisitor;
+
+public class YSQLTLPWhereOracle extends YSQLTLPBase {
+
+    public YSQLTLPWhereOracle(YSQLGlobalState state) {
+        super(state);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        whereCheck();
+    }
+
+    protected void whereCheck() throws SQLException {
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByExpressions(gen.generateOrderBy());
+        }
+        String originalQueryString = YSQLVisitor.asString(select);
+        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        select.setOrderByExpressions(Collections.emptyList());
+        select.setWhereClause(predicate);
+        String firstQueryString = YSQLVisitor.asString(select);
+        select.setWhereClause(negatedPredicate);
+        String secondQueryString = YSQLVisitor.asString(select);
+        select.setWhereClause(isNullPredicate);
+        String thirdQueryString = YSQLVisitor.asString(select);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                thirdQueryString, combinedString, Randomly.getBoolean(), state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
+                state);
+    }
+}


### PR DESCRIPTION
Added Yugabyte DB support for SQLancer 

1. YSQL API: Based on Postgres code, with few improvements for Yugabyte
2. YCQL API: Implemented from example, uses Cassandra JDBC driver as a proxy interface. Only FUZZER oracle implemented for now due to YCQL language limitations.