### PR TITLE
fix: switch off vectorize cockroachdb

### DIFF
--- a/src/sqlancer/cockroachdb/CockroachDBOptions.java
+++ b/src/sqlancer/cockroachdb/CockroachDBOptions.java
@@ -99,10 +99,6 @@ public class CockroachDBOptions implements DBMSSpecificOptions<CockroachDBOracle
     @Parameter(names = { "--test-temp-tables" }, description = "Test TEMPORARY tables")
     public boolean testTempTables; // default: false https://github.com/cockroachdb/cockroach/issues/85388
 
-    @Parameter(names = {
-            "--increased-vectorization" }, description = "Generate VECTORIZE=on with a higher probability (which found a number of bugs in the past)")
-    public boolean makeVectorizationMoreLikely = true;
-
     @Parameter(names = { "--max-num-tables" }, description = "The maximum number of tables that can be created")
     public int maxNumTables = 10;
 

--- a/src/sqlancer/cockroachdb/CockroachDBProvider.java
+++ b/src/sqlancer/cockroachdb/CockroachDBProvider.java
@@ -247,9 +247,6 @@ public class CockroachDBProvider extends SQLProviderAdapter<CockroachDBGlobalSta
             }
             total--;
         }
-        if (globalState.getDbmsSpecificOptions().makeVectorizationMoreLikely && Randomly.getBoolean()) {
-            manager.execute(new SQLQueryAdapter("SET vectorize=on;"));
-        }
     }
 
     @Override


### PR DESCRIPTION
The vectorize option is `on` by default: https://www.cockroachlabs.com/docs/v22.2/vectorized-execution#configure-vectorized-execution so we are required to randomly switch it off here.