### PR TITLE
tidb: not use DEFAULT if columns have not default value

### DIFF
--- a/src/sqlancer/tidb/TiDBExpressionGenerator.java
+++ b/src/sqlancer/tidb/TiDBExpressionGenerator.java
@@ -66,7 +66,11 @@ public class TiDBExpressionGenerator extends UntypedExpressionGenerator<TiDBExpr
             if (globalState.getSchema().getDatabaseTables().isEmpty()) {
                 throw new IgnoreMeException();
             }
-            return new TiDBFunctionCall(TiDBFunction.DEFAULT, Arrays.asList(generateColumn()));
+            TiDBColumn column = Randomly.fromList(columns);
+            if (column.hasDefault()) {
+                return new TiDBFunctionCall(TiDBFunction.DEFAULT, Arrays.asList(new TiDBColumnReference(column)));
+            }
+            throw new IgnoreMeException();
         case UNARY_POSTFIX:
             return new TiDBUnaryPostfixOperation(generateExpression(depth + 1), TiDBUnaryPostfixOperator.getRandom());
         case UNARY_PREFIX:

--- a/src/sqlancer/tidb/TiDBSchema.java
+++ b/src/sqlancer/tidb/TiDBSchema.java
@@ -350,9 +350,9 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
                     String dataType = rs.getString("Type");
                     boolean isNullable = rs.getString("Null").contentEquals("YES");
                     boolean isPrimaryKey = rs.getString("Key").contains("PRI");
-                    boolean notDefault = rs.getString("Default").isEmpty();
+                    boolean hasDefault = rs.getString("Default") != null;
                     TiDBColumn c = new TiDBColumn(columnName, getColumnType(dataType), isPrimaryKey, isNullable,
-                            !notDefault);
+                            hasDefault);
                     columns.add(c);
                 }
             }

--- a/src/sqlancer/tidb/TiDBSchema.java
+++ b/src/sqlancer/tidb/TiDBSchema.java
@@ -350,9 +350,9 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
                     String dataType = rs.getString("Type");
                     boolean isNullable = rs.getString("Null").contentEquals("YES");
                     boolean isPrimaryKey = rs.getString("Key").contains("PRI");
-                    boolean hasDefault = !rs.getString("Default").isEmpty();
+                    boolean notDefault = rs.getString("Default").isEmpty();
                     TiDBColumn c = new TiDBColumn(columnName, getColumnType(dataType), isPrimaryKey, isNullable,
-                            hasDefault);
+                            !notDefault);
                     columns.add(c);
                 }
             }

--- a/src/sqlancer/tidb/TiDBSchema.java
+++ b/src/sqlancer/tidb/TiDBSchema.java
@@ -161,10 +161,13 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
         private final boolean isPrimaryKey;
         private final boolean isNullable;
 
-        public TiDBColumn(String name, TiDBCompositeDataType columnType, boolean isPrimaryKey, boolean isNullable) {
+        private final boolean hasDefault;
+
+        public TiDBColumn(String name, TiDBCompositeDataType columnType, boolean isPrimaryKey, boolean isNullable, boolean hasDefault) {
             super(name, null, columnType);
             this.isPrimaryKey = isPrimaryKey;
             this.isNullable = isNullable;
+            this.hasDefault = hasDefault;
         }
 
         public boolean isPrimaryKey() {
@@ -173,6 +176,10 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
 
         public boolean isNullable() {
             return isNullable;
+        }
+
+        public boolean hasDefault() {
+            return hasDefault;
         }
 
     }
@@ -343,7 +350,8 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
                     String dataType = rs.getString("Type");
                     boolean isNullable = rs.getString("Null").contentEquals("YES");
                     boolean isPrimaryKey = rs.getString("Key").contains("PRI");
-                    TiDBColumn c = new TiDBColumn(columnName, getColumnType(dataType), isPrimaryKey, isNullable);
+                    boolean hasDefault = !rs.getString("Default").isEmpty();
+                    TiDBColumn c = new TiDBColumn(columnName, getColumnType(dataType), isPrimaryKey, isNullable, hasDefault);
                     columns.add(c);
                 }
             }

--- a/src/sqlancer/tidb/TiDBSchema.java
+++ b/src/sqlancer/tidb/TiDBSchema.java
@@ -160,10 +160,10 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
 
         private final boolean isPrimaryKey;
         private final boolean isNullable;
-
         private final boolean hasDefault;
 
-        public TiDBColumn(String name, TiDBCompositeDataType columnType, boolean isPrimaryKey, boolean isNullable, boolean hasDefault) {
+        public TiDBColumn(String name, TiDBCompositeDataType columnType, boolean isPrimaryKey, boolean isNullable,
+                boolean hasDefault) {
             super(name, null, columnType);
             this.isPrimaryKey = isPrimaryKey;
             this.isNullable = isNullable;
@@ -351,7 +351,8 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
                     boolean isNullable = rs.getString("Null").contentEquals("YES");
                     boolean isPrimaryKey = rs.getString("Key").contains("PRI");
                     boolean hasDefault = !rs.getString("Default").isEmpty();
-                    TiDBColumn c = new TiDBColumn(columnName, getColumnType(dataType), isPrimaryKey, isNullable, hasDefault);
+                    TiDBColumn c = new TiDBColumn(columnName, getColumnType(dataType), isPrimaryKey, isNullable,
+                            hasDefault);
                     columns.add(c);
                 }
             }

--- a/src/sqlancer/tidb/gen/TiDBTableGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBTableGenerator.java
@@ -38,7 +38,7 @@ public class TiDBTableGenerator {
         allowPrimaryKey = Randomly.getBoolean();
         primaryKeyAsTableConstraints = allowPrimaryKey && Randomly.getBoolean();
         for (int i = 0; i < nrColumns; i++) {
-            TiDBColumn fakeColumn = new TiDBColumn("c" + i, null, false, false,false);
+            TiDBColumn fakeColumn = new TiDBColumn("c" + i, null, false, false, false);
             columns.add(fakeColumn);
         }
         TiDBExpressionGenerator gen = new TiDBExpressionGenerator(globalState).setColumns(columns);

--- a/src/sqlancer/tidb/gen/TiDBTableGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBTableGenerator.java
@@ -38,7 +38,7 @@ public class TiDBTableGenerator {
         allowPrimaryKey = Randomly.getBoolean();
         primaryKeyAsTableConstraints = allowPrimaryKey && Randomly.getBoolean();
         for (int i = 0; i < nrColumns; i++) {
-            TiDBColumn fakeColumn = new TiDBColumn("c" + i, null, false, false);
+            TiDBColumn fakeColumn = new TiDBColumn("c" + i, null, false, false,false);
             columns.add(fakeColumn);
         }
         TiDBExpressionGenerator gen = new TiDBExpressionGenerator(globalState).setColumns(columns);


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

before this PR
```
$ java -jar sqlancer-*.jar   --num-threads 8   --host "127.0.0.1" --port 4000 --username "root" --password ""   tidb
[2023/01/16 00:02:09] Executed 0 queries (0 queries/s; 0.00/s dbs, successful statements: 82%). Threads shut down: 0.
[2023/01/16 00:02:14] Executed 9980 queries (1997 queries/s; 1.60/s dbs, successful statements: 73%). Threads shut down: 0.
[2023/01/16 00:02:19] Executed 25513 queries (3105 queries/s; 0.00/s dbs, successful statements: 73%). Threads shut down: 0.
[2023/01/16 00:02:24] Executed 41383 queries (3176 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
[2023/01/16 00:02:29] Executed 58620 queries (3446 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
[2023/01/16 00:02:34] Executed 63916 queries (1055 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
[2023/01/16 00:02:39] Executed 65185 queries (253 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
[2023/01/16 00:02:44] Executed 66895 queries (344 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
[2023/01/16 00:02:49] Executed 73724 queries (1366 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
[2023/01/16 00:02:54] Executed 86496 queries (2555 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
[2023/01/16 00:02:59] Executed 89432 queries (586 queries/s; 0.00/s dbs, successful statements: 72%). Threads shut down: 0.
```

after this PR

```
$ java -jar sqlancer-*.jar   --num-threads 8   --host "127.0.0.1" --port 4000 --username "root" --password ""   tidb
[2023/01/16 00:03:59] Executed 191 queries (38 queries/s; 0.20/s dbs, successful statements: 82%). Threads shut down: 0.
[2023/01/16 00:04:04] Executed 7808 queries (1524 queries/s; 1.20/s dbs, successful statements: 80%). Threads shut down: 0.
[2023/01/16 00:04:09] Executed 24424 queries (3323 queries/s; 0.20/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:14] Executed 43005 queries (3716 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:19] Executed 60919 queries (3582 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:24] Executed 79127 queries (3643 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:29] Executed 87297 queries (1632 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:34] Executed 100428 queries (2628 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:39] Executed 116637 queries (3243 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:44] Executed 130593 queries (2778 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:49] Executed 133773 queries (638 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:54] Executed 148368 queries (2920 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:04:59] Executed 165463 queries (3416 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:05:04] Executed 177157 queries (2338 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:05:09] Executed 192578 queries (3084 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:05:14] Executed 206208 queries (2726 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:05:19] Executed 224911 queries (3742 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
[2023/01/16 00:05:24] Executed 243062 queries (3628 queries/s; 0.00/s dbs, successful statements: 79%). Threads shut down: 0.
```