### PR TITLE
Add Reducer capabilities by introducing a Reproducer that can be retrieved from TestOracle

### DIFF
--- a/src/sqlancer/DatabaseProvider.java
+++ b/src/sqlancer/DatabaseProvider.java
@@ -24,6 +24,8 @@ public interface DatabaseProvider<G extends GlobalState<O, ?, C>, O extends DBMS
      * @param globalState
      *            the state created and is valid for this method call.
      *
+     * @return Reproducer if a bug is found and a reproducer is available.
+     *
      * @throws Exception
      *             if creating the database fails.
      *

--- a/src/sqlancer/DatabaseProvider.java
+++ b/src/sqlancer/DatabaseProvider.java
@@ -28,7 +28,7 @@ public interface DatabaseProvider<G extends GlobalState<O, ?, C>, O extends DBMS
      *             if creating the database fails.
      *
      */
-    void generateAndTestDatabase(G globalState) throws Exception;
+    Reproducer<G> generateAndTestDatabase(G globalState) throws Exception;
 
     C createDatabase(G globalState) throws Exception;
 

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -107,6 +107,9 @@ public class MainOptions {
     @Parameter(names = "--database-prefix", description = "The prefix used for each database created")
     private String databasePrefix = "database"; // NOPMD
 
+    @Parameter(names = "--use-reducer", description = "EXPERIMENTAL Attempt to reduce queries using a simple reducer")
+    private boolean useReducer = false; // NOPMD
+
     public int getMaxExpressionDepth() {
         return maxExpressionDepth;
     }
@@ -244,4 +247,7 @@ public class MainOptions {
         return useConnectionTest;
     }
 
+    public boolean useReducer() {
+        return useReducer;
+    }
 }

--- a/src/sqlancer/OracleFactory.java
+++ b/src/sqlancer/OracleFactory.java
@@ -4,7 +4,7 @@ import sqlancer.common.oracle.TestOracle;
 
 public interface OracleFactory<G extends GlobalState<?, ?, ?>> {
 
-    TestOracle create(G globalState) throws Exception;
+    TestOracle<G> create(G globalState) throws Exception;
 
     /**
      * Indicates whether the test oracle requires that all tables (including views) contain at least one row.

--- a/src/sqlancer/ProviderAdapter.java
+++ b/src/sqlancer/ProviderAdapter.java
@@ -41,7 +41,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
             checkViewsAreValid(globalState);
             globalState.getManager().incrementCreateDatabase();
 
-            TestOracle oracle = getTestOracle(globalState);
+            TestOracle<G> oracle = getTestOracle(globalState);
             for (int i = 0; i < globalState.getOptions().getNrQueries(); i++) {
                 try (OracleRunReproductionState localState = globalState.getState().createLocalState()) {
                     assert localState != null;
@@ -62,7 +62,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
 
     protected abstract void checkViewsAreValid(G globalState);
 
-    protected TestOracle getTestOracle(G globalState) throws Exception {
+    protected TestOracle<G> getTestOracle(G globalState) throws Exception {
         List<? extends OracleFactory<G>> testOracleFactory = globalState.getDbmsSpecificOptions()
                 .getTestOracleFactory();
         boolean testOracleRequiresMoreThanZeroRows = testOracleFactory.stream()
@@ -75,7 +75,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
         if (testOracleFactory.size() == 1) {
             return testOracleFactory.get(0).create(globalState);
         } else {
-            return new CompositeTestOracle(testOracleFactory.stream().map(o -> {
+            return new CompositeTestOracle<G>(testOracleFactory.stream().map(o -> {
                 try {
                     return o.create(globalState);
                 } catch (Exception e1) {

--- a/src/sqlancer/Reducer.java
+++ b/src/sqlancer/Reducer.java
@@ -1,0 +1,7 @@
+package sqlancer;
+
+public interface Reducer<G extends GlobalState<?, ?, ?>> {
+
+    void reduce(G state, Reproducer<G> reproducer, G newGlobalState) throws Exception;
+
+}

--- a/src/sqlancer/Reproducer.java
+++ b/src/sqlancer/Reproducer.java
@@ -1,0 +1,5 @@
+package sqlancer;
+
+public interface Reproducer<G extends GlobalState<?, ?, ?>> {
+    boolean bugStillTriggers(G globalState);
+}

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -9,7 +9,7 @@ import sqlancer.common.query.Query;
 
 public class StateToReproduce {
 
-    private final List<Query<?>> statements = new ArrayList<>();
+    private List<Query<?>> statements = new ArrayList<>();
 
     private final String databaseName;
 
@@ -126,6 +126,10 @@ public class StateToReproduce {
 
     public OracleRunReproductionState createLocalState() {
         return new OracleRunReproductionState();
+    }
+
+    public void setStatements(List<Query<?>> statements) {
+        this.statements = statements;
     }
 
 }

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -1,0 +1,87 @@
+package sqlancer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import sqlancer.common.query.Query;
+
+public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpecificOptions<?>, C extends SQLancerDBConnection>
+        implements Reducer<G> {
+    private final DatabaseProvider<G, O, C> provider;
+    private boolean observedChange;
+
+    public StatementReducer(DatabaseProvider<G, O, C> provider) {
+        this.provider = provider;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void reduce(G state, Reproducer<G> reproducer, G newGlobalState) throws Exception {
+
+        List<Query<C>> knownToReproduceBugStatements = new ArrayList<>();
+        for (Query<?> stat : state.getState().getStatements()) {
+            knownToReproduceBugStatements.add((Query<C>) stat);
+        }
+        System.out.println("Starting query:");
+        printQueries(knownToReproduceBugStatements);
+        System.out.println();
+
+        do {
+            observedChange = false;
+            knownToReproduceBugStatements = tryReduction(state, reproducer, newGlobalState,
+                    knownToReproduceBugStatements, (candidateStatements, i) -> {
+                        candidateStatements.remove((int) i);
+                        return true;
+                    });
+        } while (observedChange);
+
+        System.out.println("Reduced query:");
+        printQueries(knownToReproduceBugStatements);
+    }
+
+    private List<Query<C>> tryReduction(G state, // NOPMD
+            Reproducer<G> reproducer, G newGlobalState, List<Query<C>> knownToReproduceBugStatements,
+            BiFunction<List<Query<C>>, Integer, Boolean> reductionOperation) throws Exception {
+
+        List<Query<C>> statements = knownToReproduceBugStatements;
+        for (int i = 0; i < statements.size(); i++) {
+            try (C con2 = provider.createDatabase(newGlobalState)) {
+                newGlobalState.setConnection(con2);
+                List<Query<C>> candidateStatements = new ArrayList<>(statements);
+                if (!reductionOperation.apply(candidateStatements, i)) {
+                    continue;
+                }
+                newGlobalState.getState().setStatements(candidateStatements.stream().collect(Collectors.toList()));
+                for (Query<C> s : candidateStatements) {
+                    try {
+                        s.execute(newGlobalState);
+                    } catch (Throwable ignoredException) {
+                        // ignore
+                    }
+                }
+                try {
+                    if (reproducer.bugStillTriggers(newGlobalState)) {
+                        observedChange = true;
+                        statements = candidateStatements;
+                        // reproducer.outputHook((SQLite3GlobalState) newGlobalState);
+                        // state.getLogger().logReduced(newGlobalState.getState());
+                    }
+                } catch (Throwable ignoredException) {
+
+                }
+            }
+        }
+        return statements;
+    }
+
+    private void printQueries(List<Query<C>> statements) {
+        System.out.println("===============================");
+        for (Query<?> q : statements) {
+            System.out.println(q.getLogString());
+        }
+        System.out.println("===============================");
+    }
+
+}

--- a/src/sqlancer/arangodb/ArangoDBOptions.java
+++ b/src/sqlancer/arangodb/ArangoDBOptions.java
@@ -40,10 +40,10 @@ public class ArangoDBOptions implements DBMSSpecificOptions<ArangoDBOptions.Aran
     public enum ArangoDBOracleFactory implements OracleFactory<ArangoDBGlobalState> {
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(ArangoDBGlobalState globalState) throws Exception {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<ArangoDBGlobalState> create(ArangoDBGlobalState globalState) throws Exception {
+                List<TestOracle<ArangoDBGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new ArangoDBQueryPartitioningWhereTester(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<ArangoDBGlobalState>(oracles, globalState);
             }
         }
     }

--- a/src/sqlancer/arangodb/test/ArangoDBQueryPartitioningBase.java
+++ b/src/sqlancer/arangodb/test/ArangoDBQueryPartitioningBase.java
@@ -17,7 +17,7 @@ import sqlancer.common.oracle.TestOracle;
 
 public class ArangoDBQueryPartitioningBase
         extends TernaryLogicPartitioningOracleBase<Node<ArangoDBExpression>, ArangoDBProvider.ArangoDBGlobalState>
-        implements TestOracle {
+        implements TestOracle<ArangoDBProvider.ArangoDBGlobalState> {
 
     protected ArangoDBSchema schema;
     protected List<ArangoDBSchema.ArangoDBColumn> targetColumns;

--- a/src/sqlancer/citus/CitusOptions.java
+++ b/src/sqlancer/citus/CitusOptions.java
@@ -29,21 +29,21 @@ public class CitusOptions extends PostgresOptions {
     public enum CitusOracleFactory implements OracleFactory<PostgresGlobalState> {
         NOREC {
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
                 CitusGlobalState citusGlobalState = (CitusGlobalState) globalState;
                 return new CitusNoRECOracle(citusGlobalState);
             }
         },
         PQS {
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
                 return new PostgresPivotedQuerySynthesisOracle(globalState);
             }
         },
         HAVING {
 
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
                 CitusGlobalState citusGlobalState = (CitusGlobalState) globalState;
                 return new CitusTLPHavingOracle(citusGlobalState);
             }
@@ -51,13 +51,13 @@ public class CitusOptions extends PostgresOptions {
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
                 CitusGlobalState citusGlobalState = (CitusGlobalState) globalState;
-                List<TestOracle> oracles = new ArrayList<>();
+                List<TestOracle<PostgresGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new CitusTLPWhereOracle(citusGlobalState));
                 oracles.add(new CitusTLPHavingOracle(citusGlobalState));
                 oracles.add(new CitusTLPAggregateOracle(citusGlobalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<PostgresGlobalState>(oracles, globalState);
             }
         };
 

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -320,13 +320,14 @@ public class CitusProvider extends PostgresProvider {
 
     @Override
     protected TestOracle<PostgresGlobalState> getTestOracle(PostgresGlobalState globalState) throws SQLException {
-        List<TestOracle<PostgresGlobalState>> oracles = ((CitusOptions) globalState.getDbmsSpecificOptions()).citusOracle.stream().map(o -> {
-            try {
-                return o.create(globalState);
-            } catch (Exception e1) {
-                throw new AssertionError(e1);
-            }
-        }).collect(Collectors.toList());
+        List<TestOracle<PostgresGlobalState>> oracles = ((CitusOptions) globalState
+                .getDbmsSpecificOptions()).citusOracle.stream().map(o -> {
+                    try {
+                        return o.create(globalState);
+                    } catch (Exception e1) {
+                        throw new AssertionError(e1);
+                    }
+                }).collect(Collectors.toList());
         return new CompositeTestOracle<PostgresGlobalState>(oracles, globalState);
     }
 

--- a/src/sqlancer/citus/CitusProvider.java
+++ b/src/sqlancer/citus/CitusProvider.java
@@ -319,15 +319,15 @@ public class CitusProvider extends PostgresProvider {
     }
 
     @Override
-    protected TestOracle getTestOracle(PostgresGlobalState globalState) throws SQLException {
-        List<TestOracle> oracles = ((CitusOptions) globalState.getDbmsSpecificOptions()).citusOracle.stream().map(o -> {
+    protected TestOracle<PostgresGlobalState> getTestOracle(PostgresGlobalState globalState) throws SQLException {
+        List<TestOracle<PostgresGlobalState>> oracles = ((CitusOptions) globalState.getDbmsSpecificOptions()).citusOracle.stream().map(o -> {
             try {
                 return o.create(globalState);
             } catch (Exception e1) {
                 throw new AssertionError(e1);
             }
         }).collect(Collectors.toList());
-        return new CompositeTestOracle(oracles, globalState);
+        return new CompositeTestOracle<PostgresGlobalState>(oracles, globalState);
     }
 
     private List<CitusWorkerNode> readCitusWorkerNodes(PostgresGlobalState globalState, SQLConnection con)

--- a/src/sqlancer/clickhouse/ClickHouseOptions.java
+++ b/src/sqlancer/clickhouse/ClickHouseOptions.java
@@ -34,37 +34,37 @@ public class ClickHouseOptions implements DBMSSpecificOptions<ClickHouseOracleFa
     public enum ClickHouseOracleFactory implements OracleFactory<ClickHouseGlobalState> {
         TLPWhere {
             @Override
-            public TestOracle create(ClickHouseGlobalState globalState) throws SQLException {
+            public TestOracle<ClickHouseGlobalState> create(ClickHouseGlobalState globalState) throws SQLException {
                 return new ClickHouseTLPWhereOracle(globalState);
             }
         },
         TLPDistinct {
             @Override
-            public TestOracle create(ClickHouseGlobalState globalState) throws SQLException {
+            public TestOracle<ClickHouseGlobalState> create(ClickHouseGlobalState globalState) throws SQLException {
                 return new ClickHouseTLPDistinctOracle(globalState);
             }
         },
         TLPGroupBy {
             @Override
-            public TestOracle create(ClickHouseGlobalState globalState) throws SQLException {
+            public TestOracle<ClickHouseGlobalState> create(ClickHouseGlobalState globalState) throws SQLException {
                 return new ClickHouseTLPGroupByOracle(globalState);
             }
         },
         TLPAggregate {
             @Override
-            public TestOracle create(ClickHouseGlobalState globalState) throws SQLException {
+            public TestOracle<ClickHouseGlobalState> create(ClickHouseGlobalState globalState) throws SQLException {
                 return new ClickHouseTLPAggregateOracle(globalState);
             }
         },
         TLPHaving {
             @Override
-            public TestOracle create(ClickHouseGlobalState globalState) throws SQLException {
+            public TestOracle<ClickHouseGlobalState> create(ClickHouseGlobalState globalState) throws SQLException {
                 return new ClickHouseTLPHavingOracle(globalState);
             }
         },
         NoREC {
             @Override
-            public TestOracle create(ClickHouseGlobalState globalState) throws SQLException {
+            public TestOracle<ClickHouseGlobalState> create(ClickHouseGlobalState globalState) throws SQLException {
                 return new ClickHouseNoRECOracle(globalState);
             }
         };

--- a/src/sqlancer/clickhouse/oracle/norec/ClickHouseNoRECOracle.java
+++ b/src/sqlancer/clickhouse/oracle/norec/ClickHouseNoRECOracle.java
@@ -28,7 +28,7 @@ import sqlancer.common.oracle.TestOracle;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
 
-public class ClickHouseNoRECOracle extends NoRECBase<ClickHouseGlobalState> implements TestOracle {
+public class ClickHouseNoRECOracle extends NoRECBase<ClickHouseGlobalState> implements TestOracle<ClickHouseGlobalState> {
 
     private final ClickHouseSchema s;
 

--- a/src/sqlancer/clickhouse/oracle/norec/ClickHouseNoRECOracle.java
+++ b/src/sqlancer/clickhouse/oracle/norec/ClickHouseNoRECOracle.java
@@ -28,7 +28,8 @@ import sqlancer.common.oracle.TestOracle;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
 
-public class ClickHouseNoRECOracle extends NoRECBase<ClickHouseGlobalState> implements TestOracle<ClickHouseGlobalState> {
+public class ClickHouseNoRECOracle extends NoRECBase<ClickHouseGlobalState>
+        implements TestOracle<ClickHouseGlobalState> {
 
     private final ClickHouseSchema s;
 

--- a/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPBase.java
+++ b/src/sqlancer/clickhouse/oracle/tlp/ClickHouseTLPBase.java
@@ -26,7 +26,7 @@ import sqlancer.common.oracle.TernaryLogicPartitioningOracleBase;
 import sqlancer.common.oracle.TestOracle;
 
 public class ClickHouseTLPBase extends TernaryLogicPartitioningOracleBase<ClickHouseExpression, ClickHouseGlobalState>
-        implements TestOracle {
+        implements TestOracle<ClickHouseGlobalState> {
 
     ClickHouseSchema schema;
     ClickHouseTables targetTables;

--- a/src/sqlancer/cockroachdb/CockroachDBOptions.java
+++ b/src/sqlancer/cockroachdb/CockroachDBOptions.java
@@ -34,59 +34,59 @@ public class CockroachDBOptions implements DBMSSpecificOptions<CockroachDBOracle
     public enum CockroachDBOracleFactory implements OracleFactory<CockroachDBGlobalState> {
         NOREC {
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
                 return new CockroachDBNoRECOracle(globalState);
             }
         },
         AGGREGATE {
 
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
                 return new CockroachDBTLPAggregateOracle(globalState);
             }
 
         },
         GROUP_BY {
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
                 return new CockroachDBTLPGroupByOracle(globalState);
             }
         },
         HAVING {
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
                 return new CockroachDBTLPHavingOracle(globalState);
             }
         },
         WHERE {
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
                 return new CockroachDBTLPWhereOracle(globalState);
             }
         },
         DISTINCT {
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
                 return new CockroachDBTLPDistinctOracle(globalState);
             }
         },
         EXTENDED_WHERE {
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
                 return new CockroachDBTLPExtendedWhereOracle(globalState);
             }
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(CockroachDBGlobalState globalState) throws SQLException {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<CockroachDBGlobalState> create(CockroachDBGlobalState globalState) throws SQLException {
+                List<TestOracle<CockroachDBGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new CockroachDBTLPAggregateOracle(globalState));
                 oracles.add(new CockroachDBTLPHavingOracle(globalState));
                 oracles.add(new CockroachDBTLPWhereOracle(globalState));
                 oracles.add(new CockroachDBTLPGroupByOracle(globalState));
                 oracles.add(new CockroachDBTLPExtendedWhereOracle(globalState));
                 oracles.add(new CockroachDBTLPDistinctOracle(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<CockroachDBGlobalState>(oracles, globalState);
             }
         };
 

--- a/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
@@ -29,7 +29,8 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
 
-public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState> implements TestOracle<CockroachDBGlobalState> {
+public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState>
+        implements TestOracle<CockroachDBGlobalState> {
 
     private CockroachDBExpressionGenerator gen;
 

--- a/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/CockroachDBNoRECOracle.java
@@ -29,7 +29,7 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
 
-public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState> implements TestOracle {
+public class CockroachDBNoRECOracle extends NoRECBase<CockroachDBGlobalState> implements TestOracle<CockroachDBGlobalState> {
 
     private CockroachDBExpressionGenerator gen;
 

--- a/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
+++ b/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPAggregateOracle.java
@@ -35,7 +35,7 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
 
-public class CockroachDBTLPAggregateOracle implements TestOracle {
+public class CockroachDBTLPAggregateOracle implements TestOracle<CockroachDBGlobalState> {
 
     private final CockroachDBGlobalState state;
     private final ExpectedErrors errors = new ExpectedErrors();

--- a/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPBase.java
+++ b/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPBase.java
@@ -22,8 +22,9 @@ import sqlancer.common.gen.ExpressionGenerator;
 import sqlancer.common.oracle.TernaryLogicPartitioningOracleBase;
 import sqlancer.common.oracle.TestOracle;
 
-public class CockroachDBTLPBase extends
-        TernaryLogicPartitioningOracleBase<CockroachDBExpression, CockroachDBGlobalState> implements TestOracle<CockroachDBGlobalState> {
+public class CockroachDBTLPBase
+        extends TernaryLogicPartitioningOracleBase<CockroachDBExpression, CockroachDBGlobalState>
+        implements TestOracle<CockroachDBGlobalState> {
 
     CockroachDBSchema s;
     CockroachDBTables targetTables;

--- a/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPBase.java
+++ b/src/sqlancer/cockroachdb/oracle/tlp/CockroachDBTLPBase.java
@@ -23,7 +23,7 @@ import sqlancer.common.oracle.TernaryLogicPartitioningOracleBase;
 import sqlancer.common.oracle.TestOracle;
 
 public class CockroachDBTLPBase extends
-        TernaryLogicPartitioningOracleBase<CockroachDBExpression, CockroachDBGlobalState> implements TestOracle {
+        TernaryLogicPartitioningOracleBase<CockroachDBExpression, CockroachDBGlobalState> implements TestOracle<CockroachDBGlobalState> {
 
     CockroachDBSchema s;
     CockroachDBTables targetTables;

--- a/src/sqlancer/common/oracle/CompositeTestOracle.java
+++ b/src/sqlancer/common/oracle/CompositeTestOracle.java
@@ -4,27 +4,27 @@ import java.util.List;
 
 import sqlancer.GlobalState;
 
-public class CompositeTestOracle implements TestOracle {
+public class CompositeTestOracle<G extends GlobalState<?, ?, ?>> implements TestOracle<G> {
 
-    private final TestOracle[] oracles;
-    private final GlobalState<?, ?, ?> globalState;
+    private final List<TestOracle<G>> oracles;
+    private final G globalState;
     private int i;
 
-    public CompositeTestOracle(List<TestOracle> oracles, GlobalState<?, ?, ?> globalState) {
+    public CompositeTestOracle(List<TestOracle<G>> oracles, G globalState) {
         this.globalState = globalState;
-        this.oracles = oracles.toArray(new TestOracle[oracles.size()]);
+        this.oracles = oracles;
     }
 
     @Override
     public void check() throws Exception {
         try {
-            oracles[i].check();
-            boolean lastOracleIndex = i == oracles.length - 1;
+            oracles.get(i).check();
+            boolean lastOracleIndex = i == oracles.size() - 1;
             if (!lastOracleIndex) {
                 globalState.getManager().incrementSelectQueryCount();
             }
         } finally {
-            i = (i + 1) % oracles.length;
+            i = (i + 1) % oracles.size();
         }
     }
 }

--- a/src/sqlancer/common/oracle/DocumentRemovalOracleBase.java
+++ b/src/sqlancer/common/oracle/DocumentRemovalOracleBase.java
@@ -3,7 +3,7 @@ package sqlancer.common.oracle;
 import sqlancer.GlobalState;
 import sqlancer.common.gen.ExpressionGenerator;
 
-public abstract class DocumentRemovalOracleBase<E, S extends GlobalState<?, ?, ?>> implements TestOracle {
+public abstract class DocumentRemovalOracleBase<E, S extends GlobalState<?, ?, ?>> implements TestOracle<S> {
 
     protected E predicate;
 

--- a/src/sqlancer/common/oracle/NoRECBase.java
+++ b/src/sqlancer/common/oracle/NoRECBase.java
@@ -6,7 +6,7 @@ import sqlancer.SQLConnection;
 import sqlancer.SQLGlobalState;
 import sqlancer.common.query.ExpectedErrors;
 
-public abstract class NoRECBase<S extends SQLGlobalState<?, ?>> implements TestOracle {
+public abstract class NoRECBase<S extends SQLGlobalState<?, ?>> implements TestOracle<S> {
 
     protected final S state;
     protected final ExpectedErrors errors = new ExpectedErrors();

--- a/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
+++ b/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
@@ -12,7 +12,7 @@ import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.common.schema.AbstractRowValue;
 
 public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?, C>, R extends AbstractRowValue<?, ?, ?>, E, C extends SQLancerDBConnection>
-        implements TestOracle {
+        implements TestOracle<S> {
 
     protected final ExpectedErrors errors = new ExpectedErrors();
 

--- a/src/sqlancer/common/oracle/TernaryLogicPartitioningOracleBase.java
+++ b/src/sqlancer/common/oracle/TernaryLogicPartitioningOracleBase.java
@@ -14,7 +14,7 @@ import sqlancer.common.query.ExpectedErrors;
  * @param <S>
  *            the global state type
  */
-public abstract class TernaryLogicPartitioningOracleBase<E, S extends GlobalState<?, ?, ?>> implements TestOracle {
+public abstract class TernaryLogicPartitioningOracleBase<E, S extends GlobalState<?, ?, ?>> implements TestOracle<S> {
 
     protected E predicate;
     protected E negatedPredicate;

--- a/src/sqlancer/common/oracle/TestOracle.java
+++ b/src/sqlancer/common/oracle/TestOracle.java
@@ -1,6 +1,8 @@
 package sqlancer.common.oracle;
 
-public interface TestOracle {
+import sqlancer.GlobalState;
+
+public interface TestOracle<G extends GlobalState<?, ?, ?>> {
 
     void check() throws Exception;
 

--- a/src/sqlancer/common/oracle/TestOracle.java
+++ b/src/sqlancer/common/oracle/TestOracle.java
@@ -1,9 +1,13 @@
 package sqlancer.common.oracle;
 
 import sqlancer.GlobalState;
+import sqlancer.Reproducer;
 
 public interface TestOracle<G extends GlobalState<?, ?, ?>> {
 
     void check() throws Exception;
 
+    default Reproducer<G> getLastReproducer() {
+        return null;
+    }
 }

--- a/src/sqlancer/databend/DatabendOptions.java
+++ b/src/sqlancer/databend/DatabendOptions.java
@@ -99,53 +99,53 @@ public class DatabendOptions implements DBMSSpecificOptions<DatabendOracleFactor
         NOREC {
 
             @Override
-            public TestOracle create(DatabendGlobalState globalState) throws SQLException {
+            public TestOracle<DatabendGlobalState> create(DatabendGlobalState globalState) throws SQLException {
                 return new DatabendNoRECOracle(globalState);
             }
 
         },
         HAVING {
             @Override
-            public TestOracle create(DatabendGlobalState globalState) throws SQLException {
+            public TestOracle<DatabendGlobalState> create(DatabendGlobalState globalState) throws SQLException {
                 return new DatabendQueryPartitioningHavingTester(globalState);
             }
         },
         WHERE {
             @Override
-            public TestOracle create(DatabendGlobalState globalState) throws SQLException {
+            public TestOracle<DatabendGlobalState> create(DatabendGlobalState globalState) throws SQLException {
                 return new DatabendQueryPartitioningWhereTester(globalState);
             }
         },
         GROUP_BY {
             @Override
-            public TestOracle create(DatabendGlobalState globalState) throws SQLException {
+            public TestOracle<DatabendGlobalState> create(DatabendGlobalState globalState) throws SQLException {
                 return new DatabendQueryPartitioningGroupByTester(globalState);
             }
         },
         AGGREGATE {
 
             @Override
-            public TestOracle create(DatabendGlobalState globalState) throws SQLException {
+            public TestOracle<DatabendGlobalState> create(DatabendGlobalState globalState) throws SQLException {
                 return new DatabendQueryPartitioningAggregateTester(globalState);
             }
 
         },
         DISTINCT {
             @Override
-            public TestOracle create(DatabendGlobalState globalState) throws SQLException {
+            public TestOracle<DatabendGlobalState> create(DatabendGlobalState globalState) throws SQLException {
                 return new DatabendQueryPartitioningDistinctTester(globalState);
             }
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(DatabendGlobalState globalState) throws SQLException {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<DatabendGlobalState> create(DatabendGlobalState globalState) throws SQLException {
+                List<TestOracle<DatabendGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new DatabendQueryPartitioningWhereTester(globalState));
                 oracles.add(new DatabendQueryPartitioningHavingTester(globalState));
                 oracles.add(new DatabendQueryPartitioningAggregateTester(globalState));
                 oracles.add(new DatabendQueryPartitioningDistinctTester(globalState));
                 oracles.add(new DatabendQueryPartitioningGroupByTester(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<DatabendGlobalState>(oracles, globalState);
             }
         };
 

--- a/src/sqlancer/databend/test/DatabendNoRECOracle.java
+++ b/src/sqlancer/databend/test/DatabendNoRECOracle.java
@@ -33,7 +33,7 @@ import sqlancer.databend.ast.DatabendJoin;
 import sqlancer.databend.ast.DatabendSelect;
 import sqlancer.databend.gen.DatabendNewExpressionGenerator;
 
-public class DatabendNoRECOracle extends NoRECBase<DatabendGlobalState> implements TestOracle {
+public class DatabendNoRECOracle extends NoRECBase<DatabendGlobalState> implements TestOracle<DatabendGlobalState> {
 
     private final DatabendSchema s;
 

--- a/src/sqlancer/databend/test/DatabendQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/databend/test/DatabendQueryPartitioningAggregateTester.java
@@ -30,7 +30,8 @@ import sqlancer.databend.ast.DatabendUnaryPostfixOperation.DatabendUnaryPostfixO
 import sqlancer.databend.ast.DatabendUnaryPrefixOperation.DatabendUnaryPrefixOperator;
 import sqlancer.databend.gen.DatabendNewExpressionGenerator.DatabendAggregateFunction;
 
-public class DatabendQueryPartitioningAggregateTester extends DatabendQueryPartitioningBase implements TestOracle<DatabendGlobalState> {
+public class DatabendQueryPartitioningAggregateTester extends DatabendQueryPartitioningBase
+        implements TestOracle<DatabendGlobalState> {
 
     private String firstResult;
     private String secondResult;

--- a/src/sqlancer/databend/test/DatabendQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/databend/test/DatabendQueryPartitioningAggregateTester.java
@@ -30,7 +30,7 @@ import sqlancer.databend.ast.DatabendUnaryPostfixOperation.DatabendUnaryPostfixO
 import sqlancer.databend.ast.DatabendUnaryPrefixOperation.DatabendUnaryPrefixOperator;
 import sqlancer.databend.gen.DatabendNewExpressionGenerator.DatabendAggregateFunction;
 
-public class DatabendQueryPartitioningAggregateTester extends DatabendQueryPartitioningBase implements TestOracle {
+public class DatabendQueryPartitioningAggregateTester extends DatabendQueryPartitioningBase implements TestOracle<DatabendGlobalState> {
 
     private String firstResult;
     private String secondResult;

--- a/src/sqlancer/databend/test/DatabendQueryPartitioningBase.java
+++ b/src/sqlancer/databend/test/DatabendQueryPartitioningBase.java
@@ -25,7 +25,7 @@ import sqlancer.databend.ast.DatabendSelect;
 import sqlancer.databend.gen.DatabendNewExpressionGenerator;
 
 public class DatabendQueryPartitioningBase extends
-        TernaryLogicPartitioningOracleBase<Node<DatabendExpression>, DatabendGlobalState> implements TestOracle {
+        TernaryLogicPartitioningOracleBase<Node<DatabendExpression>, DatabendGlobalState> implements TestOracle<DatabendGlobalState> {
 
     DatabendSchema s;
     DatabendTables targetTables;

--- a/src/sqlancer/databend/test/DatabendQueryPartitioningBase.java
+++ b/src/sqlancer/databend/test/DatabendQueryPartitioningBase.java
@@ -24,8 +24,9 @@ import sqlancer.databend.ast.DatabendJoin;
 import sqlancer.databend.ast.DatabendSelect;
 import sqlancer.databend.gen.DatabendNewExpressionGenerator;
 
-public class DatabendQueryPartitioningBase extends
-        TernaryLogicPartitioningOracleBase<Node<DatabendExpression>, DatabendGlobalState> implements TestOracle<DatabendGlobalState> {
+public class DatabendQueryPartitioningBase
+        extends TernaryLogicPartitioningOracleBase<Node<DatabendExpression>, DatabendGlobalState>
+        implements TestOracle<DatabendGlobalState> {
 
     DatabendSchema s;
     DatabendTables targetTables;

--- a/src/sqlancer/databend/test/DatabendQueryPartitioningHavingTester.java
+++ b/src/sqlancer/databend/test/DatabendQueryPartitioningHavingTester.java
@@ -16,7 +16,8 @@ import sqlancer.databend.DatabendToStringVisitor;
 import sqlancer.databend.ast.DatabendConstant;
 import sqlancer.databend.ast.DatabendExpression;
 
-public class DatabendQueryPartitioningHavingTester extends DatabendQueryPartitioningBase implements TestOracle<DatabendGlobalState> {
+public class DatabendQueryPartitioningHavingTester extends DatabendQueryPartitioningBase
+        implements TestOracle<DatabendGlobalState> {
 
     public DatabendQueryPartitioningHavingTester(DatabendGlobalState state) {
         super(state);

--- a/src/sqlancer/databend/test/DatabendQueryPartitioningHavingTester.java
+++ b/src/sqlancer/databend/test/DatabendQueryPartitioningHavingTester.java
@@ -16,7 +16,7 @@ import sqlancer.databend.DatabendToStringVisitor;
 import sqlancer.databend.ast.DatabendConstant;
 import sqlancer.databend.ast.DatabendExpression;
 
-public class DatabendQueryPartitioningHavingTester extends DatabendQueryPartitioningBase implements TestOracle {
+public class DatabendQueryPartitioningHavingTester extends DatabendQueryPartitioningBase implements TestOracle<DatabendGlobalState> {
 
     public DatabendQueryPartitioningHavingTester(DatabendGlobalState state) {
         super(state);

--- a/src/sqlancer/duckdb/DuckDBOptions.java
+++ b/src/sqlancer/duckdb/DuckDBOptions.java
@@ -97,53 +97,53 @@ public class DuckDBOptions implements DBMSSpecificOptions<DuckDBOracleFactory> {
         NOREC {
 
             @Override
-            public TestOracle create(DuckDBGlobalState globalState) throws SQLException {
+            public TestOracle<DuckDBGlobalState> create(DuckDBGlobalState globalState) throws SQLException {
                 return new DuckDBNoRECOracle(globalState);
             }
 
         },
         HAVING {
             @Override
-            public TestOracle create(DuckDBGlobalState globalState) throws SQLException {
+            public TestOracle<DuckDBGlobalState> create(DuckDBGlobalState globalState) throws SQLException {
                 return new DuckDBQueryPartitioningHavingTester(globalState);
             }
         },
         WHERE {
             @Override
-            public TestOracle create(DuckDBGlobalState globalState) throws SQLException {
+            public TestOracle<DuckDBGlobalState> create(DuckDBGlobalState globalState) throws SQLException {
                 return new DuckDBQueryPartitioningWhereTester(globalState);
             }
         },
         GROUP_BY {
             @Override
-            public TestOracle create(DuckDBGlobalState globalState) throws SQLException {
+            public TestOracle<DuckDBGlobalState> create(DuckDBGlobalState globalState) throws SQLException {
                 return new DuckDBQueryPartitioningGroupByTester(globalState);
             }
         },
         AGGREGATE {
 
             @Override
-            public TestOracle create(DuckDBGlobalState globalState) throws SQLException {
+            public TestOracle<DuckDBGlobalState> create(DuckDBGlobalState globalState) throws SQLException {
                 return new DuckDBQueryPartitioningAggregateTester(globalState);
             }
 
         },
         DISTINCT {
             @Override
-            public TestOracle create(DuckDBGlobalState globalState) throws SQLException {
+            public TestOracle<DuckDBGlobalState> create(DuckDBGlobalState globalState) throws SQLException {
                 return new DuckDBQueryPartitioningDistinctTester(globalState);
             }
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(DuckDBGlobalState globalState) throws SQLException {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<DuckDBGlobalState> create(DuckDBGlobalState globalState) throws SQLException {
+                List<TestOracle<DuckDBGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new DuckDBQueryPartitioningWhereTester(globalState));
                 oracles.add(new DuckDBQueryPartitioningHavingTester(globalState));
                 oracles.add(new DuckDBQueryPartitioningAggregateTester(globalState));
                 oracles.add(new DuckDBQueryPartitioningDistinctTester(globalState));
                 oracles.add(new DuckDBQueryPartitioningGroupByTester(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<DuckDBGlobalState>(oracles, globalState);
             }
         };
 

--- a/src/sqlancer/duckdb/test/DuckDBNoRECOracle.java
+++ b/src/sqlancer/duckdb/test/DuckDBNoRECOracle.java
@@ -33,7 +33,7 @@ import sqlancer.duckdb.ast.DuckDBSelect;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator.DuckDBCastOperation;
 
-public class DuckDBNoRECOracle extends NoRECBase<DuckDBGlobalState> implements TestOracle {
+public class DuckDBNoRECOracle extends NoRECBase<DuckDBGlobalState> implements TestOracle<DuckDBGlobalState> {
 
     private final DuckDBSchema s;
 

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
@@ -30,7 +30,8 @@ import sqlancer.duckdb.gen.DuckDBExpressionGenerator.DuckDBCastOperation;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator.DuckDBUnaryPostfixOperator;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator.DuckDBUnaryPrefixOperator;
 
-public class DuckDBQueryPartitioningAggregateTester extends DuckDBQueryPartitioningBase implements TestOracle<DuckDBGlobalState> {
+public class DuckDBQueryPartitioningAggregateTester extends DuckDBQueryPartitioningBase
+        implements TestOracle<DuckDBGlobalState> {
 
     private String firstResult;
     private String secondResult;

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningAggregateTester.java
@@ -30,7 +30,7 @@ import sqlancer.duckdb.gen.DuckDBExpressionGenerator.DuckDBCastOperation;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator.DuckDBUnaryPostfixOperator;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator.DuckDBUnaryPrefixOperator;
 
-public class DuckDBQueryPartitioningAggregateTester extends DuckDBQueryPartitioningBase implements TestOracle {
+public class DuckDBQueryPartitioningAggregateTester extends DuckDBQueryPartitioningBase implements TestOracle<DuckDBGlobalState> {
 
     private String firstResult;
     private String secondResult;

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
@@ -24,7 +24,8 @@ import sqlancer.duckdb.ast.DuckDBSelect;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator;
 
 public class DuckDBQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<Node<DuckDBExpression>, DuckDBGlobalState> implements TestOracle<DuckDBGlobalState> {
+        extends TernaryLogicPartitioningOracleBase<Node<DuckDBExpression>, DuckDBGlobalState>
+        implements TestOracle<DuckDBGlobalState> {
 
     DuckDBSchema s;
     DuckDBTables targetTables;

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
@@ -24,7 +24,7 @@ import sqlancer.duckdb.ast.DuckDBSelect;
 import sqlancer.duckdb.gen.DuckDBExpressionGenerator;
 
 public class DuckDBQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<Node<DuckDBExpression>, DuckDBGlobalState> implements TestOracle {
+        extends TernaryLogicPartitioningOracleBase<Node<DuckDBExpression>, DuckDBGlobalState> implements TestOracle<DuckDBGlobalState> {
 
     DuckDBSchema s;
     DuckDBTables targetTables;

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
@@ -14,7 +14,8 @@ import sqlancer.duckdb.DuckDBProvider.DuckDBGlobalState;
 import sqlancer.duckdb.DuckDBToStringVisitor;
 import sqlancer.duckdb.ast.DuckDBExpression;
 
-public class DuckDBQueryPartitioningHavingTester extends DuckDBQueryPartitioningBase implements TestOracle<DuckDBGlobalState> {
+public class DuckDBQueryPartitioningHavingTester extends DuckDBQueryPartitioningBase
+        implements TestOracle<DuckDBGlobalState> {
 
     public DuckDBQueryPartitioningHavingTester(DuckDBGlobalState state) {
         super(state);

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
@@ -14,7 +14,7 @@ import sqlancer.duckdb.DuckDBProvider.DuckDBGlobalState;
 import sqlancer.duckdb.DuckDBToStringVisitor;
 import sqlancer.duckdb.ast.DuckDBExpression;
 
-public class DuckDBQueryPartitioningHavingTester extends DuckDBQueryPartitioningBase implements TestOracle {
+public class DuckDBQueryPartitioningHavingTester extends DuckDBQueryPartitioningBase implements TestOracle<DuckDBGlobalState> {
 
     public DuckDBQueryPartitioningHavingTester(DuckDBGlobalState state) {
         super(state);

--- a/src/sqlancer/h2/H2Options.java
+++ b/src/sqlancer/h2/H2Options.java
@@ -20,7 +20,7 @@ public class H2Options implements DBMSSpecificOptions<H2OracleFactory> {
         TLP_WHERE {
 
             @Override
-            public TestOracle create(H2GlobalState globalState) throws SQLException {
+            public TestOracle<H2GlobalState> create(H2GlobalState globalState) throws SQLException {
                 return new H2QueryPartitioningWhereTester(globalState);
             }
 

--- a/src/sqlancer/h2/H2QueryPartitioningBase.java
+++ b/src/sqlancer/h2/H2QueryPartitioningBase.java
@@ -17,7 +17,7 @@ import sqlancer.h2.H2Schema.H2Table;
 import sqlancer.h2.H2Schema.H2Tables;
 
 public class H2QueryPartitioningBase extends TernaryLogicPartitioningOracleBase<Node<H2Expression>, H2GlobalState>
-        implements TestOracle {
+        implements TestOracle<H2GlobalState> {
 
     H2Schema s;
     H2Tables targetTables;

--- a/src/sqlancer/hsqldb/HSQLDBOptions.java
+++ b/src/sqlancer/hsqldb/HSQLDBOptions.java
@@ -20,7 +20,8 @@ public class HSQLDBOptions implements DBMSSpecificOptions<HSQLDBOptions.HSQLDBOr
     public enum HSQLDBOracleFactory implements OracleFactory<HSQLDBProvider.HSQLDBGlobalState> {
         WHERE {
             @Override
-            public TestOracle create(HSQLDBProvider.HSQLDBGlobalState globalState) throws SQLException {
+            public TestOracle<HSQLDBProvider.HSQLDBGlobalState> create(HSQLDBProvider.HSQLDBGlobalState globalState)
+                    throws SQLException {
                 return new HSQLDBQueryPartitioningWhereTester(globalState);
             }
         }

--- a/src/sqlancer/hsqldb/HSQLDBOptions.java
+++ b/src/sqlancer/hsqldb/HSQLDBOptions.java
@@ -29,7 +29,8 @@ public class HSQLDBOptions implements DBMSSpecificOptions<HSQLDBOptions.HSQLDBOr
         },
         NOREC {
             @Override
-            public TestOracle create(HSQLDBProvider.HSQLDBGlobalState globalState) throws Exception {
+            public TestOracle<HSQLDBProvider.HSQLDBGlobalState> create(HSQLDBProvider.HSQLDBGlobalState globalState)
+                    throws Exception {
                 return new HSQLDBNoRECOracle(globalState);
             }
         }

--- a/src/sqlancer/hsqldb/test/HSQLDBNoRECOracle.java
+++ b/src/sqlancer/hsqldb/test/HSQLDBNoRECOracle.java
@@ -31,7 +31,7 @@ import sqlancer.hsqldb.ast.HSQLDBJoin;
 import sqlancer.hsqldb.ast.HSQLDBSelect;
 import sqlancer.hsqldb.gen.HSQLDBExpressionGenerator;
 
-public class HSQLDBNoRECOracle extends NoRECBase<HSQLDBGlobalState> implements TestOracle {
+public class HSQLDBNoRECOracle extends NoRECBase<HSQLDBGlobalState> implements TestOracle<HSQLDBGlobalState> {
 
     private final HSQLDBSchema s;
 

--- a/src/sqlancer/hsqldb/test/HSQLDBQueryPartitioningBase.java
+++ b/src/sqlancer/hsqldb/test/HSQLDBQueryPartitioningBase.java
@@ -22,7 +22,7 @@ import sqlancer.hsqldb.gen.HSQLDBExpressionGenerator;
 
 public class HSQLDBQueryPartitioningBase
         extends TernaryLogicPartitioningOracleBase<Node<HSQLDBExpression>, HSQLDBProvider.HSQLDBGlobalState>
-        implements TestOracle {
+        implements TestOracle<HSQLDBProvider.HSQLDBGlobalState> {
 
     HSQLDBSelect select;
     HSQLDBExpressionGenerator expressionGenerator;

--- a/src/sqlancer/mariadb/MariaDBOptions.java
+++ b/src/sqlancer/mariadb/MariaDBOptions.java
@@ -28,7 +28,7 @@ public class MariaDBOptions implements DBMSSpecificOptions<MariaDBOracleFactory>
         NOREC {
 
             @Override
-            public TestOracle create(MariaDBGlobalState globalState) throws SQLException {
+            public TestOracle<MariaDBGlobalState> create(MariaDBGlobalState globalState) throws SQLException {
                 return new MariaDBNoRECOracle(globalState);
             }
 

--- a/src/sqlancer/mariadb/oracle/MariaDBNoRECOracle.java
+++ b/src/sqlancer/mariadb/oracle/MariaDBNoRECOracle.java
@@ -27,7 +27,7 @@ import sqlancer.mariadb.ast.MariaDBText;
 import sqlancer.mariadb.ast.MariaDBVisitor;
 import sqlancer.mariadb.gen.MariaDBExpressionGenerator;
 
-public class MariaDBNoRECOracle extends NoRECBase<MariaDBGlobalState> implements TestOracle {
+public class MariaDBNoRECOracle extends NoRECBase<MariaDBGlobalState> implements TestOracle<MariaDBGlobalState> {
 
     private final MariaDBSchema s;
     private static final int NOT_FOUND = -1;

--- a/src/sqlancer/mongodb/MongoDBOptions.java
+++ b/src/sqlancer/mongodb/MongoDBOptions.java
@@ -56,18 +56,18 @@ public class MongoDBOptions implements DBMSSpecificOptions<MongoDBOptions.MongoD
     public enum MongoDBOracleFactory implements OracleFactory<MongoDBGlobalState> {
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(MongoDBGlobalState globalState) throws Exception {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<MongoDBGlobalState> create(MongoDBGlobalState globalState) throws Exception {
+                List<TestOracle<MongoDBGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new MongoDBQueryPartitioningWhereTester(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<MongoDBGlobalState>(oracles, globalState);
             }
         },
         DOCUMENT_REMOVAL {
             @Override
-            public TestOracle create(MongoDBGlobalState globalState) throws Exception {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<MongoDBGlobalState> create(MongoDBGlobalState globalState) throws Exception {
+                List<TestOracle<MongoDBGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new MongoDBDocumentRemovalTester(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<MongoDBGlobalState>(oracles, globalState);
             }
         }
     }

--- a/src/sqlancer/mongodb/test/MongoDBDocumentRemovalBase.java
+++ b/src/sqlancer/mongodb/test/MongoDBDocumentRemovalBase.java
@@ -15,8 +15,9 @@ import sqlancer.mongodb.ast.MongoDBSelect;
 import sqlancer.mongodb.gen.MongoDBComputedExpressionGenerator;
 import sqlancer.mongodb.gen.MongoDBMatchExpressionGenerator;
 
-public class MongoDBDocumentRemovalBase extends
-        DocumentRemovalOracleBase<Node<MongoDBExpression>, MongoDBProvider.MongoDBGlobalState> implements TestOracle<MongoDBProvider.MongoDBGlobalState> {
+public class MongoDBDocumentRemovalBase
+        extends DocumentRemovalOracleBase<Node<MongoDBExpression>, MongoDBProvider.MongoDBGlobalState>
+        implements TestOracle<MongoDBProvider.MongoDBGlobalState> {
 
     protected MongoDBSchema schema;
     protected MongoDBSchema.MongoDBTables targetTables;

--- a/src/sqlancer/mongodb/test/MongoDBDocumentRemovalBase.java
+++ b/src/sqlancer/mongodb/test/MongoDBDocumentRemovalBase.java
@@ -16,7 +16,7 @@ import sqlancer.mongodb.gen.MongoDBComputedExpressionGenerator;
 import sqlancer.mongodb.gen.MongoDBMatchExpressionGenerator;
 
 public class MongoDBDocumentRemovalBase extends
-        DocumentRemovalOracleBase<Node<MongoDBExpression>, MongoDBProvider.MongoDBGlobalState> implements TestOracle {
+        DocumentRemovalOracleBase<Node<MongoDBExpression>, MongoDBProvider.MongoDBGlobalState> implements TestOracle<MongoDBProvider.MongoDBGlobalState> {
 
     protected MongoDBSchema schema;
     protected MongoDBSchema.MongoDBTables targetTables;

--- a/src/sqlancer/mongodb/test/MongoDBQueryPartitioningBase.java
+++ b/src/sqlancer/mongodb/test/MongoDBQueryPartitioningBase.java
@@ -19,7 +19,8 @@ import sqlancer.mongodb.gen.MongoDBComputedExpressionGenerator;
 import sqlancer.mongodb.gen.MongoDBMatchExpressionGenerator;
 
 public class MongoDBQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<Node<MongoDBExpression>, MongoDBGlobalState> implements TestOracle<MongoDBGlobalState> {
+        extends TernaryLogicPartitioningOracleBase<Node<MongoDBExpression>, MongoDBGlobalState>
+        implements TestOracle<MongoDBGlobalState> {
 
     protected MongoDBSchema schema;
     protected MongoDBTables targetTables;

--- a/src/sqlancer/mongodb/test/MongoDBQueryPartitioningBase.java
+++ b/src/sqlancer/mongodb/test/MongoDBQueryPartitioningBase.java
@@ -19,7 +19,7 @@ import sqlancer.mongodb.gen.MongoDBComputedExpressionGenerator;
 import sqlancer.mongodb.gen.MongoDBMatchExpressionGenerator;
 
 public class MongoDBQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<Node<MongoDBExpression>, MongoDBGlobalState> implements TestOracle {
+        extends TernaryLogicPartitioningOracleBase<Node<MongoDBExpression>, MongoDBGlobalState> implements TestOracle<MongoDBGlobalState> {
 
     protected MongoDBSchema schema;
     protected MongoDBTables targetTables;

--- a/src/sqlancer/mysql/MySQLOptions.java
+++ b/src/sqlancer/mysql/MySQLOptions.java
@@ -28,7 +28,7 @@ public class MySQLOptions implements DBMSSpecificOptions<MySQLOracleFactory> {
         TLP_WHERE {
 
             @Override
-            public TestOracle create(MySQLGlobalState globalState) throws SQLException {
+            public TestOracle<MySQLGlobalState> create(MySQLGlobalState globalState) throws SQLException {
                 return new MySQLTLPWhereOracle(globalState);
             }
 
@@ -36,7 +36,7 @@ public class MySQLOptions implements DBMSSpecificOptions<MySQLOracleFactory> {
         PQS {
 
             @Override
-            public TestOracle create(MySQLGlobalState globalState) throws SQLException {
+            public TestOracle<MySQLGlobalState> create(MySQLGlobalState globalState) throws SQLException {
                 return new MySQLPivotedQuerySynthesisOracle(globalState);
             }
 

--- a/src/sqlancer/mysql/oracle/MySQLQueryPartitioningBase.java
+++ b/src/sqlancer/mysql/oracle/MySQLQueryPartitioningBase.java
@@ -19,8 +19,8 @@ import sqlancer.mysql.ast.MySQLSelect;
 import sqlancer.mysql.ast.MySQLTableReference;
 import sqlancer.mysql.gen.MySQLExpressionGenerator;
 
-public abstract class MySQLQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<MySQLExpression, MySQLGlobalState> implements TestOracle<MySQLGlobalState> {
+public abstract class MySQLQueryPartitioningBase extends
+        TernaryLogicPartitioningOracleBase<MySQLExpression, MySQLGlobalState> implements TestOracle<MySQLGlobalState> {
 
     MySQLSchema s;
     MySQLTables targetTables;

--- a/src/sqlancer/mysql/oracle/MySQLQueryPartitioningBase.java
+++ b/src/sqlancer/mysql/oracle/MySQLQueryPartitioningBase.java
@@ -20,7 +20,7 @@ import sqlancer.mysql.ast.MySQLTableReference;
 import sqlancer.mysql.gen.MySQLExpressionGenerator;
 
 public abstract class MySQLQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<MySQLExpression, MySQLGlobalState> implements TestOracle {
+        extends TernaryLogicPartitioningOracleBase<MySQLExpression, MySQLGlobalState> implements TestOracle<MySQLGlobalState> {
 
     MySQLSchema s;
     MySQLTables targetTables;

--- a/src/sqlancer/oceanbase/OceanBaseOptions.java
+++ b/src/sqlancer/oceanbase/OceanBaseOptions.java
@@ -28,20 +28,20 @@ public class OceanBaseOptions implements DBMSSpecificOptions<OceanBaseOracleFact
 
         TLP_WHERE {
             @Override
-            public TestOracle create(OceanBaseGlobalState globalState) throws SQLException {
+            public TestOracle<OceanBaseGlobalState> create(OceanBaseGlobalState globalState) throws SQLException {
                 return new OceanBaseTLPWhereOracle(globalState);
             }
         },
         NoREC {
             @Override
-            public TestOracle create(OceanBaseGlobalState globalState) throws SQLException {
+            public TestOracle<OceanBaseGlobalState> create(OceanBaseGlobalState globalState) throws SQLException {
                 return new OceanBaseNoRECOracle(globalState);
             }
         },
         PQS {
 
             @Override
-            public TestOracle create(OceanBaseGlobalState globalState) throws SQLException {
+            public TestOracle<OceanBaseGlobalState> create(OceanBaseGlobalState globalState) throws SQLException {
                 return new OceanBasePivotedQuerySynthesisOracle(globalState);
             }
 

--- a/src/sqlancer/oceanbase/oracle/OceanBaseNoRECOracle.java
+++ b/src/sqlancer/oceanbase/oracle/OceanBaseNoRECOracle.java
@@ -28,7 +28,7 @@ import sqlancer.oceanbase.ast.OceanBaseUnaryPostfixOperation;
 import sqlancer.oceanbase.ast.OceanBaseUnaryPrefixOperation;
 import sqlancer.oceanbase.gen.OceanBaseExpressionGenerator;
 
-public class OceanBaseNoRECOracle extends NoRECBase<OceanBaseGlobalState> implements TestOracle {
+public class OceanBaseNoRECOracle extends NoRECBase<OceanBaseGlobalState> implements TestOracle<OceanBaseGlobalState> {
 
     // SELECT COUNT(*) FROM t0 WHERE <cond>;
     // SELECT SUM(count) FROM (SELECT <cond> IS TRUE as count FROM t0);

--- a/src/sqlancer/oceanbase/oracle/OceanBaseTLPBase.java
+++ b/src/sqlancer/oceanbase/oracle/OceanBaseTLPBase.java
@@ -21,7 +21,8 @@ import sqlancer.oceanbase.gen.OceanBaseExpressionGenerator;
 import sqlancer.oceanbase.gen.OceanBaseHintGenerator;
 
 public abstract class OceanBaseTLPBase
-        extends TernaryLogicPartitioningOracleBase<OceanBaseExpression, OceanBaseGlobalState> implements TestOracle<OceanBaseGlobalState> {
+        extends TernaryLogicPartitioningOracleBase<OceanBaseExpression, OceanBaseGlobalState>
+        implements TestOracle<OceanBaseGlobalState> {
 
     OceanBaseSchema s;
     OceanBaseTables targetTables;

--- a/src/sqlancer/oceanbase/oracle/OceanBaseTLPBase.java
+++ b/src/sqlancer/oceanbase/oracle/OceanBaseTLPBase.java
@@ -21,7 +21,7 @@ import sqlancer.oceanbase.gen.OceanBaseExpressionGenerator;
 import sqlancer.oceanbase.gen.OceanBaseHintGenerator;
 
 public abstract class OceanBaseTLPBase
-        extends TernaryLogicPartitioningOracleBase<OceanBaseExpression, OceanBaseGlobalState> implements TestOracle {
+        extends TernaryLogicPartitioningOracleBase<OceanBaseExpression, OceanBaseGlobalState> implements TestOracle<OceanBaseGlobalState> {
 
     OceanBaseSchema s;
     OceanBaseTables targetTables;

--- a/src/sqlancer/postgres/PostgresOptions.java
+++ b/src/sqlancer/postgres/PostgresOptions.java
@@ -44,13 +44,13 @@ public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactor
     public enum PostgresOracleFactory implements OracleFactory<PostgresGlobalState> {
         NOREC {
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
                 return new PostgresNoRECOracle(globalState);
             }
         },
         PQS {
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
                 return new PostgresPivotedQuerySynthesisOracle(globalState);
             }
 
@@ -62,19 +62,19 @@ public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactor
         HAVING {
 
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
                 return new PostgresTLPHavingOracle(globalState);
             }
 
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(PostgresGlobalState globalState) throws SQLException {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws SQLException {
+                List<TestOracle<PostgresGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new PostgresTLPWhereOracle(globalState));
                 oracles.add(new PostgresTLPHavingOracle(globalState));
                 oracles.add(new PostgresTLPAggregateOracle(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<PostgresGlobalState>(oracles, globalState);
             }
         };
 

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -36,7 +36,7 @@ import sqlancer.postgres.gen.PostgresCommon;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
 import sqlancer.postgres.oracle.tlp.PostgresTLPBase;
 
-public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implements TestOracle {
+public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implements TestOracle<PostgresGlobalState> {
 
     private final PostgresSchema s;
 

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -29,7 +29,7 @@ import sqlancer.postgres.ast.PostgresPrefixOperation.PrefixOperator;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.gen.PostgresCommon;
 
-public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestOracle {
+public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestOracle<PostgresGlobalState> {
 
     private String firstResult;
     private String secondResult;

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
@@ -29,7 +29,7 @@ import sqlancer.postgres.gen.PostgresExpressionGenerator;
 import sqlancer.postgres.oracle.PostgresNoRECOracle;
 
 public class PostgresTLPBase extends TernaryLogicPartitioningOracleBase<PostgresExpression, PostgresGlobalState>
-        implements TestOracle {
+        implements TestOracle<PostgresGlobalState> {
 
     protected PostgresSchema s;
     protected PostgresTables targetTables;

--- a/src/sqlancer/questdb/QuestDBOptions.java
+++ b/src/sqlancer/questdb/QuestDBOptions.java
@@ -27,7 +27,7 @@ public class QuestDBOptions implements DBMSSpecificOptions<QuestDBOracleFactory>
         // TODO (anxing): implement test oracles
         WHERE {
             @Override
-            public TestOracle create(QuestDBGlobalState globalState) throws SQLException {
+            public TestOracle<QuestDBGlobalState> create(QuestDBGlobalState globalState) throws SQLException {
                 return new QuestDBQueryPartitioningWhereTester(globalState);
             }
         }

--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
@@ -24,7 +24,8 @@ import sqlancer.questdb.ast.QuestDBSelect;
 import sqlancer.questdb.gen.QuestDBExpressionGenerator;
 
 public class QuestDBQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<Node<QuestDBExpression>, QuestDBGlobalState> implements TestOracle<QuestDBGlobalState> {
+        extends TernaryLogicPartitioningOracleBase<Node<QuestDBExpression>, QuestDBGlobalState>
+        implements TestOracle<QuestDBGlobalState> {
 
     QuestDBSchema s;
     QuestDBTables targetTables;

--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
@@ -24,7 +24,7 @@ import sqlancer.questdb.ast.QuestDBSelect;
 import sqlancer.questdb.gen.QuestDBExpressionGenerator;
 
 public class QuestDBQueryPartitioningBase
-        extends TernaryLogicPartitioningOracleBase<Node<QuestDBExpression>, QuestDBGlobalState> implements TestOracle {
+        extends TernaryLogicPartitioningOracleBase<Node<QuestDBExpression>, QuestDBGlobalState> implements TestOracle<QuestDBGlobalState> {
 
     QuestDBSchema s;
     QuestDBTables targetTables;

--- a/src/sqlancer/sqlite3/SQLite3Options.java
+++ b/src/sqlancer/sqlite3/SQLite3Options.java
@@ -93,7 +93,7 @@ public class SQLite3Options implements DBMSSpecificOptions<SQLite3OracleFactory>
     public enum SQLite3OracleFactory implements OracleFactory<SQLite3GlobalState> {
         PQS {
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3PivotedQuerySynthesisOracle(globalState);
             }
 
@@ -105,14 +105,14 @@ public class SQLite3Options implements DBMSSpecificOptions<SQLite3OracleFactory>
         },
         NoREC {
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3NoRECOracle(globalState);
             }
         },
         AGGREGATE {
 
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3TLPAggregateOracle(globalState);
             }
 
@@ -120,45 +120,45 @@ public class SQLite3Options implements DBMSSpecificOptions<SQLite3OracleFactory>
         WHERE {
 
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3TLPWhereOracle(globalState);
             }
 
         },
         DISTINCT {
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3TLPDistinctOracle(globalState);
             }
         },
         GROUP_BY {
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3TLPGroupByOracle(globalState);
             }
         },
         HAVING {
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3TLPHavingOracle(globalState);
             }
         },
         FUZZER {
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
                 return new SQLite3Fuzzer(globalState);
             }
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(SQLite3GlobalState globalState) throws SQLException {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<SQLite3GlobalState> create(SQLite3GlobalState globalState) throws SQLException {
+                List<TestOracle<SQLite3GlobalState>> oracles = new ArrayList<>();
                 oracles.add(new SQLite3TLPWhereOracle(globalState));
                 oracles.add(new SQLite3TLPDistinctOracle(globalState));
                 oracles.add(new SQLite3TLPGroupByOracle(globalState));
                 oracles.add(new SQLite3TLPHavingOracle(globalState));
                 oracles.add(new SQLite3TLPAggregateOracle(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<SQLite3GlobalState>(oracles, globalState);
             }
         };
 

--- a/src/sqlancer/sqlite3/oracle/SQLite3Fuzzer.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3Fuzzer.java
@@ -7,7 +7,7 @@ import sqlancer.sqlite3.SQLite3GlobalState;
 import sqlancer.sqlite3.SQLite3Visitor;
 
 // tries to trigger a crash
-public class SQLite3Fuzzer implements TestOracle {
+public class SQLite3Fuzzer implements TestOracle<SQLite3GlobalState> {
 
     private final SQLite3GlobalState globalState;
 

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -41,13 +41,13 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
     private class SQLite3NoRECReproducer implements Reproducer<SQLite3GlobalState> {
         private final Function<SQLite3GlobalState, Integer> optimizedQuery;
         private final Function<SQLite3GlobalState, Integer> unoptimizedQuery;
-        
-        public SQLite3NoRECReproducer(
-            Function<SQLite3GlobalState, Integer> optimizedQuery,
-            Function<SQLite3GlobalState, Integer> unoptimizedQuery) {
+
+        public SQLite3NoRECReproducer(Function<SQLite3GlobalState, Integer> optimizedQuery,
+                Function<SQLite3GlobalState, Integer> unoptimizedQuery) {
             this.optimizedQuery = optimizedQuery;
             this.unoptimizedQuery = unoptimizedQuery;
         }
+
         @Override
         public boolean bugStillTriggers(SQLite3GlobalState globalState) {
             return optimizedQuery.apply(globalState) != unoptimizedQuery.apply(globalState);

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -29,7 +29,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
 
-public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements TestOracle {
+public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements TestOracle<SQLite3GlobalState> {
 
     private static final int NO_VALID_RESULT = -1;
     private final SQLite3Schema s;

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -42,7 +42,7 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
         private final Function<SQLite3GlobalState, Integer> optimizedQuery;
         private final Function<SQLite3GlobalState, Integer> unoptimizedQuery;
 
-        public SQLite3NoRECReproducer(Function<SQLite3GlobalState, Integer> optimizedQuery,
+        SQLite3NoRECReproducer(Function<SQLite3GlobalState, Integer> optimizedQuery,
                 Function<SQLite3GlobalState, Integer> unoptimizedQuery) {
             this.optimizedQuery = optimizedQuery;
             this.unoptimizedQuery = unoptimizedQuery;

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -4,9 +4,11 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
+import sqlancer.Reproducer;
 import sqlancer.common.oracle.NoRECBase;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.common.query.SQLQueryAdapter;
@@ -34,6 +36,23 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
     private static final int NO_VALID_RESULT = -1;
     private final SQLite3Schema s;
     private SQLite3ExpressionGenerator gen;
+    private Reproducer<SQLite3GlobalState> reproducer;
+
+    private class SQLite3NoRECReproducer implements Reproducer<SQLite3GlobalState> {
+        private final Function<SQLite3GlobalState, Integer> optimizedQuery;
+        private final Function<SQLite3GlobalState, Integer> unoptimizedQuery;
+        
+        public SQLite3NoRECReproducer(
+            Function<SQLite3GlobalState, Integer> optimizedQuery,
+            Function<SQLite3GlobalState, Integer> unoptimizedQuery) {
+            this.optimizedQuery = optimizedQuery;
+            this.unoptimizedQuery = unoptimizedQuery;
+        }
+        @Override
+        public boolean bugStillTriggers(SQLite3GlobalState globalState) {
+            return optimizedQuery.apply(globalState) != unoptimizedQuery.apply(globalState);
+        }
+    }
 
     public SQLite3NoRECOracle(SQLite3GlobalState globalState) {
         super(globalState);
@@ -51,6 +70,7 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
 
     @Override
     public void check() throws SQLException {
+        reproducer = null;
         SQLite3Tables randomTables = s.getRandomTableNonEmptyTables();
         List<SQLite3Column> columns = randomTables.getColumns();
         gen = new SQLite3ExpressionGenerator(state).setColumns(columns);
@@ -62,19 +82,28 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
         select.setFromTables(tableRefs);
         select.setJoinClauses(joinStatements);
 
-        int optimizedCount = getOptimizedQuery(select, randomWhereCondition);
-        int unoptimizedCount = getUnoptimizedQuery(select, randomWhereCondition);
+        Function<SQLite3GlobalState, Integer> optimizedQuery = getOptimizedQuery(select, randomWhereCondition);
+        Function<SQLite3GlobalState, Integer> unoptimizedQuery = getUnoptimizedQuery(select, randomWhereCondition);
+        int optimizedCount = optimizedQuery.apply(state);
+        int unoptimizedCount = unoptimizedQuery.apply(state);
         if (optimizedCount == NO_VALID_RESULT || unoptimizedCount == NO_VALID_RESULT) {
             throw new IgnoreMeException();
         }
         if (optimizedCount != unoptimizedCount) {
+            reproducer = new SQLite3NoRECReproducer(optimizedQuery, unoptimizedQuery);
             state.getState().getLocalState().log(optimizedQueryString + ";\n" + unoptimizedQueryString + ";");
             throw new AssertionError(optimizedCount + " " + unoptimizedCount);
         }
 
     }
 
-    private int getUnoptimizedQuery(SQLite3Select select, SQLite3Expression randomWhereCondition) throws SQLException {
+    @Override
+    public Reproducer<SQLite3GlobalState> getLastReproducer() {
+        return reproducer;
+    }
+
+    private Function<SQLite3GlobalState, Integer> getUnoptimizedQuery(SQLite3Select select,
+            SQLite3Expression randomWhereCondition) throws SQLException {
         SQLite3PostfixUnaryOperation isTrue = new SQLite3PostfixUnaryOperation(PostfixUnaryOperator.IS_TRUE,
                 randomWhereCondition);
         SQLite3PostfixText asText = new SQLite3PostfixText(isTrue, " as count", null);
@@ -85,10 +114,17 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
             logger.writeCurrent(unoptimizedQueryString);
         }
         SQLQueryAdapter q = new SQLQueryAdapter(unoptimizedQueryString, errors);
-        return extractCounts(q);
+        return new Function<SQLite3GlobalState, Integer>() {
+
+            @Override
+            public Integer apply(SQLite3GlobalState state) {
+                return extractCounts(q, state);
+            }
+        };
     }
 
-    private int getOptimizedQuery(SQLite3Select select, SQLite3Expression randomWhereCondition) throws SQLException {
+    private Function<SQLite3GlobalState, Integer> getOptimizedQuery(SQLite3Select select,
+            SQLite3Expression randomWhereCondition) throws SQLException {
         boolean useAggregate = Randomly.getBoolean();
         if (Randomly.getBoolean()) {
             select.setOrderByExpressions(gen.generateOrderBys());
@@ -106,12 +142,19 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
             logger.writeCurrent(optimizedQueryString);
         }
         SQLQueryAdapter q = new SQLQueryAdapter(optimizedQueryString, errors);
-        return useAggregate ? extractCounts(q) : countRows(q);
+        return new Function<SQLite3GlobalState, Integer>() {
+
+            @Override
+            public Integer apply(SQLite3GlobalState state) {
+                return useAggregate ? extractCounts(q, state) : countRows(q, state);
+            }
+
+        };
     }
 
-    private int countRows(SQLQueryAdapter q) {
+    private int countRows(SQLQueryAdapter q, SQLite3GlobalState globalState) {
         int count = 0;
-        try (SQLancerResultSet rs = q.executeAndGet(state)) {
+        try (SQLancerResultSet rs = q.executeAndGet(globalState)) {
             if (rs == null) {
                 return NO_VALID_RESULT;
             } else {
@@ -132,9 +175,9 @@ public class SQLite3NoRECOracle extends NoRECBase<SQLite3GlobalState> implements
         return count;
     }
 
-    private int extractCounts(SQLQueryAdapter q) {
+    private int extractCounts(SQLQueryAdapter q, SQLite3GlobalState globalState) {
         int count = 0;
-        try (SQLancerResultSet rs = q.executeAndGet(state)) {
+        try (SQLancerResultSet rs = q.executeAndGet(globalState)) {
             if (rs == null) {
                 return NO_VALID_RESULT;
             } else {

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
@@ -28,7 +28,7 @@ import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
 
-public class SQLite3TLPAggregateOracle implements TestOracle {
+public class SQLite3TLPAggregateOracle implements TestOracle<SQLite3GlobalState> {
 
     private final SQLite3GlobalState state;
     private final ExpectedErrors errors = new ExpectedErrors();

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPBase.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPBase.java
@@ -23,7 +23,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
 
 public class SQLite3TLPBase extends TernaryLogicPartitioningOracleBase<SQLite3Expression, SQLite3GlobalState>
-        implements TestOracle {
+        implements TestOracle<SQLite3GlobalState> {
 
     SQLite3Schema s;
     SQLite3Tables targetTables;

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
@@ -29,7 +29,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
 
-public class SQLite3TLPHavingOracle implements TestOracle {
+public class SQLite3TLPHavingOracle implements TestOracle<SQLite3GlobalState> {
 
     private final SQLite3GlobalState state;
     private final ExpectedErrors errors = new ExpectedErrors();

--- a/src/sqlancer/tidb/TiDBOptions.java
+++ b/src/sqlancer/tidb/TiDBOptions.java
@@ -29,23 +29,23 @@ public class TiDBOptions implements DBMSSpecificOptions<TiDBOracleFactory> {
     public enum TiDBOracleFactory implements OracleFactory<TiDBGlobalState> {
         HAVING {
             @Override
-            public TestOracle create(TiDBGlobalState globalState) throws SQLException {
+            public TestOracle<TiDBGlobalState> create(TiDBGlobalState globalState) throws SQLException {
                 return new TiDBTLPHavingOracle(globalState);
             }
         },
         WHERE {
             @Override
-            public TestOracle create(TiDBGlobalState globalState) throws SQLException {
+            public TestOracle<TiDBGlobalState> create(TiDBGlobalState globalState) throws SQLException {
                 return new TiDBTLPWhereOracle(globalState);
             }
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(TiDBGlobalState globalState) throws SQLException {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<TiDBGlobalState> create(TiDBGlobalState globalState) throws SQLException {
+                List<TestOracle<TiDBGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new TiDBTLPWhereOracle(globalState));
                 oracles.add(new TiDBTLPHavingOracle(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<TiDBGlobalState>(oracles, globalState);
             }
         };
 

--- a/src/sqlancer/tidb/oracle/TiDBTLPBase.java
+++ b/src/sqlancer/tidb/oracle/TiDBTLPBase.java
@@ -23,7 +23,7 @@ import sqlancer.tidb.ast.TiDBTableReference;
 import sqlancer.tidb.gen.TiDBHintGenerator;
 
 public abstract class TiDBTLPBase extends TernaryLogicPartitioningOracleBase<TiDBExpression, TiDBGlobalState>
-        implements TestOracle {
+        implements TestOracle<TiDBGlobalState> {
 
     TiDBSchema s;
     TiDBTables targetTables;

--- a/src/sqlancer/tidb/oracle/TiDBTLPHavingOracle.java
+++ b/src/sqlancer/tidb/oracle/TiDBTLPHavingOracle.java
@@ -12,7 +12,7 @@ import sqlancer.tidb.TiDBProvider.TiDBGlobalState;
 import sqlancer.tidb.ast.TiDBExpression;
 import sqlancer.tidb.visitor.TiDBVisitor;
 
-public class TiDBTLPHavingOracle extends TiDBTLPBase implements TestOracle {
+public class TiDBTLPHavingOracle extends TiDBTLPBase implements TestOracle<TiDBGlobalState> {
 
     public TiDBTLPHavingOracle(TiDBGlobalState state) {
         super(state);

--- a/src/sqlancer/yugabyte/ycql/YCQLOptions.java
+++ b/src/sqlancer/yugabyte/ycql/YCQLOptions.java
@@ -37,7 +37,7 @@ public class YCQLOptions implements DBMSSpecificOptions<YCQLOracleFactory> {
     public enum YCQLOracleFactory implements OracleFactory<YCQLGlobalState> {
         FUZZER {
             @Override
-            public TestOracle create(YCQLGlobalState globalState) throws SQLException {
+            public TestOracle<YCQLGlobalState> create(YCQLGlobalState globalState) throws SQLException {
                 return new YCQLFuzzer(globalState);
             }
 

--- a/src/sqlancer/yugabyte/ycql/test/YCQLFuzzer.java
+++ b/src/sqlancer/yugabyte/ycql/test/YCQLFuzzer.java
@@ -11,7 +11,7 @@ import sqlancer.yugabyte.ycql.YCQLProvider;
 import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
 import sqlancer.yugabyte.ycql.gen.YCQLRandomQuerySynthesizer;
 
-public class YCQLFuzzer implements TestOracle {
+public class YCQLFuzzer implements TestOracle<YCQLProvider.YCQLGlobalState> {
     private final YCQLProvider.YCQLGlobalState globalState;
     private final List<Query> testQueries;
     private final ExpectedErrors errors = new ExpectedErrors();

--- a/src/sqlancer/yugabyte/ysql/YSQLOptions.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLOptions.java
@@ -48,25 +48,25 @@ public class YSQLOptions implements DBMSSpecificOptions<YSQLOracleFactory> {
     public enum YSQLOracleFactory implements OracleFactory<YSQLGlobalState> {
         FUZZER {
             @Override
-            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+            public TestOracle<YSQLGlobalState> create(YSQLGlobalState globalState) throws SQLException {
                 return new YSQLFuzzer(globalState);
             }
         },
         CATALOG {
             @Override
-            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+            public TestOracle<YSQLGlobalState> create(YSQLGlobalState globalState) throws SQLException {
                 return new YSQLCatalog(globalState);
             }
         },
         NOREC {
             @Override
-            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+            public TestOracle<YSQLGlobalState> create(YSQLGlobalState globalState) throws SQLException {
                 return new YSQLNoRECOracle(globalState);
             }
         },
         PQS {
             @Override
-            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+            public TestOracle<YSQLGlobalState> create(YSQLGlobalState globalState) throws SQLException {
                 return new YSQLPivotedQuerySynthesisOracle(globalState);
             }
 
@@ -77,19 +77,19 @@ public class YSQLOptions implements DBMSSpecificOptions<YSQLOracleFactory> {
         },
         HAVING {
             @Override
-            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
+            public TestOracle<YSQLGlobalState> create(YSQLGlobalState globalState) throws SQLException {
                 return new YSQLTLPHavingOracle(globalState);
             }
 
         },
         QUERY_PARTITIONING {
             @Override
-            public TestOracle create(YSQLGlobalState globalState) throws SQLException {
-                List<TestOracle> oracles = new ArrayList<>();
+            public TestOracle<YSQLGlobalState> create(YSQLGlobalState globalState) throws SQLException {
+                List<TestOracle<YSQLGlobalState>> oracles = new ArrayList<>();
                 oracles.add(new YSQLTLPWhereOracle(globalState));
                 oracles.add(new YSQLTLPHavingOracle(globalState));
                 oracles.add(new YSQLTLPAggregateOracle(globalState));
-                return new CompositeTestOracle(oracles, globalState);
+                return new CompositeTestOracle<YSQLGlobalState>(oracles, globalState);
             }
         }
 

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLCatalog.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLCatalog.java
@@ -18,7 +18,7 @@ import sqlancer.yugabyte.ysql.YSQLGlobalState;
 import sqlancer.yugabyte.ysql.YSQLProvider;
 import sqlancer.yugabyte.ysql.gen.YSQLTableGenerator;
 
-public class YSQLCatalog implements TestOracle {
+public class YSQLCatalog implements TestOracle<YSQLGlobalState> {
     protected final YSQLGlobalState state;
 
     protected final ExpectedErrors errors = new ExpectedErrors();

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLFuzzer.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLFuzzer.java
@@ -13,7 +13,7 @@ import sqlancer.yugabyte.ysql.YSQLProvider;
 import sqlancer.yugabyte.ysql.YSQLVisitor;
 import sqlancer.yugabyte.ysql.gen.YSQLRandomQueryGenerator;
 
-public class YSQLFuzzer implements TestOracle {
+public class YSQLFuzzer implements TestOracle<YSQLGlobalState> {
     private final YSQLGlobalState globalState;
     private final List<Query> testQueries;
     private final ExpectedErrors errors = new ExpectedErrors();

--- a/src/sqlancer/yugabyte/ysql/oracle/YSQLNoRECOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/YSQLNoRECOracle.java
@@ -33,7 +33,7 @@ import sqlancer.yugabyte.ysql.ast.YSQLSelect;
 import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
 import sqlancer.yugabyte.ysql.oracle.tlp.YSQLTLPBase;
 
-public class YSQLNoRECOracle extends NoRECBase<YSQLGlobalState> implements TestOracle {
+public class YSQLNoRECOracle extends NoRECBase<YSQLGlobalState> implements TestOracle<YSQLGlobalState> {
 
     private final YSQLSchema s;
 

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPAggregateOracle.java
@@ -29,7 +29,7 @@ import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation;
 import sqlancer.yugabyte.ysql.ast.YSQLPrefixOperation.PrefixOperator;
 import sqlancer.yugabyte.ysql.ast.YSQLSelect;
 
-public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle {
+public class YSQLTLPAggregateOracle extends YSQLTLPBase implements TestOracle<YSQLGlobalState> {
 
     private String firstResult;
     private String secondResult;

--- a/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPBase.java
+++ b/src/sqlancer/yugabyte/ysql/oracle/tlp/YSQLTLPBase.java
@@ -26,7 +26,7 @@ import sqlancer.yugabyte.ysql.gen.YSQLExpressionGenerator;
 import sqlancer.yugabyte.ysql.oracle.YSQLNoRECOracle;
 
 public class YSQLTLPBase extends TernaryLogicPartitioningOracleBase<YSQLExpression, YSQLGlobalState>
-        implements TestOracle {
+        implements TestOracle<YSQLGlobalState> {
 
     protected YSQLSchema s;
     protected YSQLTables targetTables;


### PR DESCRIPTION
Quick preview of what I'm working on. This adds the type information to return a Reproducer, but doesn't modify the `check()` method. Is this heading in the right direction? If so, I can add the Reducer changes tomorrow.