### PR TITLE
Add SYMBOL type support for QuestDB

### DIFF
--- a/src/sqlancer/questdb/QuestDBSchema.java
+++ b/src/sqlancer/questdb/QuestDBSchema.java
@@ -70,7 +70,7 @@ public class QuestDBSchema extends AbstractSchema<QuestDBGlobalState, QuestDBTab
                 isNullable = false;
                 break;
             case SYMBOL:
-                isNullable = false;
+                isNullable = true;
                 break;
             default:
                 isNullable = true;

--- a/src/sqlancer/questdb/QuestDBSchema.java
+++ b/src/sqlancer/questdb/QuestDBSchema.java
@@ -27,8 +27,7 @@ public class QuestDBSchema extends AbstractSchema<QuestDBGlobalState, QuestDBTab
 
         BOOLEAN, // CHAR,
         /* STRING, */
-        INT, FLOAT,
-        /* SYMBOL, */
+        INT, FLOAT, SYMBOL,
         // DATE, TIMESTAMP,
         /* GEOHASH, */
         NULL;
@@ -70,6 +69,9 @@ public class QuestDBSchema extends AbstractSchema<QuestDBGlobalState, QuestDBTab
             case BOOLEAN:
                 isNullable = false;
                 break;
+            case SYMBOL:
+                isNullable = false;
+                break;
             default:
                 isNullable = true;
             }
@@ -104,6 +106,9 @@ public class QuestDBSchema extends AbstractSchema<QuestDBGlobalState, QuestDBTab
                 // case CHAR:
                 // case DATE:
                 // case TIMESTAMP:
+                size = 0;
+                break;
+            case SYMBOL:
                 size = 0;
                 break;
             default:
@@ -142,6 +147,8 @@ public class QuestDBSchema extends AbstractSchema<QuestDBGlobalState, QuestDBTab
                 }
             case BOOLEAN:
                 return Randomly.fromOptions("BOOLEAN");
+            case SYMBOL:
+                return Randomly.fromOptions("SYMBOL");
             // case TIMESTAMP:
             // return Randomly.fromOptions("TIMESTAMP");
             // case DATE:
@@ -232,6 +239,9 @@ public class QuestDBSchema extends AbstractSchema<QuestDBGlobalState, QuestDBTab
         case "SHORT":
             primitiveType = QuestDBDataType.INT;
             size = 2;
+            break;
+        case "SYMBOL":
+            primitiveType = QuestDBDataType.SYMBOL;
             break;
         case "NULL":
             primitiveType = QuestDBDataType.NULL;

--- a/src/sqlancer/questdb/ast/QuestDBConstant.java
+++ b/src/sqlancer/questdb/ast/QuestDBConstant.java
@@ -56,7 +56,10 @@ public class QuestDBConstant implements Node<QuestDBExpression> {
 
         @Override
         public String toString() {
-            return value;
+            if (value.equals("NULL")) {
+                return value;
+            }
+            return "'" + value + "'";
         }
 
         public String getValue() {

--- a/src/sqlancer/questdb/ast/QuestDBConstant.java
+++ b/src/sqlancer/questdb/ast/QuestDBConstant.java
@@ -47,6 +47,23 @@ public class QuestDBConstant implements Node<QuestDBExpression> {
         }
     }
 
+    public static class QuestDBSymbolConstant extends QuestDBConstant {
+        private final String value;
+
+        public QuestDBSymbolConstant(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
     public static Node<QuestDBExpression> createIntConstant(long val) {
         return new QuestDBIntConstant(val);
     }
@@ -85,5 +102,9 @@ public class QuestDBConstant implements Node<QuestDBExpression> {
 
     public static Node<QuestDBExpression> createFloatConstant(double val) {
         return new QuestDBDoubleConstant(val);
+    }
+
+    public static Node<QuestDBExpression> createSymbolConstant(String val) {
+        return new QuestDBSymbolConstant(val);
     }
 }

--- a/src/sqlancer/questdb/ast/QuestDBConstant.java
+++ b/src/sqlancer/questdb/ast/QuestDBConstant.java
@@ -56,8 +56,8 @@ public class QuestDBConstant implements Node<QuestDBExpression> {
 
         @Override
         public String toString() {
-            if (value.equals("NULL")) {
-                return value;
+            if (value.equals("")) {
+                return "NULL";
             }
             return "'" + value + "'";
         }

--- a/src/sqlancer/questdb/gen/QuestDBExpressionGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBExpressionGenerator.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.Randomly.StringGenerationStrategy;
 import sqlancer.common.ast.BinaryOperatorNode.Operator;
 import sqlancer.common.ast.newast.ColumnReferenceNode;
 import sqlancer.common.ast.newast.NewBinaryOperatorNode;
@@ -54,6 +55,15 @@ public class QuestDBExpressionGenerator extends UntypedExpressionGenerator<Node<
             return QuestDBConstant.createBooleanConstant(Randomly.getBoolean());
         case FLOAT:
             return QuestDBConstant.createFloatConstant(globalState.getRandomly().getDouble());
+        case SYMBOL:
+            StringGenerationStrategy strategy = Randomly.StringGenerationStrategy.ALPHANUMERIC;
+            // Add quotes to form a valid string for QuestDB
+            String str = '\"' + strategy.getString(globalState.getRandomly()) + '\"';
+            // When the value of symbol is not specified, set it to NULL (not "NULL")
+            if (str.length() == 2) {
+                str = "NULL";
+            }
+            return QuestDBConstant.createSymbolConstant(str);
         // case CHAR:
         // case DATE:
         // case TIMESTAMP:

--- a/src/sqlancer/questdb/gen/QuestDBExpressionGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBExpressionGenerator.java
@@ -57,13 +57,7 @@ public class QuestDBExpressionGenerator extends UntypedExpressionGenerator<Node<
             return QuestDBConstant.createFloatConstant(globalState.getRandomly().getDouble());
         case SYMBOL:
             StringGenerationStrategy strategy = Randomly.StringGenerationStrategy.ALPHANUMERIC;
-            // Add quotes to form a valid string for QuestDB
-            String str = '\"' + strategy.getString(globalState.getRandomly()) + '\"';
-            // When the value of symbol is not specified, set it to NULL (not "NULL")
-            if (str.length() == 2) {
-                str = "NULL";
-            }
-            return QuestDBConstant.createSymbolConstant(str);
+            return QuestDBConstant.createSymbolConstant(strategy.getString(globalState.getRandomly()));
         // case CHAR:
         // case DATE:
         // case TIMESTAMP:

--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
@@ -27,7 +27,7 @@ public class QuestDBQueryPartitioningBase
         implements TestOracle<QuestDBGlobalState> {
 
     QuestDBSchema s;
-    QuestDBTable targetTable; // single table
+    QuestDBTable targetTable;
     QuestDBExpressionGenerator gen;
     QuestDBSelect select;
 


### PR DESCRIPTION
Add `SYMBOL` type support for QuestDB because an index can only be created on `SYMBOL` type columns according to QuestDB.