### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,76 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'type:bug'
+assignees: ''
+
+---
+<!-- This template provide a checklist for reporting an issue for SQLancer. Modify the template if it's not suitable for your use case -->
+
+Thanks for contributing! Note that your issue may already be reported, please search on the [issue tracker](https://github.com/sqlancer/sqlancer/issues)
+before creating a new one.
+
+**Affected Phases**
+<!-- SQLancer operates in the following two phases: Database generation and Testing. -->
+<!-- Please tell us which phases of sqlancer is affected (leave empty if you are unsure). -->
+
+* [ ] Database generation
+* [ ] Testing
+
+**Testing Approaches**
+<!-- Please tell us which testing approaches you are using(leave empty if you are unsure). -->
+
+* [ ] Pivoted Query Synthesis (PQS)
+* [ ] Non-optimizing Reference Engine Construction (NoREC)
+* [ ] Ternary Logic Partitioning (TLP)
+
+**Generation Approaches**
+<!-- Please tell us which generation approaches you are using(leave empty if you are unsure). -->
+
+* [ ] Random Generation
+* [ ] Query Plan Guidance (QPG)
+
+**DBMS**
+<!-- Please tell us which DBMS is affected (leave empty if you are unsure). -->
+
+* [ ] SQLite
+* [ ] MySQL
+* [ ] PostgreSQL
+* [ ] Citus (PostgreSQL Extension)
+* [ ] MariaDB
+* [ ] CockroachDB
+* [ ] TiDB
+* [ ] DuckDB
+* [ ] ClickHouse
+* [ ] TDEngine
+* [ ] OceanBase
+* [ ] YugabyteDB
+* [ ] Databend
+* [ ] QuestDB
+* [ ] CnosDB
+
+**Describe the bug**
+<!-- Please provide a clear and concise description of what the bug is. Code samples should be put in the **To Reproduce** section. -->
+
+**To Reproduce**
+<!-- Please provide detailed instructions on how to reproduce the behaviour, including code samples if applicable. -->
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+<!--- Please provide a clear and concise description of what you expected to happen -->
+
+**Current behavior**
+<!--- Please tell us what happens instead of the expected behavior -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "SQLancer Community"
+    url: "https://join.slack.com/t/sqlancer/shared_invite/zt-eozrcao4-ieG29w1LNaBDMF7OB_~ACg"
+    about: "Please ask and answer questions here"

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Description
+
+[Provide a brief description of the changes you have made and why they are necessary.]
+
+## Changes Made
+[List the changes you have made in bullet points.]
+
+## Checklist
+- [ ] I have read and followed the contributing guidelines.
+- [ ] I have tested my changes thoroughly and they work as expected.
+- [ ] I have added necessary tests for the changes made.
+- [ ] I have updated the documentation to reflect the changes made.
+- [ ] My code follows the project's coding style and standards.
+- [ ] I have added appropriate commit messages and comments for my changes.
+
+
+## Related Issues
+[If your changes relate to any existing issues, please list them here.]
+
+## Additional Notes
+[Provide any additional notes or context that may be helpful for the reviewers.]
+
+Feel free to modify and customize this template as needed to fit the specific needs of the SQLancer project.


### PR DESCRIPTION
fix: #742 

Currently our repo do not have a issue template.

GitHub supports Issue templates. Ref: [Issue template docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).

The issue template will provide contributors with a structured entry point for reporting any issue or bug.