### PR TITLE
chore: upgrade versions in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,7 +300,8 @@ jobs:
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
       - name: Setup MySQL
-        uses: mirromutth/mysql-action@v1.1
+        run: |
+          sudo systemctl start mysql.service # MySQL 8.0.32-0ubuntu0.22.04.2
       - name: Create SQLancer user
         run: mysql -uroot -proot -e "CREATE USER 'sqlancer'@'localhost' IDENTIFIED BY 'sqlancer'; GRANT ALL PRIVILEGES ON * . * TO 'sqlancer'@'localhost';"
       - name: Run Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -25,7 +25,7 @@ jobs:
         run: mvn -B verify -DskipTests=true
       - name: Misc Tests
         run: mvn -B '-Dtest=!sqlancer.dbms.**,!sqlancer.qpg.**' test
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -39,13 +39,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup Citus
+      - name: Set up Citus
         run: |
           echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list
           curl https://install.citusdata.com/community/deb.sh | sudo bash
@@ -85,13 +85,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup ClickHouse
+      - name: Set up ClickHouse
         run: |
           docker pull clickhouse/clickhouse-server:head
           docker run --ulimit nofile=262144:262144 --name clickhouse-server -p8123:8123 -d clickhouse/clickhouse-server:head
@@ -112,13 +112,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup CockroachDB
+      - name: Set up CockroachDB
         run: |
           wget -qO- https://binaries.cockroachdb.com/cockroach-v23.1.0-beta.2.linux-amd64.tgz | tar  xvz
           cd  cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach start-single-node --insecure &
@@ -135,13 +135,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup CockroachDB
+      - name: Set up CockroachDB
         run: |
           wget -qO- https://binaries.cockroachdb.com/cockroach-v23.1.0-beta.2.linux-amd64.tgz | tar  xvz
           cd  cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach start-single-node --insecure &
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -243,14 +243,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Materialize
+      - name: Set up Materialize
         run: |
           docker pull materialize/materialized:latest
           docker run -d -p6875:6875 -p6877:6877 -p 26257:26257 materialize/materialized:latest
           sleep 5
           # Workaround for https://github.com/cockroachdb/cockroach/issues/93892
           psql postgres://root@localhost:26257 -c "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -268,14 +268,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup Materialize
+      - name: Set up Materialize
         run: |
           docker pull materialize/materialized:latest
           docker run -d -p6875:6875 -p6877:6877 -p 26257:26257 materialize/materialized:latest
           sleep 5
           # Workaround for https://github.com/cockroachdb/cockroach/issues/93892
           psql postgres://root@localhost:26257 -c "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -293,13 +293,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup MySQL
+      - name: Set up MySQL
         run: |
           sudo systemctl start mysql.service # MySQL 8.0.32-0ubuntu0.22.04.2
       - name: Create SQLancer user
@@ -316,14 +316,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup PostgreSQL
+      - name: Set up PostgreSQL
         uses: harmon758/postgresql-action@v1.0.0
         with:
           postgresql version: '12'
           postgresql user: 'sqlancer'
           postgresql password: 'sqlancer'
           postgresql db: 'test'
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -340,7 +340,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -359,7 +359,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -376,13 +376,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup TiDB
+      - name: Set up TiDB
         run: |
           docker pull pingcap/tidb:latest
           docker run --name tidb-server -d -p 4000:4000 pingcap/tidb:latest
@@ -399,13 +399,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup TiDB
+      - name: Set up TiDB
         run: |
           docker pull pingcap/tidb:latest
           docker run --name tidb-server -d -p 4000:4000 pingcap/tidb:latest
@@ -422,13 +422,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Setup Yugabyte
+      - name: Set up Yugabyte
         run: |
           docker pull yugabytedb/yugabyte:latest
           docker run -d --name yugabyte -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 yugabytedb/yugabyte:latest bin/yugabyted start --daemon=false 
@@ -444,7 +444,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 13
+      - name: Set up JDK 13
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 13
@@ -461,7 +461,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 14
+      - name: Set up JDK 14
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 14
@@ -478,7 +478,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Setup JDK 15
+      - name: Set up JDK 15
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 15-ea

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Verify
@@ -36,11 +36,11 @@ jobs:
     name: DBMS Tests (Citus)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -82,11 +82,11 @@ jobs:
     name: DBMS Tests (ClickHouse)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -105,17 +105,15 @@ jobs:
           docker stop clickhouse-server
           docker rm clickhouse-server
 
-
-
   cockroachdb:
     name: DBMS Tests (CockroachDB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -134,11 +132,11 @@ jobs:
     name: QPG Tests (CockroachDB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -166,11 +164,11 @@ jobs:
           - 8000:8000
           - 3307:3307
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -179,17 +177,16 @@ jobs:
         run: |
           DATABEND_AVAILABLE=true mvn -Dtest=TestDatabend test
 
-
   duckdb:
     name: DBMS Tests (DuckDB)
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build
@@ -201,11 +198,11 @@ jobs:
     name: DBMS Tests (H2)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -215,14 +212,14 @@ jobs:
 
   mariadb:
     name: DBMS Tests (MariaDB)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -243,7 +240,7 @@ jobs:
     name: DBMS Tests (Materialize)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Materialize
@@ -254,7 +251,7 @@ jobs:
           # Workaround for https://github.com/cockroachdb/cockroach/issues/93892
           psql postgres://root@localhost:26257 -c "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -268,7 +265,7 @@ jobs:
     name: QPG Tests (Materialize)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Materialize
@@ -279,7 +276,7 @@ jobs:
           # Workaround for https://github.com/cockroachdb/cockroach/issues/93892
           psql postgres://root@localhost:26257 -c "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -291,13 +288,13 @@ jobs:
 
   mysql:
     name: DBMS Tests (MySQL)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -317,16 +314,15 @@ jobs:
           MYSQL_AVAILABLE=true mvn test -Dtest=TestMySQLPQS
           MYSQL_AVAILABLE=true mvn test -Dtest=TestMySQLTLP
 
-
   postgres:
     name: DBMS Tests (PostgreSQL)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up PostgreSQL
-        uses: harmon758/postgresql-action@v1
+        uses: harmon758/postgresql-action@v3
         with:
           postgresql version: '12'
           postgresql user: 'sqlancer'
@@ -346,11 +342,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build
@@ -360,17 +356,16 @@ jobs:
           mvn -Dtest=TestSQLitePQS test
           mvn -Dtest=TestSQLite3 test
 
-
   sqlite-qpg:
     name: QPG Tests (SQLite)
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build
@@ -379,16 +374,15 @@ jobs:
         run: |
           mvn -Dtest=TestSQLiteQPG test
 
-
   tidb:
     name: DBMS Tests (TiDB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -407,11 +401,11 @@ jobs:
     name: QPG Tests (TiDB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -430,11 +424,11 @@ jobs:
     name: DBMS Tests (YugabyteDB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
@@ -452,11 +446,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 13
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 13
       - name: Build
@@ -469,11 +463,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 14
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 14
       - name: Build
@@ -486,11 +480,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK 15
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: 15-ea
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -39,13 +39,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up Citus
+      - name: Setup Citus
         run: |
           echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list
           curl https://install.citusdata.com/community/deb.sh | sudo bash
@@ -85,13 +85,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up ClickHouse
+      - name: Setup ClickHouse
         run: |
           docker pull clickhouse/clickhouse-server:head
           docker run --ulimit nofile=262144:262144 --name clickhouse-server -p8123:8123 -d clickhouse/clickhouse-server:head
@@ -112,13 +112,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up CockroachDB
+      - name: Setup CockroachDB
         run: |
           wget -qO- https://binaries.cockroachdb.com/cockroach-v23.1.0-beta.2.linux-amd64.tgz | tar  xvz
           cd  cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach start-single-node --insecure &
@@ -135,13 +135,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up CockroachDB
+      - name: Setup CockroachDB
         run: |
           wget -qO- https://binaries.cockroachdb.com/cockroach-v23.1.0-beta.2.linux-amd64.tgz | tar  xvz
           cd  cockroach-v23.1.0-beta.2.linux-amd64/ && ./cockroach start-single-node --insecure &
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -243,14 +243,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Materialize
+      - name: Setup Materialize
         run: |
           docker pull materialize/materialized:latest
           docker run -d -p6875:6875 -p6877:6877 -p 26257:26257 materialize/materialized:latest
           sleep 5
           # Workaround for https://github.com/cockroachdb/cockroach/issues/93892
           psql postgres://root@localhost:26257 -c "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -268,14 +268,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Materialize
+      - name: Setup Materialize
         run: |
           docker pull materialize/materialized:latest
           docker run -d -p6875:6875 -p6877:6877 -p 26257:26257 materialize/materialized:latest
           sleep 5
           # Workaround for https://github.com/cockroachdb/cockroach/issues/93892
           psql postgres://root@localhost:26257 -c "SET CLUSTER SETTING sql.stats.forecasts.enabled = false"
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -293,20 +293,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up MySQL
-        run: |
-          sudo apt-get install libssl-dev libmecab2 libjson-perl mecab-ipadic-utf8
-          sudo apt-get remove mysql-*
-          wget -q https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-server_8.0.20-1ubuntu18.04_amd64.deb-bundle.tar
-          tar -xvf mysql-server_8.0.20-1ubuntu18.04_amd64.deb-bundle.tar
-          sudo dpkg -i *.deb
-          sudo systemctl start mysql
+      - name: Setup MySQL
+        uses: mirromutth/mysql-action@v1.1
       - name: Create SQLancer user
         run: mysql -uroot -proot -e "CREATE USER 'sqlancer'@'localhost' IDENTIFIED BY 'sqlancer'; GRANT ALL PRIVILEGES ON * . * TO 'sqlancer'@'localhost';"
       - name: Run Tests
@@ -321,14 +315,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up PostgreSQL
-        uses: harmon758/postgresql-action@v3
+      - name: Setup PostgreSQL
+        uses: harmon758/postgresql-action@v1.0.0
         with:
           postgresql version: '12'
           postgresql user: 'sqlancer'
           postgresql password: 'sqlancer'
           postgresql db: 'test'
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -345,7 +339,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -364,7 +358,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -381,13 +375,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up TiDB
+      - name: Setup TiDB
         run: |
           docker pull pingcap/tidb:latest
           docker run --name tidb-server -d -p 4000:4000 pingcap/tidb:latest
@@ -404,13 +398,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up TiDB
+      - name: Setup TiDB
         run: |
           docker pull pingcap/tidb:latest
           docker run --name tidb-server -d -p 4000:4000 pingcap/tidb:latest
@@ -427,7 +421,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 11
@@ -449,7 +443,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 13
+      - name: Setup JDK 13
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 13
@@ -466,7 +460,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 14
+      - name: Setup JDK 14
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 14
@@ -483,7 +477,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 15
+      - name: Setup JDK 15
         uses: actions/setup-java@v1.4.4
         with:
           java-version: 15-ea

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -16,6 +16,7 @@ public final class Randomly {
     private static int cacheSize = 100;
 
     private final List<Long> cachedLongs = new ArrayList<>();
+    private final List<Integer> cachedIntegers = new ArrayList<>();
     private final List<String> cachedStrings = new ArrayList<>();
     private final List<Double> cachedDoubles = new ArrayList<>();
     private final List<byte[]> cachedBytes = new ArrayList<>();
@@ -27,6 +28,12 @@ public final class Randomly {
     private void addToCache(long val) {
         if (useCaching && cachedLongs.size() < cacheSize && !cachedLongs.contains(val)) {
             cachedLongs.add(val);
+        }
+    }
+
+    private void addToCache(int val) {
+        if (useCaching && cachedIntegers.size() < cacheSize && !cachedIntegers.contains(val)) {
+            cachedIntegers.add(val);
         }
     }
 
@@ -47,6 +54,14 @@ public final class Randomly {
             return null;
         } else {
             return Randomly.fromList(cachedLongs);
+        }
+    }
+
+    private Integer getFromIntegerCache() {
+        if (!useCaching || cachedIntegers.isEmpty()) {
+            return null;
+        } else {
+            return Randomly.fromList(cachedIntegers);
         }
     }
 
@@ -362,6 +377,24 @@ public final class Randomly {
             value = Randomly.fromOptions(0L, Long.MAX_VALUE, 1L);
         } else {
             value = getNextLong(0, Long.MAX_VALUE);
+        }
+        addToCache(value);
+        assert value >= 0;
+        return value;
+    }
+
+    public int getPositiveIntegerInt() {
+        if (cacheProbability()) {
+            Integer value = getFromIntegerCache();
+            if (value != null && value >= 0) {
+                return value;
+            }
+        }
+        int value;
+        if (smallBiasProbability()) {
+            value = Randomly.fromOptions(0, Integer.MAX_VALUE, 1);
+        } else {
+            value = getNextInt(0, Integer.MAX_VALUE);
         }
         addToCache(value);
         assert value >= 0;

--- a/src/sqlancer/mysql/gen/MySQLSetGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLSetGenerator.java
@@ -66,8 +66,9 @@ public class MySQLSetGenerator {
         MAX_SP_RECURSION_DEPTH("max_sp_recursion_depth", (r) -> r.getLong(0, 255), Scope.GLOBAL, Scope.SESSION), //
         MYISAM_DATA_POINTER_SIZE("myisam_data_pointer_size", (r) -> r.getLong(2, 7), Scope.GLOBAL), //
         MYISAM_MAX_SORT_FILE_SIZE("myisam_max_sort_file_size", (r) -> r.getLong(0, 9223372036854775807L), Scope.GLOBAL), //
-        MYISAM_REPAIR_THREADS("myisam_repair_threads", (r) -> r.getLong(1, Long.MAX_VALUE), Scope.GLOBAL,
-                Scope.SESSION), //
+        // MYISAM_REPAIR_THREADS("myisam_repair_threads", (r) -> r.getLong(1, Long.MAX_VALUE), Scope.GLOBAL,
+        // Scope.SESSION), // comment out this to avoid java.sql.SQLException: Unknown system variable
+        // 'myisam_repair_threads'
         MYISAM_SORT_BUFFER_SIZE("myisam_sort_buffer_size", (r) -> r.getLong(4096, Long.MAX_VALUE), Scope.GLOBAL,
                 Scope.SESSION), //
         MYISAM_STATS_METHOD("myisam_stats_method",

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -176,9 +176,10 @@ public class MySQLTableGenerator {
                 sb.append("AUTO_INCREMENT = ");
                 sb.append(r.getPositiveInteger());
                 break;
+            // The valid range for avg_row_length is [0,4294967295]
             case AVG_ROW_LENGTH:
                 sb.append("AVG_ROW_LENGTH = ");
-                sb.append(r.getPositiveInteger());
+                sb.append(r.getLong(0, 4294967295L + 1));
                 break;
             case CHECKSUM:
                 sb.append("CHECKSUM = 1");
@@ -212,9 +213,10 @@ public class MySQLTableGenerator {
                 sb.append("INSERT_METHOD = ");
                 sb.append(Randomly.fromOptions("NO", "FIRST", "LAST"));
                 break;
+            // The valid range for key_block_size is [0,65535]
             case KEY_BLOCK_SIZE:
                 sb.append("KEY_BLOCK_SIZE = ");
-                sb.append(r.getPositiveInteger());
+                sb.append(r.getInteger(0, 65535 + 1));
                 break;
             case MAX_ROWS:
                 sb.append("MAX_ROWS = ");
@@ -336,7 +338,7 @@ public class MySQLTableGenerator {
             if (Randomly.getBoolean()) {
                 sb.append("(");
                 sb.append(Randomly.getNotCachedInteger(0, 255)); // Display width out of range for column 'c0' (max =
-                                                                 // 255)
+                // 255)
                 sb.append(")");
             }
             break;


### PR DESCRIPTION
fix: #781

upgrade ubuntu to latest
upgrade actions/checkout@v3
upgrade actions/setup-java@v1.4.4
change mysql on ubuntu18 to ubuntu22

note that the CI error now with MySQL is resulted by the `Caused by: java.sql.SQLException: Memory capacity exceeded (capacity 8388608 bytes)`, I think this is not caused by this update and should be ignored?