### PR TITLE
tidb: ignore Empty pattern is invalid error

### DIFF
--- a/src/sqlancer/tidb/TiDBErrors.java
+++ b/src/sqlancer/tidb/TiDBErrors.java
@@ -31,6 +31,7 @@ public final class TiDBErrors {
         // regex
         errors.add("error parsing regexp");
         errors.add("from regexp");
+        errors.add("Empty pattern is invalid");
 
         // To avoid bugs
         errors.add("Unknown column"); // https://github.com/pingcap/tidb/issues/35522


### PR DESCRIPTION
We find sqlancer will report this error messenge many time. this error messenge can be ignored.

Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>