### PR TITLE
fix: credential env for databend docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,7 +146,7 @@ jobs:
         run: cd cockroach-v22.2.3.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
       - name: Run Tests
         run: COCKROACHDB_AVAILABLE=true mvn -Dtest=TestCockroachDBQPG test
-        
+
   databend:
     name: DBMS Tests (Databend)
     runs-on: ubuntu-latest
@@ -154,8 +154,8 @@ jobs:
       databend:
         image: datafuselabs/databend
         env:
-          DATABEND_DEFAULT_USER: sqlancer
-          DATABEND_DEFAULT_PASSWORD: sqlancer
+          QUERY_DEFAULT_USER: sqlancer
+          QUERY_DEFAULT_PASSWORD: sqlancer
         ports:
           - 8000:8000
           - 3307:3307


### PR DESCRIPTION
for: #707

According to document on https://hub.docker.com/r/datafuselabs/databend