### PR TITLE
fix ci when to install citus

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,9 @@ jobs:
         run: |
           echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list
           curl https://install.citusdata.com/community/deb.sh | sudo bash
-          sudo apt-get -y install postgresql-13-citus-10.1
+          sudo apt-get -y install  postgresql-15-citus-11.1
           sudo chown -R $USER:$USER /var/run/postgresql
-          export PATH=/usr/lib/postgresql/13/bin:$PATH
+          export PATH=/usr/lib/postgresql/15/bin:$PATH
           cd ~
           mkdir -p citus/coordinator citus/worker1 citus/worker2
           initdb -D citus/coordinator


### PR DESCRIPTION
we can read some error message when to install citus.

```
The repository is set up! You can now install packages.
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package postgresql-13-citus-10.1
E: Couldn't find any package by glob 'postgresql-13-citus-10.1'
E: Couldn't find any package by regex 'postgresql-13-citus-10.1'
Error: Process completed with exit code 100.
``` 
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>