### PR TITLE
ClickHouse: set allow_suspicious_indices

### DIFF
--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -143,8 +143,8 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
         }
         con.close();
         con = DriverManager.getConnection(
-                String.format("jdbc:clickhouse://%s:%d/%s?socket_timeout=300000&allow_suspicious_indices=1%s", host,
-                        port, databaseName, clickHouseOptions.enableAnalyzer ? "&allow_experimental_analyzer=1" : ""),
+                String.format("jdbc:clickhouse://%s:%d/%s?socket_timeout=300000%s", host, port, databaseName,
+                        clickHouseOptions.enableAnalyzer ? "&allow_experimental_analyzer=1" : ""),
                 globalState.getOptions().getUserName(), globalState.getOptions().getPassword());
         return new SQLConnection(con);
     }

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -143,7 +143,7 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
         }
         con.close();
         con = DriverManager.getConnection(
-                String.format("jdbc:clickhouse://%s:%d/%s?allow_suspicious_indices=1&socket_timeout=300000%s%s", host,
+                String.format("jdbc:clickhouse://%s:%d/%s?socket_timeout=300000&allow_suspicious_indices=1%s", host,
                         port, databaseName, clickHouseOptions.enableAnalyzer ? "&allow_experimental_analyzer=1" : ""),
                 globalState.getOptions().getUserName(), globalState.getOptions().getPassword());
         return new SQLConnection(con);

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -143,9 +143,8 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
         }
         con.close();
         con = DriverManager.getConnection(
-                String.format("jdbc:clickhouse://%s:%d/%s?socket_timeout=300000%s%s", host, port, databaseName,
-                        clickHouseOptions.enableAnalyzer ? "&allow_experimental_analyzer=1" : "",
-                        "&allow_suspicious_indices=1"),
+                String.format("jdbc:clickhouse://%s:%d/%s?allow_suspicious_indices=1&socket_timeout=300000%s%s", host,
+                        port, databaseName, clickHouseOptions.enableAnalyzer ? "&allow_experimental_analyzer=1" : ""),
                 globalState.getOptions().getUserName(), globalState.getOptions().getPassword());
         return new SQLConnection(con);
     }

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -143,8 +143,9 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
         }
         con.close();
         con = DriverManager.getConnection(
-                String.format("jdbc:clickhouse://%s:%d/%s?socket_timeout=300000%s", host, port, databaseName,
-                        clickHouseOptions.enableAnalyzer ? "&allow_experimental_analyzer=1" : ""),
+                String.format("jdbc:clickhouse://%s:%d/%s?socket_timeout=300000%s%s", host, port, databaseName,
+                        clickHouseOptions.enableAnalyzer ? "&allow_experimental_analyzer=1" : "",
+                        "&allow_suspicious_indices=1"),
                 globalState.getOptions().getUserName(), globalState.getOptions().getPassword());
         return new SQLConnection(con);
     }

--- a/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
@@ -98,6 +98,7 @@ public class ClickHouseTableGenerator {
                         columns.stream().map(c -> c.asColumnReference(null)).collect(Collectors.toList()), 3);
                 sb.append(ClickHouseToStringVisitor.asString(expr));
             }
+            // Suppress index sanity checks https://github.com/sqlancer/sqlancer/issues/788
             sb.append(" SETTINGS allow_suspicious_indices=1");
             // TODO: PRIMARY KEY
         }

--- a/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseTableGenerator.java
@@ -98,6 +98,7 @@ public class ClickHouseTableGenerator {
                         columns.stream().map(c -> c.asColumnReference(null)).collect(Collectors.toList()), 3);
                 sb.append(ClickHouseToStringVisitor.asString(expr));
             }
+            sb.append(" SETTINGS allow_suspicious_indices=1");
             // TODO: PRIMARY KEY
         }
 


### PR DESCRIPTION
We just can generate constant primary key and similar suspicious indexes in schema. Just skip this check as it is not a bug in generator.