### PR TITLE
Implement more expressions and add SELECT, WHERE to test

### DIFF
--- a/src/sqlancer/questdb/QuestDBBugs.java
+++ b/src/sqlancer/questdb/QuestDBBugs.java
@@ -2,9 +2,6 @@ package sqlancer.questdb;
 
 public final class QuestDBBugs {
 
-    // https://github.com/questdb/questdb/issues/2689
-    public static boolean bug2689 = true;
-
     private QuestDBBugs() {
     }
 }

--- a/src/sqlancer/questdb/QuestDBErrors.java
+++ b/src/sqlancer/questdb/QuestDBErrors.java
@@ -9,6 +9,13 @@ public final class QuestDBErrors {
 
     public static void addExpressionErrors(ExpectedErrors errors) {
         // TODO (anxing)
+        errors.add("unexpected argument for function: ");
+        errors.add("unexpected token:"); // SELECT FROM multiple tables without WHERE/ JOIN clause
+        errors.add("boolean expression expected");
+        errors.add("Column name expected");
+        errors.add("too few arguments for 'in'");
+        errors.add("cannot compare TIMESTAMP with type"); // WHERE column IN with nonTIMESTAMP arg
+        errors.add("constant expected");
     }
 
     public static void addGroupByErrors(ExpectedErrors errors) {

--- a/src/sqlancer/questdb/QuestDBToStringVisitor.java
+++ b/src/sqlancer/questdb/QuestDBToStringVisitor.java
@@ -4,6 +4,7 @@ import sqlancer.common.ast.newast.NewToStringVisitor;
 import sqlancer.common.ast.newast.Node;
 import sqlancer.questdb.ast.QuestDBConstant;
 import sqlancer.questdb.ast.QuestDBExpression;
+import sqlancer.questdb.ast.QuestDBSelect;
 
 public class QuestDBToStringVisitor extends NewToStringVisitor<QuestDBExpression> {
 
@@ -11,13 +12,51 @@ public class QuestDBToStringVisitor extends NewToStringVisitor<QuestDBExpression
     public void visitSpecific(Node<QuestDBExpression> expr) {
         if (expr instanceof QuestDBConstant) {
             visit((QuestDBConstant) expr);
-        } else { // TODO: maybe implement QuestDBSelect & Join
+        } else if (expr instanceof QuestDBSelect) {
+            visit((QuestDBSelect) expr);
+        } else { // TODO: maybe implement QuestDBJoin
             throw new AssertionError("Unknown class: " + expr.getClass());
         }
     }
 
     private void visit(QuestDBConstant constant) {
         sb.append(constant.toString());
+    }
+
+    private void visit(QuestDBSelect select) {
+        sb.append("SELECT ");
+        if (select.isDistinct()) {
+            sb.append("DISTINCT ");
+        }
+        visit(select.getFetchColumns());
+        sb.append(" FROM ");
+        visit(select.getFromList());
+        if (!select.getFromList().isEmpty() && !select.getJoinList().isEmpty()) {
+            sb.append(", ");
+        }
+        if (!select.getJoinList().isEmpty()) {
+            visit(select.getJoinList());
+        }
+        if (select.getWhereClause() != null) {
+            sb.append(" WHERE ");
+            visit(select.getWhereClause());
+        }
+        // if (!select.getGroupByExpressions().isEmpty()) {
+        // sb.append(" GROUP BY ");
+        // visit(select.getGroupByExpressions());
+        // }
+        // if (select.getHavingClause() != null) {
+        // sb.append(" HAVING ");
+        // visit(select.getHavingClause());
+        // }
+        // if (!select.getOrderByExpressions().isEmpty()) {
+        // sb.append(" ORDER BY ");
+        // visit(select.getOrderByExpressions());
+        // }
+        if (select.getLimitClause() != null) {
+            sb.append(" LIMIT ");
+            visit(select.getLimitClause());
+        }
     }
 
     public static String asString(Node<QuestDBExpression> expr) {

--- a/src/sqlancer/questdb/ast/QuestDBConstant.java
+++ b/src/sqlancer/questdb/ast/QuestDBConstant.java
@@ -66,9 +66,9 @@ public class QuestDBConstant implements Node<QuestDBExpression> {
         @Override
         public String toString() {
             if (value == Double.POSITIVE_INFINITY) {
-                return "'+Inf'";
+                return "cast('Infinity' as double)";
             } else if (value == Double.NEGATIVE_INFINITY) {
-                return "'-Inf'";
+                return "cast('-Infinity' as double)";
             }
             return String.valueOf(value);
         }

--- a/src/sqlancer/questdb/gen/QuestDBExpressionGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBExpressionGenerator.java
@@ -1,8 +1,14 @@
 package sqlancer.questdb.gen;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import sqlancer.Randomly;
 import sqlancer.common.ast.BinaryOperatorNode.Operator;
 import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.common.ast.newast.NewBinaryOperatorNode;
+import sqlancer.common.ast.newast.NewInOperatorNode;
 import sqlancer.common.ast.newast.NewUnaryPostfixOperatorNode;
 import sqlancer.common.ast.newast.NewUnaryPrefixOperatorNode;
 import sqlancer.common.ast.newast.Node;
@@ -19,6 +25,10 @@ public class QuestDBExpressionGenerator extends UntypedExpressionGenerator<Node<
 
     public QuestDBExpressionGenerator(QuestDBGlobalState globalState) {
         this.globalState = globalState;
+    }
+
+    private enum Expression {
+        UNARY_POSTFIX, UNARY_PREFIX, BINARY_COMPARISON, BINARY_LOGICAL, BINARY_ARITHMETIC, IN
     }
 
     @Override
@@ -57,7 +67,31 @@ public class QuestDBExpressionGenerator extends UntypedExpressionGenerator<Node<
     protected Node<QuestDBExpression> generateExpression(int depth) {
         if (depth >= globalState.getOptions().getMaxExpressionDepth() || Randomly.getBoolean()) {
             return generateLeafNode();
-        } else {
+        }
+
+        List<Expression> possibleOptions = new ArrayList<>(Arrays.asList(Expression.values()));
+        Expression expr = Randomly.fromList(possibleOptions);
+
+        switch (expr) {
+        case UNARY_PREFIX:
+            return new NewUnaryPrefixOperatorNode<>(generateExpression(depth + 1),
+                    QuestDBUnaryPrefixOperator.getRandom());
+        case UNARY_POSTFIX:
+            return new NewUnaryPostfixOperatorNode<>(generateExpression(depth + 1),
+                    QuestDBUnaryPostfixOperator.getRandom());
+        case BINARY_COMPARISON:
+            return new NewBinaryOperatorNode<>(generateExpression(depth + 1), generateExpression(depth + 1),
+                    QuestDBBinaryComparisonOperator.getRandom());
+        case BINARY_ARITHMETIC:
+            return new NewBinaryOperatorNode<>(generateExpression(depth + 1), generateExpression(depth + 1),
+                    QuestDBBinaryArithmeticOperator.getRandom());
+        case BINARY_LOGICAL:
+            return new NewBinaryOperatorNode<>(generateExpression(depth + 1), generateExpression(depth + 1),
+                    QuestDBBinaryLogicalOperator.getRandom());
+        case IN:
+            return new NewInOperatorNode<>(generateExpression(depth + 1),
+                    generateExpressions(Randomly.smallNumber() + 1, depth + 1), Randomly.getBoolean());
+        default:
             throw new AssertionError("Expression generation failed, depth=" + depth);
         }
     }
@@ -125,7 +159,7 @@ public class QuestDBExpressionGenerator extends UntypedExpressionGenerator<Node<
 
     public enum QuestDBBinaryComparisonOperator implements Operator {
         EQUALS("="), GREATER_THAN(">"), GREATER_THAN_EQUALS(">="), LESS_THAN("<"), SMALLER_THAN_EQUALS("<="),
-        NOT_EQUALS("!=");
+        NOT_EQUALS("!="), REGEX_POSIX("~"), REGEX_POSIT_NOT("!~");
 
         private String textRepr;
 
@@ -142,5 +176,25 @@ public class QuestDBExpressionGenerator extends UntypedExpressionGenerator<Node<
             return textRepr;
         }
 
+    }
+
+    public enum QuestDBBinaryArithmeticOperator implements Operator {
+        CONCAT("||"), ADD("+"), SUB("-"), MULT("*"), DIV("/"), MOD("%"), AND("&"), OR("|"); // , LSHIFT("<<"),
+                                                                                            // RSHIFT(">>");
+
+        private String textRepr;
+
+        QuestDBBinaryArithmeticOperator(String textRepr) {
+            this.textRepr = textRepr;
+        }
+
+        public static Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepr;
+        }
     }
 }

--- a/src/sqlancer/questdb/gen/QuestDBTableGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBTableGenerator.java
@@ -7,7 +7,6 @@ import javax.annotation.Nullable;
 import sqlancer.Randomly;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.questdb.QuestDBBugs;
 import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
 import sqlancer.questdb.QuestDBSchema.QuestDBColumn;
 import sqlancer.questdb.QuestDBSchema.QuestDBCompositeDataType;
@@ -37,18 +36,6 @@ public class QuestDBTableGenerator {
             sb.append(columns.get(i).getType());
         }
         sb.append(")");
-        // test index at Create Table
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            errors.add("cannot create index");
-            // QuestDB does not support index for non-SYMBOL typed columns
-            errors.add("Index flag is only supported for SYMBOL");
-            sb.append(",");
-            String index = String.format(" INDEX (%s)", Randomly.fromList(columns).getName());
-            sb.append(index);
-        }
-        if (QuestDBBugs.bug2689) {
-            errors.add("Invalid metadata");
-        }
         sb.append(";");
         errors.add("table already exists");
         return new SQLQueryAdapter(sb.toString(), errors, true);


### PR DESCRIPTION
- Implement Unary/Binary operator generators for testing
- Implement `SELECT` visitor
- Add expected errors found when running sqlancer against QuestDB 
- Fix `Inf` String representation in Double
