### PR TITLE
Add DuckDB canonicalization rule for `-0` -> `0`

### DIFF
--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
@@ -3,7 +3,6 @@ package sqlancer.duckdb.test;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
@@ -38,9 +37,16 @@ public class DuckDBQueryPartitioningBase
     }
 
     public static String canonicalizeResultValue(String value) {
-        // Rule: -0.0 should be canonicalized to 0.0
-        if (Objects.equals(value, "-0.0")) {
+        if (value == null) {
+            return value;
+        }
+
+        switch (value) {
+        case "-0.0":
             return "0.0";
+        case "-0":
+            return "0";
+        default:
         }
 
         return value;


### PR DESCRIPTION
While testing SQLancer on DuckDB, noticed from some errors that the previous implementation only canonicalized double/float negative zeros -- this rule adds the same rule for integers.