### PR TITLE
refactor: better code logic, try-with-resources with multiple resources

### DIFF
--- a/src/sqlancer/citus/CitusSchema.java
+++ b/src/sqlancer/citus/CitusSchema.java
@@ -23,17 +23,14 @@ public class CitusSchema extends PostgresSchema {
         // colocationId is null for local tables
         private Integer colocationId;
 
-        public CitusTable(String tableName, List<PostgresColumn> columns, List<PostgresIndex> indexes,
-                TableType tableType, List<PostgresStatisticsObject> statistics, boolean isView, boolean isInsertable,
-                PostgresColumn distributionColumn, Integer colocationId) {
+        public CitusTable(String tableName, List<PostgresColumn> columns, List<PostgresIndex> indexes, TableType tableType, List<PostgresStatisticsObject> statistics, boolean isView, boolean isInsertable, PostgresColumn distributionColumn, Integer colocationId) {
             super(tableName, columns, indexes, tableType, statistics, isView, isInsertable);
             this.distributionColumn = distributionColumn;
             this.colocationId = colocationId;
         }
 
         public CitusTable(PostgresTable table, PostgresColumn distributionColumn, Integer colocationId) {
-            super(table.getName(), table.getColumns(), table.getIndexes(), table.getTableType(), table.getStatistics(),
-                    table.isView(), table.isInsertable());
+            super(table.getName(), table.getColumns(), table.getIndexes(), table.getTableType(), table.getStatistics(), table.isView(), table.isInsertable());
             this.distributionColumn = distributionColumn;
             this.colocationId = colocationId;
         }
@@ -58,41 +55,34 @@ public class CitusSchema extends PostgresSchema {
 
     public static CitusSchema fromConnection(SQLConnection con, String databaseName) throws SQLException {
         PostgresSchema schema = PostgresSchema.fromConnection(con, databaseName);
-        try {
-            List<CitusTable> databaseTables = new ArrayList<>();
-            try (Statement s = con.createStatement()) {
-                try (ResultSet rs = s.executeQuery(
-                        "SELECT table_name, column_to_column_name(logicalrelid, partkey) AS dist_col_name, colocationid FROM information_schema.tables LEFT OUTER JOIN pg_dist_partition ON logicalrelid=table_name::regclass WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%';")) {
-                    while (rs.next()) {
-                        String tableName = rs.getString("table_name");
-                        /* citus_tables is a helper view, we don't need to test with it so we let's ignore it */
-                        if (tableName.equals("citus_tables")) {
-                            continue;
-                        }
-                        String distributionColumnName = rs.getString("dist_col_name");
-                        Integer colocationId = rs.getInt("colocationid");
-                        if (rs.wasNull()) {
-                            colocationId = null;
-                        }
-                        PostgresTable t = schema.getDatabaseTable(tableName);
-                        PostgresColumn distributionColumn = null;
-                        if (t == null) {
-                            continue;
-                        }
-                        if (distributionColumnName != null && !distributionColumnName.equals("")) {
-                            distributionColumn = t.getColumns().stream()
-                                    .filter(c -> c.getName().equals(distributionColumnName))
-                                    .collect(Collectors.toList()).get(0);
-                        }
-                        CitusTable tCitus = new CitusTable(t, distributionColumn, colocationId);
-                        databaseTables.add(tCitus);
-                    }
+        List<CitusTable> databaseTables = new ArrayList<>();
+        try (Statement s = con.createStatement();
+             ResultSet rs = s.executeQuery("SELECT table_name, column_to_column_name(logicalrelid, partkey) AS dist_col_name, colocationid FROM information_schema.tables LEFT OUTER JOIN pg_dist_partition ON logicalrelid=table_name::regclass WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%';")) {
+            while (rs.next()) {
+                String tableName = rs.getString("table_name");
+                /* citus_tables is a helper view, we don't need to test with it so we let's ignore it */
+                if (tableName.equals("citus_tables")) {
+                    continue;
                 }
+                String distributionColumnName = rs.getString("dist_col_name");
+                Integer colocationId = rs.getInt("colocationid");
+                if (rs.wasNull()) {
+                    colocationId = null;
+                }
+                PostgresTable t = schema.getDatabaseTable(tableName);
+                PostgresColumn distributionColumn = null;
+                if (t == null) {
+                    continue;
+                }
+                if (distributionColumnName != null && !distributionColumnName.equals("")) {
+                    distributionColumn = t.getColumns().stream().filter(c -> c.getName().equals(distributionColumnName)).collect(Collectors.toList()).get(0);
+                }
+                CitusTable tCitus = new CitusTable(t, distributionColumn, colocationId);
+                databaseTables.add(tCitus);
             }
-            return new CitusSchema(databaseTables, databaseName);
         } catch (SQLIntegrityConstraintViolationException e) {
             throw new AssertionError(e);
         }
+        return new CitusSchema(databaseTables, databaseName);
     }
-
 }

--- a/src/sqlancer/citus/CitusSchema.java
+++ b/src/sqlancer/citus/CitusSchema.java
@@ -23,14 +23,17 @@ public class CitusSchema extends PostgresSchema {
         // colocationId is null for local tables
         private Integer colocationId;
 
-        public CitusTable(String tableName, List<PostgresColumn> columns, List<PostgresIndex> indexes, TableType tableType, List<PostgresStatisticsObject> statistics, boolean isView, boolean isInsertable, PostgresColumn distributionColumn, Integer colocationId) {
+        public CitusTable(String tableName, List<PostgresColumn> columns, List<PostgresIndex> indexes,
+                TableType tableType, List<PostgresStatisticsObject> statistics, boolean isView, boolean isInsertable,
+                PostgresColumn distributionColumn, Integer colocationId) {
             super(tableName, columns, indexes, tableType, statistics, isView, isInsertable);
             this.distributionColumn = distributionColumn;
             this.colocationId = colocationId;
         }
 
         public CitusTable(PostgresTable table, PostgresColumn distributionColumn, Integer colocationId) {
-            super(table.getName(), table.getColumns(), table.getIndexes(), table.getTableType(), table.getStatistics(), table.isView(), table.isInsertable());
+            super(table.getName(), table.getColumns(), table.getIndexes(), table.getTableType(), table.getStatistics(),
+                    table.isView(), table.isInsertable());
             this.distributionColumn = distributionColumn;
             this.colocationId = colocationId;
         }
@@ -56,8 +59,8 @@ public class CitusSchema extends PostgresSchema {
     public static CitusSchema fromConnection(SQLConnection con, String databaseName) throws SQLException {
         PostgresSchema schema = PostgresSchema.fromConnection(con, databaseName);
         List<CitusTable> databaseTables = new ArrayList<>();
-        try (Statement s = con.createStatement();
-             ResultSet rs = s.executeQuery("SELECT table_name, column_to_column_name(logicalrelid, partkey) AS dist_col_name, colocationid FROM information_schema.tables LEFT OUTER JOIN pg_dist_partition ON logicalrelid=table_name::regclass WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%';")) {
+        try (Statement s = con.createStatement(); ResultSet rs = s.executeQuery(
+                "SELECT table_name, column_to_column_name(logicalrelid, partkey) AS dist_col_name, colocationid FROM information_schema.tables LEFT OUTER JOIN pg_dist_partition ON logicalrelid=table_name::regclass WHERE table_schema='public' OR table_schema LIKE 'pg_temp_%';")) {
             while (rs.next()) {
                 String tableName = rs.getString("table_name");
                 /* citus_tables is a helper view, we don't need to test with it so we let's ignore it */
@@ -75,7 +78,8 @@ public class CitusSchema extends PostgresSchema {
                     continue;
                 }
                 if (distributionColumnName != null && !distributionColumnName.equals("")) {
-                    distributionColumn = t.getColumns().stream().filter(c -> c.getName().equals(distributionColumnName)).collect(Collectors.toList()).get(0);
+                    distributionColumn = t.getColumns().stream().filter(c -> c.getName().equals(distributionColumnName))
+                            .collect(Collectors.toList()).get(0);
                 }
                 CitusTable tCitus = new CitusTable(t, distributionColumn, colocationId);
                 databaseTables.add(tCitus);


### PR DESCRIPTION
Refactor code logic in CitusScheme.java

- Try with multiple resources, separated by `;`
- Move the return statement to the end of the function