### PR TITLE
Disable SEMI JOIN in ClickHouse

### DIFF
--- a/src/sqlancer/clickhouse/ClickHouseErrors.java
+++ b/src/sqlancer/clickhouse/ClickHouseErrors.java
@@ -73,6 +73,7 @@ public final class ClickHouseErrors {
         errors.add(" is out of bounds. Expected in range");
         errors.add("with constants is not supported. (INVALID_JOIN_ON_EXPRESSION)");
         errors.add("Different order of columns in UNION subquery"); // https://github.com/ClickHouse/ClickHouse/issues/44866
+        errors.add("Unexpected inf or nan to integer conversion");
     }
 
 }

--- a/src/sqlancer/clickhouse/ClickHouseToStringVisitor.java
+++ b/src/sqlancer/clickhouse/ClickHouseToStringVisitor.java
@@ -151,12 +151,6 @@ public class ClickHouseToStringVisitor extends ToStringVisitor<ClickHouseExpress
         } else if (type == ClickHouseExpression.ClickHouseJoin.JoinType.FULL_OUTER) {
             sb.append(" FULL OUTER JOIN ");
             visit(join.getRightTable());
-        } else if (type == ClickHouseExpression.ClickHouseJoin.JoinType.LEFT_SEMI) {
-            sb.append(" LEFT SEMI JOIN ");
-            visit(join.getRightTable());
-        } else if (type == ClickHouseExpression.ClickHouseJoin.JoinType.RIGHT_SEMI) {
-            sb.append(" RIGHT SEMI JOIN ");
-            visit(join.getRightTable());
         } else if (type == ClickHouseExpression.ClickHouseJoin.JoinType.LEFT_ANTI) {
             sb.append(" LEFT ANTI JOIN ");
             visit(join.getRightTable());

--- a/src/sqlancer/clickhouse/ast/ClickHouseExpression.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseExpression.java
@@ -63,8 +63,10 @@ public abstract class ClickHouseExpression {
 
     public static class ClickHouseJoin extends ClickHouseExpression {
         // TODO: support ANY, ALL, ASOF modifiers
+        // LEFT_SEMI, RIGHT_SEMI are not deterministic as ClickHouse allows to read columns from
+        // whitelist table as well
         public enum JoinType {
-            INNER, CROSS, LEFT_OUTER, RIGHT_OUTER, FULL_OUTER, LEFT_SEMI, RIGHT_SEMI, LEFT_ANTI, RIGHT_ANTI;
+            INNER, CROSS, LEFT_OUTER, RIGHT_OUTER, FULL_OUTER, NATURAL, LEFT_ANTI, RIGHT_ANTI;
         }
 
         private final ClickHouseTableReference leftTable;

--- a/src/sqlancer/clickhouse/ast/ClickHouseExpression.java
+++ b/src/sqlancer/clickhouse/ast/ClickHouseExpression.java
@@ -66,7 +66,7 @@ public abstract class ClickHouseExpression {
         // LEFT_SEMI, RIGHT_SEMI are not deterministic as ClickHouse allows to read columns from
         // whitelist table as well
         public enum JoinType {
-            INNER, CROSS, LEFT_OUTER, RIGHT_OUTER, FULL_OUTER, NATURAL, LEFT_ANTI, RIGHT_ANTI;
+            INNER, CROSS, LEFT_OUTER, RIGHT_OUTER, FULL_OUTER, LEFT_ANTI, RIGHT_ANTI;
         }
 
         private final ClickHouseTableReference leftTable;


### PR DESCRIPTION
This JOIN is non-deterministic for some columns and we can't check it with SQLancer.