### PR TITLE
Add Provider and Schema for QuestDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,11 @@
       <artifactId>arangodb-java-driver</artifactId>
       <version>6.9.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.questdb</groupId>
+      <artifactId>questdb</artifactId>
+      <version>6.5.3</version>
+    </dependency>
   </dependencies>
   <reporting>
     <plugins>

--- a/src/sqlancer/GlobalState.java
+++ b/src/sqlancer/GlobalState.java
@@ -131,7 +131,7 @@ public abstract class GlobalState<O extends DBMSSpecificOptions<?>, S extends Ab
             try {
                 updateSchema();
             } catch (Exception e) {
-                throw new AssertionError();
+                throw new AssertionError(e.getMessage());
             }
         }
         return schema;

--- a/src/sqlancer/questdb/QuestDBErrors.java
+++ b/src/sqlancer/questdb/QuestDBErrors.java
@@ -1,0 +1,4 @@
+package sqlancer.questdb;
+
+public class QuestDBErrors {
+}

--- a/src/sqlancer/questdb/QuestDBOptions.java
+++ b/src/sqlancer/questdb/QuestDBOptions.java
@@ -1,0 +1,55 @@
+package sqlancer.questdb;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import sqlancer.DBMSSpecificOptions;
+import sqlancer.OracleFactory;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.questdb.QuestDBOptions.QuestDBOracleFactory;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+
+@Parameters(separators = "=", commandDescription = "QuestDB (default port: " + QuestDBOptions.DEFAULT_PORT
+        + " default host: " + QuestDBOptions.DEFAULT_HOST + ")")
+public class QuestDBOptions implements DBMSSpecificOptions<QuestDBOracleFactory> {
+    public static final String DEFAULT_HOST = "localhost";
+    public static final int DEFAULT_PORT = 8812;
+
+    @Parameter(names = "--oracle")
+    public QuestDBOracleFactory oracle = QuestDBOracleFactory.WHERE;
+
+    public enum QuestDBOracleFactory implements OracleFactory<QuestDBGlobalState> {
+        // TODO: implement test oracles
+        WHERE {
+            @Override
+            public TestOracle create(QuestDBGlobalState globalState) throws SQLException {
+                return null;
+            }
+        };
+
+    }
+
+    @Parameter(names = "--username", description = "The user name used to log into QuestDB")
+    private String userName = "admin"; // NOPMD
+
+    @Parameter(names = "--password", description = "The password used to log into QuestDB")
+    private String password = "quest"; // NOPMD
+
+    @Override
+    public List<QuestDBOracleFactory> getTestOracleFactory() {
+        return Arrays.asList(oracle);
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/src/sqlancer/questdb/QuestDBProvider.java
+++ b/src/sqlancer/questdb/QuestDBProvider.java
@@ -1,0 +1,106 @@
+package sqlancer.questdb;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import com.google.auto.service.AutoService;
+
+import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
+import sqlancer.SQLConnection;
+import sqlancer.SQLGlobalState;
+import sqlancer.SQLProviderAdapter;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLQueryProvider;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+import sqlancer.questdb.gen.QuestDBDeleteGenerator;
+import sqlancer.questdb.gen.QuestDBIndexGenerator;
+import sqlancer.questdb.gen.QuestDBInsertGenerator;
+import sqlancer.questdb.gen.QuestDBTableGenerator;
+
+@AutoService(DatabaseProvider.class)
+public class QuestDBProvider extends SQLProviderAdapter<QuestDBGlobalState, QuestDBOptions> {
+    public QuestDBProvider() {
+        super(QuestDBGlobalState.class, QuestDBOptions.class);
+    }
+
+    public enum Action implements AbstractAction<QuestDBGlobalState> {
+        INSERT(QuestDBInsertGenerator::getQuery), //
+        CREATE_INDEX(QuestDBIndexGenerator::getQuery), //
+        DELETE(QuestDBDeleteGenerator::generate); //
+        // TODO: maybe implement these later
+        // UPDATE(QuestDBUpdateGenerator::getQuery), //
+        // CREATE_VIEW(QuestDBViewGenerator::generate), //
+
+        private final SQLQueryProvider<QuestDBGlobalState> sqlQueryProvider;
+
+        Action(SQLQueryProvider<QuestDBGlobalState> sqlQueryProvider) {
+            this.sqlQueryProvider = sqlQueryProvider;
+        }
+
+        @Override
+        public SQLQueryAdapter getQuery(QuestDBGlobalState state) throws Exception {
+            return sqlQueryProvider.getQuery(state);
+        }
+    }
+
+    public static class QuestDBGlobalState extends SQLGlobalState<QuestDBOptions, QuestDBSchema> {
+
+        @Override
+        protected QuestDBSchema readSchema() throws SQLException {
+            return QuestDBSchema.fromConnection(getConnection(), getDatabaseName());
+        }
+
+    }
+
+    @Override
+    public void generateDatabase(QuestDBGlobalState globalState) throws Exception {
+        // TODO: should follow duckdb or cockrachdb? what's the difference between generate and create db?
+    }
+
+    @Override
+    public SQLConnection createDatabase(QuestDBGlobalState globalState) throws Exception {
+        String host = globalState.getOptions().getHost();
+        int port = globalState.getOptions().getPort();
+        if (host == null) {
+            host = QuestDBOptions.DEFAULT_HOST;
+        }
+        if (port == sqlancer.MainOptions.NO_SET_PORT) {
+            port = QuestDBOptions.DEFAULT_PORT;
+        }
+        // TODO(anxing): maybe not hardcode here...
+        String databaseName = "qdb";
+        String tableName = "test";
+        String url = String.format("jdbc:postgresql://%s:%d/%s", host, port, databaseName);
+        // use QuestDB default username & password for Postgres JDBC
+        Properties properties = new Properties();
+        properties.setProperty("user", globalState.getDbmsSpecificOptions().getUserName());
+        properties.setProperty("password", globalState.getDbmsSpecificOptions().getPassword());
+        properties.setProperty("sslmode", "disable");
+
+        Connection con = DriverManager.getConnection(url, properties);
+        // QuestDB cannot create or drop `DATABASE`, can only create or drop `TABLE`
+        globalState.getState().logStatement("DROP TABLE IF EXISTS " + tableName + " CASCADE");
+        SQLQueryAdapter createTableCommand = new QuestDBTableGenerator().getQuery(globalState);
+        globalState.getState().logStatement(createTableCommand);
+
+        try (Statement s = con.createStatement()) {
+            s.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+        try (Statement s = con.createStatement()) {
+            s.execute(createTableCommand.getQueryString());
+        }
+        con.close();
+        con = DriverManager.getConnection(url, properties);
+        return new SQLConnection(con);
+    }
+
+    @Override
+    public String getDBMSName() {
+        return "questdb";
+    }
+
+}

--- a/src/sqlancer/questdb/QuestDBSchema.java
+++ b/src/sqlancer/questdb/QuestDBSchema.java
@@ -1,0 +1,308 @@
+package sqlancer.questdb;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.common.DBMSCommon;
+import sqlancer.common.schema.AbstractRelationalTable;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+import sqlancer.common.schema.TableIndex;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+import sqlancer.questdb.QuestDBSchema.QuestDBTable;
+
+public class QuestDBSchema extends AbstractSchema<QuestDBGlobalState, QuestDBTable> {
+
+    public enum QuestDBDataType {
+
+        BOOLEAN, CHAR,
+        /* STRING, */
+        INT, FLOAT,
+        /* SYMBOL, */
+        DATE, TIMESTAMP,
+        /* GEOHASH, */
+        NULL;
+
+        public static QuestDBDataType getRandomWithoutNull() {
+            QuestDBDataType dt;
+            do {
+                dt = Randomly.fromOptions(values());
+            } while (dt == QuestDBDataType.NULL);
+            return dt;
+        }
+
+    }
+
+    public static class QuestDBCompositeDataType {
+
+        private final QuestDBDataType dataType;
+
+        private final int size;
+
+        private final boolean isNullable;
+
+        public QuestDBCompositeDataType(QuestDBDataType dataType, int size) {
+            this.dataType = dataType;
+            this.size = size;
+
+            switch (dataType) {
+            case INT:
+                switch (size) {
+                case 1:
+                case 2:
+                    isNullable = false;
+                    break;
+                default:
+                    isNullable = true;
+                    break;
+                }
+                break;
+            case BOOLEAN:
+                isNullable = false;
+                break;
+            default:
+                isNullable = true;
+            }
+        }
+
+        public QuestDBDataType getPrimitiveDataType() {
+            return dataType;
+        }
+
+        public int getSize() {
+            if (size == -1) {
+                throw new AssertionError(this);
+            }
+            return size;
+        }
+
+        public boolean isNullable() {
+            return isNullable;
+        }
+
+        public static QuestDBCompositeDataType getRandomWithoutNull() {
+            QuestDBDataType type = QuestDBDataType.getRandomWithoutNull();
+            int size = -1;
+            switch (type) {
+            case INT:
+                size = Randomly.fromOptions(1, 2, 4);
+                break;
+            case FLOAT:
+                size = Randomly.fromOptions(4, 8, 32);
+                break;
+            case BOOLEAN:
+            case CHAR:
+            case DATE:
+            case TIMESTAMP:
+                size = 0;
+                break;
+            default:
+                throw new AssertionError(type);
+            }
+
+            return new QuestDBCompositeDataType(type, size);
+        }
+
+        @Override
+        public String toString() {
+            switch (getPrimitiveDataType()) {
+            case INT:
+                switch (size) {
+                case 1:
+                    return Randomly.fromOptions("BYTE");
+                case 2:
+                    return Randomly.fromOptions("SHORT");
+                case 4:
+                    return Randomly.fromOptions("INT");
+                default:
+                    throw new AssertionError(size);
+                }
+            case CHAR:
+                return "CHAR";
+            case FLOAT:
+                switch (size) {
+                case 4:
+                    return Randomly.fromOptions("FLOAT");
+                case 8:
+                    return Randomly.fromOptions(/* "DOUBLE", */"LONG");
+                case 32:
+                    return Randomly.fromOptions("LONG256");
+                default:
+                    throw new AssertionError(size);
+                }
+            case BOOLEAN:
+                return Randomly.fromOptions("BOOLEAN");
+            case TIMESTAMP:
+                return Randomly.fromOptions("TIMESTAMP");
+            case DATE:
+                return Randomly.fromOptions("DATE");
+            case NULL:
+                return Randomly.fromOptions("NULL");
+            default:
+                throw new AssertionError(getPrimitiveDataType());
+            }
+        }
+
+    }
+
+    public static class QuestDBColumn extends AbstractTableColumn<QuestDBTable, QuestDBCompositeDataType> {
+        private final boolean isIndexed;
+        private final boolean isNullable;
+
+        public QuestDBColumn(String name, QuestDBCompositeDataType columnType, boolean isIndexed) {
+            super(name, null, columnType);
+            this.isIndexed = isIndexed;
+            this.isNullable = columnType.isNullable();
+        }
+
+        public boolean isIndexed() {
+            return isIndexed;
+        }
+
+        public boolean isNullable() {
+            return isNullable;
+        }
+
+    }
+
+    public static class QuestDBTables extends AbstractTables<QuestDBTable, QuestDBColumn> {
+        public static final Set<String> RESERVED_TABLES = new HashSet<>(
+                Arrays.asList("sys.column_versions_purge_log", "telemetry_config", "telemetry"));
+
+        public QuestDBTables(List<QuestDBTable> tables) {
+            super(tables);
+        }
+    }
+
+    public QuestDBSchema(List<QuestDBTable> databaseTables) {
+        super(databaseTables);
+    }
+
+    public QuestDBTables getRandomTableNonEmptyTables() {
+        return new QuestDBTables(Randomly.nonEmptySubset(getDatabaseTables()));
+    }
+
+    private static QuestDBCompositeDataType getColumnType(String typeString) {
+        QuestDBDataType primitiveType;
+        int size = -1;
+
+        switch (typeString) {
+        case "INT":
+            primitiveType = QuestDBDataType.INT;
+            size = 4;
+            break;
+        case "CHAR":
+            primitiveType = QuestDBDataType.CHAR;
+            break;
+        case "FLOAT":
+            primitiveType = QuestDBDataType.FLOAT;
+            size = 4;
+            break;
+        case "LONG":
+            primitiveType = QuestDBDataType.FLOAT;
+            size = 8;
+            break;
+        case "LONG256":
+            primitiveType = QuestDBDataType.FLOAT;
+            size = 32;
+            break;
+        case "BOOLEAN":
+            primitiveType = QuestDBDataType.BOOLEAN;
+            break;
+        case "DATE":
+            primitiveType = QuestDBDataType.DATE;
+            break;
+        case "TIMESTAMP":
+            primitiveType = QuestDBDataType.TIMESTAMP;
+            break;
+        case "BYTE":
+            primitiveType = QuestDBDataType.INT;
+            size = 1;
+            break;
+        case "SHORT":
+            primitiveType = QuestDBDataType.INT;
+            size = 2;
+            break;
+        case "NULL":
+            primitiveType = QuestDBDataType.NULL;
+            break;
+        default:
+            throw new AssertionError(typeString);
+        }
+        return new QuestDBCompositeDataType(primitiveType, size);
+    }
+
+    public static class QuestDBTable extends AbstractRelationalTable<QuestDBColumn, TableIndex, QuestDBGlobalState> {
+
+        public QuestDBTable(String tableName, List<QuestDBColumn> columns, boolean isView) {
+            super(tableName, columns, Collections.emptyList(), isView);
+        }
+
+    }
+
+    public static QuestDBSchema fromConnection(SQLConnection con, String databaseName) throws SQLException {
+        List<QuestDBTable> databaseTables = new ArrayList<>();
+        List<String> tableNames = getTableNames(con);
+        for (String tableName : tableNames) {
+            if (DBMSCommon.matchesIndexName(tableName)) {
+                continue; // TODO: unexpected?
+            }
+            List<QuestDBColumn> databaseColumns = getTableColumns(con, tableName);
+            boolean isView = tableName.startsWith("v");
+            QuestDBTable t = new QuestDBTable(tableName, databaseColumns, isView);
+            for (QuestDBColumn c : databaseColumns) {
+                c.setTable(t);
+            }
+            databaseTables.add(t);
+
+        }
+        return new QuestDBSchema(databaseTables);
+    }
+
+    private static List<String> getTableNames(SQLConnection con) throws SQLException {
+        List<String> tableNames = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery("SHOW TABLES;")) {
+                while (rs.next()) {
+                    String tName = rs.getString("table");
+                    // exclude reserved tables for testing
+                    if (!QuestDBTables.RESERVED_TABLES.contains(tName)) {
+                        tableNames.add(rs.getString("table"));
+                    }
+                }
+            }
+        }
+        return tableNames;
+    }
+
+    private static List<QuestDBColumn> getTableColumns(SQLConnection con, String tableName) throws SQLException {
+        List<QuestDBColumn> columns = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery(String.format("SHOW COLUMNS FROM %s;", tableName))) {
+                while (rs.next()) {
+                    String columnName = rs.getString("column");
+                    String dataType = rs.getString("type");
+                    boolean isIndexed = rs.getString("indexed").contains("true");
+                    QuestDBColumn c = new QuestDBColumn(columnName, getColumnType(dataType), isIndexed);
+                    columns.add(c);
+                }
+            }
+        }
+        if (columns.stream().noneMatch(c -> c.isIndexed())) {
+            // TODO: implement an option to enable/disable rowids
+            columns.add(new QuestDBColumn("rowid", new QuestDBCompositeDataType(QuestDBDataType.INT, 4), false));
+        }
+        return columns;
+    }
+
+}

--- a/src/sqlancer/questdb/gen/QuestDBDeleteGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBDeleteGenerator.java
@@ -1,0 +1,15 @@
+package sqlancer.questdb.gen;
+
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+
+public final class QuestDBDeleteGenerator {
+    private QuestDBDeleteGenerator() {
+
+    }
+
+    public static SQLQueryAdapter generate(QuestDBGlobalState globalState) {
+        // TODO
+        return null;
+    }
+}

--- a/src/sqlancer/questdb/gen/QuestDBIndexGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBIndexGenerator.java
@@ -1,0 +1,14 @@
+package sqlancer.questdb.gen;
+
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+
+public final class QuestDBIndexGenerator {
+    private QuestDBIndexGenerator() {
+    }
+
+    public static SQLQueryAdapter getQuery(QuestDBGlobalState globalState) {
+        // TODO
+        return null;
+    }
+}

--- a/src/sqlancer/questdb/gen/QuestDBInsertGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBInsertGenerator.java
@@ -1,0 +1,35 @@
+package sqlancer.questdb.gen;
+
+import sqlancer.common.gen.AbstractInsertGenerator;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+import sqlancer.questdb.QuestDBSchema;
+import sqlancer.questdb.QuestDBSchema.QuestDBColumn;
+
+public class QuestDBInsertGenerator extends AbstractInsertGenerator<QuestDBColumn> {
+
+    private final QuestDBGlobalState globalState;
+
+    // uncomment later:
+    // private final ExpectedErrors errors = new ExpectedErrors();
+
+    public QuestDBInsertGenerator(QuestDBGlobalState globalState) {
+        this.globalState = globalState;
+    }
+
+    private SQLQueryAdapter generate() {
+        // TODO: below is dummy implementation to pass compilation
+        QuestDBSchema.QuestDBTable table = globalState.getSchema().getRandomTable();
+        table.getRandomNonEmptyColumnSubset();
+        return null;
+    }
+
+    public static SQLQueryAdapter getQuery(QuestDBGlobalState globalState) {
+        return new QuestDBInsertGenerator(globalState).generate();
+    }
+
+    @Override
+    protected void insertValue(QuestDBColumn tiDBColumn) {
+        // TODO
+    }
+}

--- a/src/sqlancer/questdb/gen/QuestDBTableGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBTableGenerator.java
@@ -1,0 +1,43 @@
+package sqlancer.questdb.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+import sqlancer.questdb.QuestDBSchema.QuestDBColumn;
+import sqlancer.questdb.QuestDBSchema.QuestDBCompositeDataType;
+
+public class QuestDBTableGenerator {
+
+    public SQLQueryAdapter getQuery(QuestDBGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder();
+        String tableName = "test"; // globalState.getSchema().getFreeTableName();
+        sb.append("CREATE TABLE ");
+        sb.append(tableName);
+        sb.append("(");
+        List<QuestDBColumn> columns = getNewColumns();
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(columns.get(i).getName());
+            sb.append(" ");
+            sb.append(columns.get(i).getType());
+        }
+        sb.append(");");
+        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+    private static List<QuestDBColumn> getNewColumns() {
+        List<QuestDBColumn> columns = new ArrayList<>();
+        for (int i = 0; i < sqlancer.Randomly.smallNumber() + 1; i++) {
+            String columnName = String.format("c%d", i);
+            QuestDBCompositeDataType columnType = QuestDBCompositeDataType.getRandomWithoutNull();
+            columns.add(new QuestDBColumn(columnName, columnType, false));
+        }
+        return columns;
+    }
+}

--- a/src/sqlancer/questdb/gen/QuestDBUpdateGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBUpdateGenerator.java
@@ -1,0 +1,16 @@
+package sqlancer.questdb.gen;
+
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+
+public final class QuestDBUpdateGenerator {
+
+    private QuestDBUpdateGenerator() {
+    }
+
+    public static SQLQueryAdapter getQuery(QuestDBGlobalState globalState) {
+        // TODO
+        return null;
+    }
+
+}

--- a/src/sqlancer/questdb/gen/QuestDBViewGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBViewGenerator.java
@@ -1,0 +1,14 @@
+package sqlancer.questdb.gen;
+
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
+
+public final class QuestDBViewGenerator {
+    private QuestDBViewGenerator() {
+    }
+
+    public static SQLQueryAdapter generate(QuestDBGlobalState globalState) {
+        // TODO
+        return null;
+    }
+}


### PR DESCRIPTION
Add Provider and Schema classes for QuestDB.
Generators are only skeletons for now. They will be implemented in the upcoming PRs.

QuestDB is connected via PostgreSQL JDBC with default setting: https://questdb.io/docs/reference/api/postgres/