### PR TITLE
fix: broken grammar of LIKELIHOOD

### DIFF
--- a/src/sqlancer/sqlite3/SQLite3Errors.java
+++ b/src/sqlancer/sqlite3/SQLite3Errors.java
@@ -21,7 +21,6 @@ public final class SQLite3Errors {
         errors.add("FTS expression tree is too large");
         errors.add("String or BLOB exceeds size limit");
         errors.add("[SQLITE_ERROR] SQL error or missing database (integer overflow)");
-        errors.add("second argument to likelihood() must be a constant between 0.0 and 1.0");
         errors.add("ORDER BY term out of range");
         errors.add("GROUP BY term out of range");
         errors.add("not authorized"); // load_extension

--- a/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
@@ -547,6 +547,12 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
                 nrArgs += Randomly.smallNumber();
             }
             List<SQLite3Expression> expressions = randomFunction.generateArguments(nrArgs, depth + 1, this);
+            // The second argument of LIKELIHOOD must be a float number within 0.0 -1.0
+            if (randomFunction == AnyFunction.LIKELIHOOD) {
+                SQLite3Expression lastArg = SQLite3Constant.createRealConstant(Randomly.getPercentage());
+                expressions.remove(expressions.size() - 1);
+                expressions.add(lastArg);
+            }
             return new SQLite3Expression.Function(randomFunction.toString(),
                     expressions.toArray(new SQLite3Expression[0]));
         }
@@ -603,6 +609,11 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
             if (i == 0 && Randomly.getBoolean()) {
                 args[i] = new SQLite3Distinct(args[i]);
             }
+        }
+        // The second argument of LIKELIHOOD must be a float number within 0.0 -1.0
+        if (func == ComputableFunction.LIKELIHOOD) {
+            SQLite3Expression lastArg = SQLite3Constant.createRealConstant(Randomly.getPercentage());
+            args[args.length - 1] = lastArg;
         }
         return new SQLite3Function(func, args);
     }


### PR DESCRIPTION
To avoid the grammar error: `The second argument of LIKELIHOOD must be a float number within 0.0 -1.0`