### PR TITLE
tidb: support create tiflash replicas

### DIFF
--- a/src/sqlancer/tidb/TiDBOptions.java
+++ b/src/sqlancer/tidb/TiDBOptions.java
@@ -29,6 +29,9 @@ public class TiDBOptions implements DBMSSpecificOptions<TiDBOracleFactory> {
     @Parameter(names = { "--max-num-indexes" }, description = "The maximum number of indexes that can be created")
     public int maxNumIndexes = 20;
 
+    @Parameter(names = "--enable-tiflash", description = "enable tiflash")
+    public boolean enableTiflash = false;
+
     @Parameter(names = "--oracle")
     public List<TiDBOracleFactory> oracle = Arrays.asList(TiDBOracleFactory.QUERY_PARTITIONING);
 

--- a/src/sqlancer/tidb/gen/TiDBCreateTiFlashReplicaGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBCreateTiFlashReplicaGenerator.java
@@ -1,0 +1,22 @@
+package sqlancer.tidb.gen;
+
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.tidb.TiDBProvider.TiDBGlobalState;
+import sqlancer.tidb.TiDBSchema;
+
+public final class TiDBCreateTiFlashReplicaGenerator {
+    private TiDBCreateTiFlashReplicaGenerator() {
+    }
+
+
+    public static SQLQueryAdapter getQuery(TiDBGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        TiDBSchema.TiDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        StringBuilder sb = new StringBuilder("ALTER TABLE ");
+        sb.append(table.getName());
+        sb.append(" SET TIFLASH REPLICA 1;");
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+
+}


### PR DESCRIPTION
As the title discipline, TiDB uses tiflash to accelerate the TP. so we need to use command to enable when to test it.
