### PR TITLE
Disable QPG tests in general Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Verify
         run: mvn -B verify -DskipTests=true
       - name: Misc Tests
-        run: mvn -B '-Dtest=!sqlancer.dbms.**' test
+        run: mvn -B '-Dtest=!sqlancer.dbms.**,!sqlancer.qpg.**' test
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
The QPG tests are wrongly executed in general Action, which takes an overly long time.