### PR TITLE
Forbid multiple table selection from QuestDB

### DIFF
--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
@@ -67,15 +67,15 @@ public class QuestDBQueryPartitioningBase
     @Override
     public void check() throws SQLException {
         s = state.getSchema();
-        // Only return one table instead of multiple tables, which is regarded as illegal by QuestDB 
+        // Only return one table instead of multiple tables, which is regarded as illegal by QuestDB
         // e.g. "SELECT * FROM t0, t1;"
-        targetTable = s.getRandomTable(t -> !t.isView()); 
-        gen = new QuestDBExpressionGenerator(state).setColumns(targetTable.getColumns()); 
+        targetTable = s.getRandomTable(t -> !t.isView());
+        gen = new QuestDBExpressionGenerator(state).setColumns(targetTable.getColumns());
         initializeTernaryPredicateVariants();
         select = new QuestDBSelect();
         select.setFetchColumns(generateFetchColumns());
-        List<QuestDBTable> tables = new ArrayList<>(); 
-        tables.add(targetTable); 
+        List<QuestDBTable> tables = new ArrayList<>();
+        tables.add(targetTable);
         List<TableReferenceNode<QuestDBExpression, QuestDBTable>> tableList = tables.stream()
                 .map(t -> new TableReferenceNode<QuestDBExpression, QuestDBTable>(t)).collect(Collectors.toList());
         // Ignore JOINs for now

--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
@@ -29,6 +29,7 @@ public class QuestDBQueryPartitioningBase
 
     QuestDBSchema s;
     QuestDBTables targetTables;
+    QuestDBTable targetTable; // single table
     QuestDBExpressionGenerator gen;
     QuestDBSelect select;
 
@@ -42,7 +43,7 @@ public class QuestDBQueryPartitioningBase
         if (Randomly.getBoolean()) {
             columns.add(new ColumnReferenceNode<>(new QuestDBColumn("*", null, false)));
         } else {
-            columns = Randomly.nonEmptySubset(targetTables.getColumns()).stream()
+            columns = Randomly.nonEmptySubset(targetTable.getColumns()).stream()
                     .map(c -> new ColumnReferenceNode<QuestDBExpression, QuestDBColumn>(c))
                     .collect(Collectors.toList());
         }
@@ -66,12 +67,15 @@ public class QuestDBQueryPartitioningBase
     @Override
     public void check() throws SQLException {
         s = state.getSchema();
-        targetTables = s.getRandomTableNonEmptyTables();
-        gen = new QuestDBExpressionGenerator(state).setColumns(targetTables.getColumns());
+        // Only return one table instead of multiple tables, which is regarded as illegal by QuestDB 
+        // e.g. "SELECT * FROM t0, t1;"
+        targetTable = s.getRandomTable(t -> !t.isView()); 
+        gen = new QuestDBExpressionGenerator(state).setColumns(targetTable.getColumns()); 
         initializeTernaryPredicateVariants();
         select = new QuestDBSelect();
         select.setFetchColumns(generateFetchColumns());
-        List<QuestDBTable> tables = targetTables.getTables();
+        List<QuestDBTable> tables = new ArrayList<>(); 
+        tables.add(targetTable); 
         List<TableReferenceNode<QuestDBExpression, QuestDBTable>> tableList = tables.stream()
                 .map(t -> new TableReferenceNode<QuestDBExpression, QuestDBTable>(t)).collect(Collectors.toList());
         // Ignore JOINs for now

--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
@@ -18,7 +18,6 @@ import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
 import sqlancer.questdb.QuestDBSchema;
 import sqlancer.questdb.QuestDBSchema.QuestDBColumn;
 import sqlancer.questdb.QuestDBSchema.QuestDBTable;
-import sqlancer.questdb.QuestDBSchema.QuestDBTables;
 import sqlancer.questdb.ast.QuestDBExpression;
 import sqlancer.questdb.ast.QuestDBSelect;
 import sqlancer.questdb.gen.QuestDBExpressionGenerator;
@@ -28,7 +27,6 @@ public class QuestDBQueryPartitioningBase
         implements TestOracle<QuestDBGlobalState> {
 
     QuestDBSchema s;
-    QuestDBTables targetTables;
     QuestDBTable targetTable; // single table
     QuestDBExpressionGenerator gen;
     QuestDBSelect select;
@@ -69,7 +67,7 @@ public class QuestDBQueryPartitioningBase
         s = state.getSchema();
         // Only return one table instead of multiple tables, which is regarded as illegal by QuestDB
         // e.g. "SELECT * FROM t0, t1;"
-        targetTable = s.getRandomTable(t -> !t.isView());
+        targetTable = s.getRandomTable();
         gen = new QuestDBExpressionGenerator(state).setColumns(targetTable.getColumns());
         initializeTernaryPredicateVariants();
         select = new QuestDBSelect();

--- a/src/sqlancer/tidb/TiDBSchema.java
+++ b/src/sqlancer/tidb/TiDBSchema.java
@@ -238,6 +238,7 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
                 primitiveType = TiDBDataType.FLOATING;
                 break;
             case "double":
+            case "double(8,6)": // workaround to address https://github.com/sqlancer/sqlancer/issues/669
                 size = 8;
                 primitiveType = TiDBDataType.FLOATING;
                 break;
@@ -271,6 +272,7 @@ public class TiDBSchema extends AbstractSchema<TiDBGlobalState, TiDBTable> {
                 break;
             case "date":
             case "datetime":
+            case "datetime(6)": // workaround to address https://github.com/sqlancer/sqlancer/issues/669
             case "timestamp":
             case "time":
             case "year":


### PR DESCRIPTION
Currently, selecting from multiple tables are regarded as illegal by QuestDB. E.g. `SELECT * FROM t0, t1;`

This will cause the low "successful statements" when running our code (~20%)
This PR forbids such operation, and increase the successful statements to 70%.

Running command: `java -jar sqlancer-*.jar --num-threads 1 questdb`