### PR TITLE
Update runner to latest version of Ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,7 +215,7 @@ jobs:
 
   mariadb:
     name: DBMS Tests (MariaDB)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -291,7 +291,7 @@ jobs:
 
   mysql:
     name: DBMS Tests (MySQL)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
GitHub stopped supporting Ubuntu 18.04 on April 1, 2023, see:

https://github.com/actions/runner-images/issues/6002


Updating to latest version of Ubuntu to avoid the error "Waiting for a runner to pick up this job" when running the CI.