### PR TITLE
Remove the redundancy in comparing floating-point values

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -166,4 +166,20 @@ public final class ComparatorHelper {
         return secondResultSet;
     }
 
+    public static String canonicalizeResultValue(String value) {
+        if (value == null) {
+            return value;
+        }
+
+        switch (value) {
+        case "-0.0":
+            return "0.0";
+        case "-0":
+            return "0";
+        default:
+        }
+
+        return value;
+    }
+
 }

--- a/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningBase.java
+++ b/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningBase.java
@@ -4,7 +4,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
@@ -41,15 +40,6 @@ public class DatabendQueryPartitioningBase
     public DatabendQueryPartitioningBase(DatabendGlobalState state) {
         super(state);
         DatabendErrors.addExpressionErrors(errors);
-    }
-
-    public static String canonicalizeResultValue(String value) {
-        // Rule: -0.0 should be canonicalized to 0.0
-        if (Objects.equals(value, "-0.0")) {
-            return "0.0";
-        }
-
-        return value;
     }
 
     @Override

--- a/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningDistinctTester.java
+++ b/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningDistinctTester.java
@@ -41,7 +41,7 @@ public class DatabendQueryPartitioningDistinctTester extends DatabendQueryPartit
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DatabendQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
 }

--- a/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningGroupByTester.java
+++ b/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningGroupByTester.java
@@ -42,7 +42,7 @@ public class DatabendQueryPartitioningGroupByTester extends DatabendQueryPartiti
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DatabendQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningHavingTester.java
+++ b/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningHavingTester.java
@@ -54,7 +54,7 @@ public class DatabendQueryPartitioningHavingTester extends DatabendQueryPartitio
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DatabendQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningWhereTester.java
+++ b/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningWhereTester.java
@@ -40,7 +40,7 @@ public class DatabendQueryPartitioningWhereTester extends DatabendQueryPartition
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DatabendQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
 }

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningBase.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningBase.java
@@ -41,22 +41,6 @@ public class DorisQueryPartitioningBase extends TernaryLogicPartitioningOracleBa
         DorisErrors.addInsertErrors(errors);
     }
 
-    public static String canonicalizeResultValue(String value) {
-        if (value == null) {
-            return value;
-        }
-
-        switch (value) {
-        case "-0.0":
-            return "0.0";
-        case "-0":
-            return "0";
-        default:
-        }
-
-        return value;
-    }
-
     @Override
     public void check() throws SQLException {
         s = state.getSchema();

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningDistinctTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningDistinctTester.java
@@ -39,7 +39,7 @@ public class DorisQueryPartitioningDistinctTester extends DorisQueryPartitioning
         combinedString.add(unionString);
         List<String> secondResultSet = ComparatorHelper.getResultSetFirstColumnAsString(unionString, errors, state);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DorisQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
 }

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningGroupByTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningGroupByTester.java
@@ -43,7 +43,7 @@ public class DorisQueryPartitioningGroupByTester extends DorisQueryPartitioningB
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DorisQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningHavingTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningHavingTester.java
@@ -53,7 +53,7 @@ public class DorisQueryPartitioningHavingTester extends DorisQueryPartitioningBa
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DorisQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningWhereTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningWhereTester.java
@@ -47,7 +47,7 @@ public class DorisQueryPartitioningWhereTester extends DorisQueryPartitioningBas
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DorisQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
 }

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningBase.java
@@ -37,22 +37,6 @@ public class DuckDBQueryPartitioningBase
         DuckDBErrors.addExpressionErrors(errors);
     }
 
-    public static String canonicalizeResultValue(String value) {
-        if (value == null) {
-            return value;
-        }
-
-        switch (value) {
-        case "-0.0":
-            return "0.0";
-        case "-0":
-            return "0";
-        default:
-        }
-
-        return value;
-    }
-
     @Override
     public void check() throws SQLException {
         s = state.getSchema();

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningDistinctTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningDistinctTester.java
@@ -38,7 +38,7 @@ public class DuckDBQueryPartitioningDistinctTester extends DuckDBQueryPartitioni
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
 }

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningGroupByTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningGroupByTester.java
@@ -41,7 +41,7 @@ public class DuckDBQueryPartitioningGroupByTester extends DuckDBQueryPartitionin
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningHavingTester.java
@@ -47,7 +47,7 @@ public class DuckDBQueryPartitioningHavingTester extends DuckDBQueryPartitioning
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
     @Override

--- a/src/sqlancer/duckdb/test/DuckDBQueryPartitioningWhereTester.java
+++ b/src/sqlancer/duckdb/test/DuckDBQueryPartitioningWhereTester.java
@@ -39,7 +39,7 @@ public class DuckDBQueryPartitioningWhereTester extends DuckDBQueryPartitioningB
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, DuckDBQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 
 }

--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningBase.java
@@ -3,7 +3,6 @@ package sqlancer.questdb.test;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
@@ -46,15 +45,6 @@ public class QuestDBQueryPartitioningBase
                     .collect(Collectors.toList());
         }
         return columns;
-    }
-
-    public static String canonicalizeResultValue(String value) {
-        // Rule: -0.0 should be canonicalized to 0.0
-        if (Objects.equals(value, "-0.0")) {
-            return "0.0";
-        }
-
-        return value;
     }
 
     @Override

--- a/src/sqlancer/questdb/test/QuestDBQueryPartitioningWhereTester.java
+++ b/src/sqlancer/questdb/test/QuestDBQueryPartitioningWhereTester.java
@@ -36,6 +36,6 @@ public class QuestDBQueryPartitioningWhereTester extends QuestDBQueryPartitionin
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, false, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state, QuestDBQueryPartitioningBase::canonicalizeResultValue);
+                state, ComparatorHelper::canonicalizeResultValue);
     }
 }


### PR DESCRIPTION
The canonicalization was first introduced as part of https://github.com/sqlancer/sqlancer/pull/497 and then copied to subsequent implementations.