### PR TITLE
Escaping newlines in logs

### DIFF
--- a/src/sqlancer/common/log/SQLLoggableFactory.java
+++ b/src/sqlancer/common/log/SQLLoggableFactory.java
@@ -14,6 +14,8 @@ public class SQLLoggableFactory extends LoggableFactory {
         if (!input.endsWith(";")) {
             completeString += ";";
         }
+        completeString = completeString.replace("\n", "\\n");
+        completeString = completeString.replace("\r", "\\r");
         if (suffix != null && suffix.length() != 0) {
             completeString += suffix;
         }


### PR DESCRIPTION
For some databases, especially SQLite, it is required to escape the newlines in the log for a reproducible log.