### PR TITLE
Ignore AMBIGUOUS_IDENTIFIER

### DIFF
--- a/src/sqlancer/clickhouse/ClickHouseErrors.java
+++ b/src/sqlancer/clickhouse/ClickHouseErrors.java
@@ -75,8 +75,10 @@ public final class ClickHouseErrors {
         errors.add("Unexpected inf or nan to integer conversion");
         errors.add("Unsigned type must not contain");
         errors.add("Unexpected inf or nan to integer conversion");
+
         // The way we generate JOINs we can have ambiguous left table column without alias
         // We may not count it as an issue, but it makes no sense to add more complex AST generation logic
+        errors.add("MULTIPLE_EXPRESSIONS_FOR_ALIAS");
         errors.add("AMBIGUOUS_IDENTIFIER"); // https://github.com/ClickHouse/ClickHouse/issues/45389
     }
 

--- a/src/sqlancer/clickhouse/ClickHouseErrors.java
+++ b/src/sqlancer/clickhouse/ClickHouseErrors.java
@@ -75,6 +75,9 @@ public final class ClickHouseErrors {
         errors.add("Unexpected inf or nan to integer conversion");
         errors.add("Unsigned type must not contain");
         errors.add("Unexpected inf or nan to integer conversion");
+        // The way we generate JOINs we can have ambiguous left table column without alias
+        // We may not count it as an issue, but it makes no sense to add more complex AST generation logic
+        errors.add("AMBIGUOUS_IDENTIFIER"); // https://github.com/ClickHouse/ClickHouse/issues/45389
     }
 
 }


### PR DESCRIPTION
Related to https://github.com/ClickHouse/ClickHouse/issues/45389
But it is not a bug - we generate query with references that are not resolved correctly in ClickHouse scoping model. Will just ignore them as I don't want always add alias to left table.
MULTIPLE_EXPRESSIONS_FOR_ALIAS is the same error as AMBIGUOUS_IDENTIFIER in older codebase.