### PR TITLE
Update Cockroach DB to v23.1.0-beta.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,11 +122,11 @@ jobs:
         run: mvn -B package -DskipTests=true
       - name: Set up CockroachDB
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v22.2.3.linux-amd64.tgz | tar  xvz
-          cd  cockroach-v22.2.3.linux-amd64/ && ./cockroach start-single-node --insecure &
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v23.1.0-beta.2.linux-amd64.tgz | tar  xvz
+          cd  cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach start-single-node --insecure &
           sleep 10
       - name: Create SQLancer user
-        run: cd cockroach-v22.2.3.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
+        run: cd cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
       - name: Run Tests
         run: COCKROACHDB_AVAILABLE=true mvn -Dtest=TestCockroachDB test
 
@@ -145,11 +145,11 @@ jobs:
         run: mvn -B package -DskipTests=true
       - name: Set up CockroachDB
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v22.2.3.linux-amd64.tgz | tar  xvz
-          cd cockroach-v22.2.3.linux-amd64/ && ./cockroach start-single-node --insecure &
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v23.1.0-beta.2.linux-amd64.tgz | tar  xvz
+          cd  cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach start-single-node --insecure &
           sleep 10
       - name: Create SQLancer user
-        run: cd cockroach-v22.2.3.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
+        run: cd cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach sql --insecure -e "CREATE USER sqlancer; GRANT admin to sqlancer" && cd ..
       - name: Run Tests
         run: COCKROACHDB_AVAILABLE=true mvn -Dtest=TestCockroachDBQPG test
 

--- a/src/sqlancer/cockroachdb/CockroachDBBugs.java
+++ b/src/sqlancer/cockroachdb/CockroachDBBugs.java
@@ -18,41 +18,43 @@ public final class CockroachDBBugs {
     public static boolean bug83874 = true;
 
     // https://github.com/cockroachdb/cockroach/issues/83973
-    public static boolean bug83973 = true;
+    public static boolean bug83973;
 
     // https://github.com/cockroachdb/cockroach/issues/83976
-    public static boolean bug83976 = true;
+    public static boolean bug83976;
 
+    // The following bug is closed, but leave it enabled until
+    // the underlying interval issue is resolved.
+    // https://github.com/cockroachdb/cockroach/issues/84078
     // https://github.com/cockroachdb/cockroach/issues/84154
     public static boolean bug84154 = true;
 
     // https://github.com/cockroachdb/cockroach/issues/85356
-    public static boolean bug85356 = true;
+    public static boolean bug85356;
 
     // https://github.com/cockroachdb/cockroach/issues/85371
-    public static boolean bug85371 = true;
+    public static boolean bug85371;
 
     // https://github.com/cockroachdb/cockroach/issues/85389
-    public static boolean bug85389 = true;
+    public static boolean bug85389;
 
     // https://github.com/cockroachdb/cockroach/issues/85390
-    public static boolean bug85390 = true;
+    public static boolean bug85390;
 
     // https://github.com/cockroachdb/cockroach/issues/85393
-    public static boolean bug85393 = true;
+    public static boolean bug85393;
 
     // https://github.com/cockroachdb/cockroach/issues/85394
     public static boolean bug85394 = true;
 
     // https://github.com/cockroachdb/cockroach/issues/85441
-    public static boolean bug85441 = true;
+    public static boolean bug85441;
 
     // https://github.com/cockroachdb/cockroach/issues/85499
-    public static boolean bug85499 = true;
+    public static boolean bug85499;
 
     // https://github.com/cockroachdb/cockroach/issues/88037
-    // TODO: This should be fixed in v22.2.1.
-    public static boolean bug88037 = true;
+    public static boolean bug88037;
 
     private CockroachDBBugs() {
     }

--- a/src/sqlancer/cockroachdb/CockroachDBErrors.java
+++ b/src/sqlancer/cockroachdb/CockroachDBErrors.java
@@ -74,6 +74,10 @@ public final class CockroachDBErrors {
         errors.add(" unsupported comparison operator: <string> NOT LIKE <collatedstring{");
         errors.add("unsupported comparison operator: <string> != <bytes>");
         errors.add("expected DEFAULT expression to have type bytes");
+        errors.add("expected DEFAULT (in CREATE TABLE) expression to have type bytes");
+        errors.add("expected DEFAULT (in CREATE VIEW) expression to have type bytes");
+        errors.add("expected DEFAULT (in SET DEFAULT) expression to have type bytes");
+        errors.add("expected DEFAULT (in ADD COLUMN) expression to have type bytes");
         errors.add("value type string doesn't match type bytes of column");
         errors.add("as decimal, found type: int");
         errors.add("to be of type decimal, found type float");

--- a/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
@@ -38,6 +38,7 @@ public class CockroachDBTableGenerator extends CockroachDBGenerator {
     @Override
     public void buildStatement() {
         errors.add("and thus is not indexable"); // array types are not indexable
+        errors.add("context-dependent operators are not allowed in STORED COMPUTED COLUMN");
         if (globalState.getDbmsSpecificOptions().testTempTables) {
             errors.add("constraints on temporary tables may reference only temporary tables");
             errors.add("constraints on permanent tables may reference only permanent tables");


### PR DESCRIPTION
Update CockroachDB to v23.1.0-beta.2
    
Disable ignored errors from CockroachDB bugs that have been fixed.