### PR TITLE
fix: ahere to max number of queries in QPG

### DIFF
--- a/src/sqlancer/ProviderAdapter.java
+++ b/src/sqlancer/ProviderAdapter.java
@@ -125,7 +125,7 @@ public abstract class ProviderAdapter<G extends GlobalState<O, ? extends Abstrac
             while (executedQueryCount < globalState.getOptions().getNrQueries()) {
                 int numOfNoNewQueryPlans = 0;
                 TestOracle<G> oracle = getTestOracle(globalState);
-                while (true) {
+                while (executedQueryCount < globalState.getOptions().getNrQueries()) {
                     try (OracleRunReproductionState localState = globalState.getState().createLocalState()) {
                         assert localState != null;
                         try {

--- a/src/sqlancer/common/query/SQLQueryAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryAdapter.java
@@ -92,6 +92,8 @@ public class SQLQueryAdapter extends Query<SQLConnection> {
             Main.nrUnsuccessfulActions.addAndGet(1);
             checkException(e);
             return false;
+        } finally {
+            s.close();
         }
     }
 


### PR DESCRIPTION
Previously, QPG algorithm does not obey the limitation of maximum queries per database, so we fix it now.



Co-authored-by: hanyisong <yisong8686@gmail.com>