### PR TITLE
Refactor several classes 

### DIFF
--- a/src/sqlancer/ProviderAdapter.java
+++ b/src/sqlancer/ProviderAdapter.java
@@ -26,7 +26,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
     int currentSelectCounts;
     int currentMutationOperator = -1;
 
-    public ProviderAdapter(Class<G> globalClass, Class<O> optionClass) {
+    protected ProviderAdapter(Class<G> globalClass, Class<O> optionClass) {
         this.globalClass = globalClass;
         this.optionClass = optionClass;
     }
@@ -85,7 +85,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
         List<? extends OracleFactory<G>> testOracleFactory = globalState.getDbmsSpecificOptions()
                 .getTestOracleFactory();
         boolean testOracleRequiresMoreThanZeroRows = testOracleFactory.stream()
-                .anyMatch(p -> p.requiresAllTablesToContainRows());
+                .anyMatch(OracleFactory::requiresAllTablesToContainRows);
         boolean userRequiresMoreThanZeroRows = globalState.getOptions().testOnlyWithMoreThanZeroRows();
         boolean checkZeroRows = testOracleRequiresMoreThanZeroRows || userRequiresMoreThanZeroRows;
         if (checkZeroRows && globalState.getSchema().containsTableWithZeroRows(globalState)) {
@@ -98,7 +98,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
         if (testOracleFactory.size() == 1) {
             return testOracleFactory.get(0).create(globalState);
         } else {
-            return new CompositeTestOracle<G>(testOracleFactory.stream().map(o -> {
+            return new CompositeTestOracle<>(testOracleFactory.stream().map(o -> {
                 try {
                     return o.create(globalState);
                 } catch (Exception e1) {
@@ -170,7 +170,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
         if (Randomly.getPercentage() < globalState.getOptions().getQPGProbability()) {
             selectedActionIndex = globalState.getRandomly().getInteger(0, weightedAverageReward.length);
         } else {
-            selectedActionIndex = DBMSCommon.getMaxIndexInDoubleArrary(weightedAverageReward);
+            selectedActionIndex = DBMSCommon.getMaxIndexInDoubleArray(weightedAverageReward);
         }
         int reward = 0;
 

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -132,7 +132,6 @@ public final class Randomly {
         return extractNrRandomColumns(columns, nr);
     }
 
-
     public static <T> List<T> subset(int nr, @SuppressWarnings("unchecked") T... values) {
         List<T> list = new ArrayList<>();
         Collections.addAll(list, values);

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -1,9 +1,9 @@
 package sqlancer;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -1,6 +1,7 @@
 package sqlancer;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -131,19 +132,15 @@ public final class Randomly {
         return extractNrRandomColumns(columns, nr);
     }
 
+
     public static <T> List<T> subset(int nr, @SuppressWarnings("unchecked") T... values) {
         List<T> list = new ArrayList<>();
-        for (T val : values) {
-            list.add(val);
-        }
+        Collections.addAll(list, values);
         return extractNrRandomColumns(list, nr);
     }
 
     public static <T> List<T> subset(@SuppressWarnings("unchecked") T... values) {
-        List<T> list = new ArrayList<>();
-        for (T val : values) {
-            list.add(val);
-        }
+        List<T> list = new ArrayList<>(Arrays.asList(values));
         return subset(list);
     }
 
@@ -350,7 +347,6 @@ public final class Randomly {
         do {
             value = getInteger();
         } while (value == 0);
-        assert value != 0;
         addToCache(value);
         return value;
     }
@@ -425,7 +421,7 @@ public final class Randomly {
     }
 
     public BigDecimal getRandomBigDecimal() {
-        return new BigDecimal(getThreadRandom().get().nextDouble());
+        return BigDecimal.valueOf(getThreadRandom().get().nextDouble());
     }
 
     public long getPositiveIntegerNotNull() {
@@ -494,7 +490,7 @@ public final class Randomly {
         if (lower == upper) {
             return lower;
         }
-        return (long) (getThreadRandom().get().longs(lower, upper).findFirst().getAsLong());
+        return getThreadRandom().get().longs(lower, upper).findFirst().getAsLong();
     }
 
     private static int getNextInt(int lower, int upper) {

--- a/src/sqlancer/SQLProviderAdapter.java
+++ b/src/sqlancer/SQLProviderAdapter.java
@@ -10,7 +10,7 @@ import sqlancer.common.schema.AbstractTable;
 
 public abstract class SQLProviderAdapter<G extends SQLGlobalState<O, ? extends AbstractSchema<G, ?>>, O extends DBMSSpecificOptions<? extends OracleFactory<G>>>
         extends ProviderAdapter<G, O, SQLConnection> {
-    public SQLProviderAdapter(Class<G> globalClass, Class<O> optionClass) {
+    protected SQLProviderAdapter(Class<G> globalClass, Class<O> optionClass) {
         super(globalClass, optionClass);
     }
 

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -70,6 +70,9 @@ public class StateToReproduce {
         return Collections.unmodifiableList(statements);
     }
 
+    /**
+     * @deprecated
+     */
     @Deprecated
     public void commentStatements() {
         for (int i = 0; i < statements.size(); i++) {
@@ -100,7 +103,7 @@ public class StateToReproduce {
 
         private final List<Query<?>> statements = new ArrayList<>();
 
-        public boolean success;
+        private boolean success;
 
         public OracleRunReproductionState() {
             StateToReproduce.this.localState = this;

--- a/src/sqlancer/StatementExecutor.java
+++ b/src/sqlancer/StatementExecutor.java
@@ -70,7 +70,7 @@ public class StatementExecutor<G extends GlobalState<?, ?, ?>, A extends Abstrac
                     success = globalState.executeStatement(query);
                 } while (nextAction.canBeRetried() && !success
                         && nrTries++ < globalState.getOptions().getNrStatementRetryCount());
-            } catch (IgnoreMeException e) {
+            } catch (IgnoreMeException ignored) {
 
             }
             if (query != null && query.couldAffectSchema()) {

--- a/src/sqlancer/common/DBMSCommon.java
+++ b/src/sqlancer/common/DBMSCommon.java
@@ -27,7 +27,7 @@ public final class DBMSCommon {
         return matcher.matches();
     }
 
-    public static int getMaxIndexInDoubleArrary(double... doubleArray) {
+    public static int getMaxIndexInDoubleArray(double... doubleArray) {
         int maxIndex = 0;
         double maxValue = 0.0;
         for (int j = 0; j < doubleArray.length; j++) {

--- a/src/sqlancer/common/ast/BinaryNode.java
+++ b/src/sqlancer/common/ast/BinaryNode.java
@@ -7,7 +7,7 @@ public abstract class BinaryNode<T> implements BinaryOperation<T> {
     private final T left;
     private final T right;
 
-    public BinaryNode(T left, T right) {
+    protected BinaryNode(T left, T right) {
         this.left = left;
         this.right = right;
     }

--- a/src/sqlancer/common/ast/BinaryOperatorNode.java
+++ b/src/sqlancer/common/ast/BinaryOperatorNode.java
@@ -10,7 +10,7 @@ public abstract class BinaryOperatorNode<T, O extends Operator> extends BinaryNo
         String getTextRepresentation();
     }
 
-   protected BinaryOperatorNode(T left, T right, O op) {
+    protected BinaryOperatorNode(T left, T right, O op) {
         super(left, right);
         this.op = op;
     }

--- a/src/sqlancer/common/ast/BinaryOperatorNode.java
+++ b/src/sqlancer/common/ast/BinaryOperatorNode.java
@@ -10,7 +10,7 @@ public abstract class BinaryOperatorNode<T, O extends Operator> extends BinaryNo
         String getTextRepresentation();
     }
 
-    public BinaryOperatorNode(T left, T right, O op) {
+   protected BinaryOperatorNode(T left, T right, O op) {
         super(left, right);
         this.op = op;
     }

--- a/src/sqlancer/common/ast/FunctionNode.java
+++ b/src/sqlancer/common/ast/FunctionNode.java
@@ -7,7 +7,7 @@ public abstract class FunctionNode<F, A> {
     protected F function;
     protected List<A> args;
 
-    public FunctionNode(F function, List<A> args) {
+    protected FunctionNode(F function, List<A> args) {
         this.function = function;
         this.args = args;
     }

--- a/src/sqlancer/common/ast/TernaryNode.java
+++ b/src/sqlancer/common/ast/TernaryNode.java
@@ -8,7 +8,7 @@ public abstract class TernaryNode<T> implements BinaryOperation<T> {
     private final T middle;
     private final T right;
 
-    public TernaryNode(T left, T middle, T right) {
+    protected TernaryNode(T left, T middle, T right) {
         this.left = left;
         this.middle = middle;
         this.right = right;

--- a/src/sqlancer/common/ast/UnaryNode.java
+++ b/src/sqlancer/common/ast/UnaryNode.java
@@ -6,7 +6,7 @@ public abstract class UnaryNode<T> implements UnaryOperation<T> {
 
     protected final T expr;
 
-    public UnaryNode(T expr) {
+    protected UnaryNode(T expr) {
         this.expr = expr;
     }
 

--- a/src/sqlancer/common/ast/UnaryOperatorNode.java
+++ b/src/sqlancer/common/ast/UnaryOperatorNode.java
@@ -6,7 +6,7 @@ public abstract class UnaryOperatorNode<T, O extends Operator> extends UnaryNode
 
     protected final O op;
 
-    public UnaryOperatorNode(T expr, O op) {
+    protected UnaryOperatorNode(T expr, O op) {
         super(expr);
         this.op = op;
     }

--- a/src/sqlancer/common/log/SQLLoggableFactory.java
+++ b/src/sqlancer/common/log/SQLLoggableFactory.java
@@ -37,10 +37,10 @@ public class SQLLoggableFactory extends LoggableFactory {
     @Override
     protected Loggable infoToLoggable(String time, String databaseName, String databaseVersion, long seedValue) {
         StringBuilder sb = new StringBuilder();
-        sb.append("-- Time: " + time + "\n");
-        sb.append("-- Database: " + databaseName + "\n");
-        sb.append("-- Database version: " + databaseVersion + "\n");
-        sb.append("-- seed value: " + seedValue + "\n");
+        sb.append("-- Time: ").append(time).append("\n");
+        sb.append("-- Database: ").append(databaseName).append("\n");
+        sb.append("-- Database version: ").append(databaseVersion).append("\n");
+        sb.append("-- seed value: ").append(seedValue).append("\n");
         return new LoggedString(sb.toString());
     }
 

--- a/src/sqlancer/common/oracle/NoRECBase.java
+++ b/src/sqlancer/common/oracle/NoRECBase.java
@@ -16,7 +16,7 @@ public abstract class NoRECBase<S extends SQLGlobalState<?, ?>> implements TestO
     protected String optimizedQueryString;
     protected String unoptimizedQueryString;
 
-    public NoRECBase(S state) {
+    protected NoRECBase(S state) {
         this.state = state;
         this.con = state.getConnection();
         this.logger = state.getLogger();

--- a/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
+++ b/src/sqlancer/common/oracle/PivotedQuerySynthesisBase.java
@@ -29,7 +29,7 @@ public abstract class PivotedQuerySynthesisBase<S extends GlobalState<?, ?, C>, 
     protected final S globalState;
     protected R pivotRow;
 
-    public PivotedQuerySynthesisBase(S globalState) {
+    protected PivotedQuerySynthesisBase(S globalState) {
         this.globalState = globalState;
     }
 

--- a/src/sqlancer/common/schema/AbstractRowValue.java
+++ b/src/sqlancer/common/schema/AbstractRowValue.java
@@ -63,7 +63,7 @@ public abstract class AbstractRowValue<T extends AbstractTables<?, C>, C extends
                 sb.append("\n");
             }
             AbstractTable<?, ?, ?> t = tableList.get(j);
-            sb.append("-- " + t.getName() + "\n");
+            sb.append("-- ").append(t.getName()).append("\n");
             List<C> columnsForTable = columnList.stream().filter(c -> c.getTable().equals(t))
                     .collect(Collectors.toList());
             for (int i = 0; i < columnsForTable.size(); i++) {

--- a/src/sqlancer/common/schema/AbstractSchema.java
+++ b/src/sqlancer/common/schema/AbstractSchema.java
@@ -45,7 +45,7 @@ public class AbstractSchema<G extends GlobalState<?, ?, ?>, A extends AbstractTa
     }
 
     public A getRandomTableOrBailout(Function<A, Boolean> f) {
-        List<A> relevantTables = databaseTables.stream().filter(t -> f.apply(t)).collect(Collectors.toList());
+        List<A> relevantTables = databaseTables.stream().filter(f::apply).collect(Collectors.toList());
         if (relevantTables.isEmpty()) {
             throw new IgnoreMeException();
         }

--- a/src/sqlancer/common/schema/AbstractTable.java
+++ b/src/sqlancer/common/schema/AbstractTable.java
@@ -19,7 +19,7 @@ public abstract class AbstractTable<C extends AbstractTableColumn<?, ?>, I exten
     private final boolean isView;
     protected long rowCount = NO_ROW_COUNT_AVAILABLE;
 
-    public AbstractTable(String name, List<C> columns, List<I> indexes, boolean isView) {
+    protected AbstractTable(String name, List<C> columns, List<I> indexes, boolean isView) {
         this.name = name;
         this.indexes = indexes;
         this.isView = isView;
@@ -41,7 +41,7 @@ public abstract class AbstractTable<C extends AbstractTableColumn<?, ?>, I exten
         sb.append(getName());
         sb.append("\n");
         for (C c : columns) {
-            sb.append("\t" + c + "\n");
+            sb.append("\t").append(c).append("\n");
         }
         return sb.toString();
     }


### PR DESCRIPTION
### **Refactor codes in several java files:**

- StateToReproduce.java
- StatementExecutor.java
- SQLProviderAdapter.java
- Randomly.java
- ProviderAdapter.java
- BinaryNode.java
- BinaryOperatorNode.java
- FunctionNode.java
- TernaryNode.java
- UnaryNode.java
- UnaryOperatorNode.java
- SQLLoggableFactory.java
- NoRECBase.java
- PivotedQuerySynthesisBase.java
- AbstractRowValue.java
- AbstractSchema.java
- AbstractTable.java
- DBMSCommon.java

### **Changes that are done :**

- Access Modifier of the abstract classes’ Constructor changed from public to protected because constructors of abstract classes can only be called in constructors of their subclasses.No need to make them public.
- Refactor a  method name due to incorrect spellings.(In DBMSCommon.java)
- Simplified some of the codes.
- Added some comments.