### PR TITLE
Feat: add support for StoneDB NoREC oracle

### DIFF
--- a/src/sqlancer/stonedb/StoneDBSchema.java
+++ b/src/sqlancer/stonedb/StoneDBSchema.java
@@ -12,6 +12,7 @@ import sqlancer.common.ast.newast.Node;
 import sqlancer.common.schema.AbstractRelationalTable;
 import sqlancer.common.schema.AbstractSchema;
 import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
 import sqlancer.common.schema.TableIndex;
 import sqlancer.stonedb.ast.StoneDBConstant;
 import sqlancer.stonedb.ast.StoneDBExpression;
@@ -97,6 +98,12 @@ public class StoneDBSchema extends AbstractSchema<StoneDBProvider.StoneDBGlobalS
             return getColumns().stream().anyMatch(c -> c.isPrimaryKey());
         }
 
+    }
+
+    public static class StoneDBTables extends AbstractTables<StoneDBTable, StoneDBColumn> {
+        public StoneDBTables(List<StoneDBTable> tables) {
+            super(tables);
+        }
     }
 
     public static final class StoneDBIndex extends TableIndex {
@@ -338,5 +345,9 @@ public class StoneDBSchema extends AbstractSchema<StoneDBProvider.StoneDBGlobalS
             StoneDBDataType type = StoneDBDataType.getRandomWithoutNull();
             return new StoneDBCompositeDataType(type);
         }
+    }
+
+    public StoneDBTables getRandomTableNonEmptyTables() {
+        return new StoneDBTables(Randomly.nonEmptySubset(getDatabaseTables()));
     }
 }

--- a/src/sqlancer/stonedb/ast/StoneDBJoin.java
+++ b/src/sqlancer/stonedb/ast/StoneDBJoin.java
@@ -1,0 +1,126 @@
+package sqlancer.stonedb.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.stonedb.StoneDBProvider.StoneDBGlobalState;
+import sqlancer.stonedb.StoneDBSchema.StoneDBColumn;
+import sqlancer.stonedb.StoneDBSchema.StoneDBTable;
+import sqlancer.stonedb.gen.StoneDBExpressionGenerator;
+
+public class StoneDBJoin implements Node<StoneDBExpression> {
+
+    public enum JoinType {
+        INNER, NATURAL, LEFT, RIGHT;
+
+        public static JoinType getRandom() {
+            return Randomly.fromOptions(values());
+        }
+    }
+
+    public enum NaturalJoinType {
+        FULL, LEFT, RIGHT;
+
+        public static NaturalJoinType getRandom() {
+            return Randomly.fromOptions(values());
+        }
+    }
+
+    private final TableReferenceNode<StoneDBExpression, StoneDBTable> leftTable;
+    private final TableReferenceNode<StoneDBExpression, StoneDBTable> rightTable;
+    private final JoinType joinType;
+    private final Node<StoneDBExpression> onCondition;
+    private NaturalJoinType naturalJoinType;
+
+    public StoneDBJoin(TableReferenceNode<StoneDBExpression, StoneDBTable> leftTable,
+            TableReferenceNode<StoneDBExpression, StoneDBTable> rightTable, JoinType joinType,
+            Node<StoneDBExpression> onCondition) {
+        this.leftTable = leftTable;
+        this.rightTable = rightTable;
+        this.joinType = joinType;
+        this.onCondition = onCondition;
+    }
+
+    public TableReferenceNode<StoneDBExpression, StoneDBTable> getLeftTable() {
+        return leftTable;
+    }
+
+    public TableReferenceNode<StoneDBExpression, StoneDBTable> getRightTable() {
+        return rightTable;
+    }
+
+    public JoinType getJoinType() {
+        return joinType;
+    }
+
+    public Node<StoneDBExpression> getOnCondition() {
+        return onCondition;
+    }
+
+    public NaturalJoinType getNaturalJoinType() {
+        return naturalJoinType;
+    }
+
+    public void setNaturalJoinType(NaturalJoinType naturalJoinType) {
+        this.naturalJoinType = naturalJoinType;
+    }
+
+    public static List<Node<StoneDBExpression>> getJoins(
+            List<TableReferenceNode<StoneDBExpression, StoneDBTable>> tableList, StoneDBGlobalState globalState) {
+        List<Node<StoneDBExpression>> joinExpressions = new ArrayList<>();
+        while (tableList.size() >= 2 && Randomly.getBooleanWithRatherLowProbability()) {
+            // get two tables to join
+            TableReferenceNode<StoneDBExpression, StoneDBTable> leftTable = tableList.remove(0);
+            TableReferenceNode<StoneDBExpression, StoneDBTable> rightTable = tableList.remove(0);
+            // store all columns in the above two tables
+            List<StoneDBColumn> columns = new ArrayList<>(leftTable.getTable().getColumns());
+            columns.addAll(rightTable.getTable().getColumns());
+            // create a join generator
+            StoneDBExpressionGenerator joinGen = new StoneDBExpressionGenerator(globalState).setColumns(columns);
+            switch (StoneDBJoin.JoinType.getRandom()) {
+            case INNER:
+                joinExpressions.add(StoneDBJoin.createInnerJoin(leftTable, rightTable, joinGen.generateExpression()));
+                break;
+            case NATURAL:
+                joinExpressions.add(StoneDBJoin.createNaturalJoin(leftTable, rightTable, NaturalJoinType.getRandom()));
+                break;
+            case LEFT:
+                joinExpressions
+                        .add(StoneDBJoin.createLeftOuterJoin(leftTable, rightTable, joinGen.generateExpression()));
+                break;
+            case RIGHT:
+                joinExpressions
+                        .add(StoneDBJoin.createRightOuterJoin(leftTable, rightTable, joinGen.generateExpression()));
+                break;
+            default:
+                throw new AssertionError();
+            }
+        }
+        return joinExpressions;
+    }
+
+    public static StoneDBJoin createRightOuterJoin(TableReferenceNode<StoneDBExpression, StoneDBTable> left,
+            TableReferenceNode<StoneDBExpression, StoneDBTable> right, Node<StoneDBExpression> onClause) {
+        return new StoneDBJoin(left, right, JoinType.RIGHT, onClause);
+    }
+
+    public static StoneDBJoin createLeftOuterJoin(TableReferenceNode<StoneDBExpression, StoneDBTable> left,
+            TableReferenceNode<StoneDBExpression, StoneDBTable> right, Node<StoneDBExpression> onClause) {
+        return new StoneDBJoin(left, right, JoinType.LEFT, onClause);
+    }
+
+    public static StoneDBJoin createInnerJoin(TableReferenceNode<StoneDBExpression, StoneDBTable> left,
+            TableReferenceNode<StoneDBExpression, StoneDBTable> right, Node<StoneDBExpression> onClause) {
+        return new StoneDBJoin(left, right, JoinType.INNER, onClause);
+    }
+
+    public static Node<StoneDBExpression> createNaturalJoin(TableReferenceNode<StoneDBExpression, StoneDBTable> left,
+            TableReferenceNode<StoneDBExpression, StoneDBTable> right, NaturalJoinType naturalJoinType) {
+        StoneDBJoin join = new StoneDBJoin(left, right, JoinType.NATURAL, null);
+        join.setNaturalJoinType(naturalJoinType);
+        return join;
+    }
+}

--- a/src/sqlancer/stonedb/ast/StoneDBSelect.java
+++ b/src/sqlancer/stonedb/ast/StoneDBSelect.java
@@ -1,0 +1,17 @@
+package sqlancer.stonedb.ast;
+
+import sqlancer.common.ast.SelectBase;
+import sqlancer.common.ast.newast.Node;
+
+public class StoneDBSelect extends SelectBase<Node<StoneDBExpression>> implements Node<StoneDBExpression> {
+
+    private boolean isDistinct;
+
+    public void setDistinct(boolean isDistinct) {
+        this.isDistinct = isDistinct;
+    }
+
+    public boolean isDistinct() {
+        return isDistinct;
+    }
+}

--- a/src/sqlancer/stonedb/gen/StoneDBExpressionGenerator.java
+++ b/src/sqlancer/stonedb/gen/StoneDBExpressionGenerator.java
@@ -18,6 +18,7 @@ import sqlancer.common.ast.newast.Node;
 import sqlancer.common.gen.UntypedExpressionGenerator;
 import sqlancer.stonedb.StoneDBProvider.StoneDBGlobalState;
 import sqlancer.stonedb.StoneDBSchema.StoneDBColumn;
+import sqlancer.stonedb.StoneDBSchema.StoneDBCompositeDataType;
 import sqlancer.stonedb.StoneDBSchema.StoneDBDataType;
 import sqlancer.stonedb.ast.StoneDBConstant;
 import sqlancer.stonedb.ast.StoneDBExpression;
@@ -33,6 +34,20 @@ public class StoneDBExpressionGenerator extends UntypedExpressionGenerator<Node<
     private enum Expression {
         UNARY_PREFIX, UNARY_POSTFIX, BINARY_COMPARISON, BINARY_LOGICAL, BINARY_ARITHMETIC, BINARY_BITWISE, BETWEEN, IN,
         CASE
+    }
+
+    public static class StoneDBCastOperation extends NewUnaryPostfixOperatorNode<StoneDBExpression> {
+
+        public StoneDBCastOperation(Node<StoneDBExpression> expr, StoneDBCompositeDataType type) {
+            super(expr, new Operator() {
+
+                @Override
+                public String getTextRepresentation() {
+                    return "::" + type.toString();
+                }
+            });
+        }
+
     }
 
     @Override

--- a/src/sqlancer/stonedb/oracle/StoneDBNoRECOracle.java
+++ b/src/sqlancer/stonedb/oracle/StoneDBNoRECOracle.java
@@ -1,16 +1,126 @@
 package sqlancer.stonedb.oracle;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.common.ast.newast.NewPostfixTextNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
 import sqlancer.common.oracle.NoRECBase;
 import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.stonedb.StoneDBProvider.StoneDBGlobalState;
+import sqlancer.stonedb.StoneDBSchema;
+import sqlancer.stonedb.StoneDBSchema.StoneDBColumn;
+import sqlancer.stonedb.StoneDBSchema.StoneDBCompositeDataType;
+import sqlancer.stonedb.StoneDBSchema.StoneDBDataType;
+import sqlancer.stonedb.StoneDBSchema.StoneDBTable;
+import sqlancer.stonedb.StoneDBSchema.StoneDBTables;
+import sqlancer.stonedb.StoneDBToStringVisitor;
+import sqlancer.stonedb.ast.StoneDBExpression;
+import sqlancer.stonedb.ast.StoneDBJoin;
+import sqlancer.stonedb.ast.StoneDBSelect;
+import sqlancer.stonedb.gen.StoneDBExpressionGenerator;
+import sqlancer.stonedb.gen.StoneDBExpressionGenerator.StoneDBCastOperation;
 
 public class StoneDBNoRECOracle extends NoRECBase<StoneDBGlobalState> implements TestOracle<StoneDBGlobalState> {
-    public StoneDBNoRECOracle(StoneDBGlobalState state) {
-        super(state);
+
+    private final StoneDBSchema schema;
+
+    public StoneDBNoRECOracle(StoneDBGlobalState globalState) {
+        super(globalState);
+        this.schema = globalState.getSchema();
     }
 
     @Override
     public void check() throws Exception {
+        StoneDBTables randomTables = schema.getRandomTableNonEmptyTables();
+        List<StoneDBColumn> columns = randomTables.getColumns();
+        StoneDBExpressionGenerator gen = new StoneDBExpressionGenerator(state).setColumns(columns);
+        Node<StoneDBExpression> randomWhereCondition = gen.generateExpression();
+        List<StoneDBTable> tables = randomTables.getTables();
+        List<TableReferenceNode<StoneDBExpression, StoneDBTable>> tableList = tables.stream()
+                .map(t -> new TableReferenceNode<StoneDBExpression, StoneDBTable>(t)).collect(Collectors.toList());
+        List<Node<StoneDBExpression>> joins = StoneDBJoin.getJoins(tableList, state);
+        int secondCount = getUnoptimizedQueryCount(new ArrayList<>(tableList), randomWhereCondition, joins);
+        int firstCount = getOptimizedQueryCount(con, new ArrayList<>(tableList), columns, randomWhereCondition, joins);
+        if (firstCount == -1 || secondCount == -1) {
+            throw new IgnoreMeException();
+        }
+        if (firstCount != secondCount) {
+            throw new AssertionError(
+                    optimizedQueryString + "; -- " + firstCount + "\n" + unoptimizedQueryString + " -- " + secondCount);
+        }
+    }
 
+    private int getUnoptimizedQueryCount(List<Node<StoneDBExpression>> tableList,
+            Node<StoneDBExpression> randomWhereCondition, List<Node<StoneDBExpression>> joins) throws SQLException {
+        StoneDBSelect select = new StoneDBSelect();
+        Node<StoneDBExpression> asText = new NewPostfixTextNode<>(new StoneDBCastOperation(
+                new NewPostfixTextNode<StoneDBExpression>(randomWhereCondition,
+                        " IS NOT NULL AND " + StoneDBToStringVisitor.asString(randomWhereCondition)),
+                new StoneDBCompositeDataType(StoneDBDataType.INT, 8)), "as count");
+        select.setFetchColumns(List.of(asText));
+        select.setFromList(tableList);
+        // select.setSelectType(SelectType.ALL);
+        select.setJoinList(joins);
+        int secondCount = 0;
+        unoptimizedQueryString = "SELECT SUM(count) FROM (" + StoneDBToStringVisitor.asString(select) + ") as res";
+        errors.add("canceling statement due to statement timeout");
+        SQLQueryAdapter q = new SQLQueryAdapter(unoptimizedQueryString, errors);
+        SQLancerResultSet rs;
+        try {
+            rs = q.executeAndGetLogged(state);
+        } catch (Exception e) {
+            throw new AssertionError(unoptimizedQueryString, e);
+        }
+        if (rs == null) {
+            return -1;
+        }
+        if (rs.next()) {
+            secondCount += rs.getLong(1);
+        }
+        rs.close();
+        return secondCount;
+    }
+
+    private int getOptimizedQueryCount(SQLConnection con, List<Node<StoneDBExpression>> tableList,
+            List<StoneDBColumn> columns, Node<StoneDBExpression> randomWhereCondition,
+            List<Node<StoneDBExpression>> joins) throws SQLException {
+        StoneDBSelect select = new StoneDBSelect();
+        List<Node<StoneDBExpression>> allColumns = columns.stream()
+                .map((c) -> new ColumnReferenceNode<StoneDBExpression, StoneDBColumn>(c)).collect(Collectors.toList());
+        select.setFetchColumns(allColumns);
+        select.setFromList(tableList);
+        select.setWhereClause(randomWhereCondition);
+        if (Randomly.getBooleanWithSmallProbability()) {
+            select.setOrderByExpressions(new StoneDBExpressionGenerator(state).setColumns(columns).generateOrderBys());
+        }
+        // select.setSelectType(SelectType.ALL);
+        select.setJoinList(joins);
+        int firstCount = 0;
+        try (Statement stat = con.createStatement()) {
+            optimizedQueryString = StoneDBToStringVisitor.asString(select);
+            if (options.logEachSelect()) {
+                logger.writeCurrent(optimizedQueryString);
+            }
+            try (ResultSet rs = stat.executeQuery(optimizedQueryString)) {
+                while (rs.next()) {
+                    firstCount++;
+                }
+            }
+        } catch (SQLException e) {
+            throw new IgnoreMeException();
+        }
+        return firstCount;
     }
 }


### PR DESCRIPTION
In this PR, we add support for StoneDB NoREC oracle.

Change list:
- add StoneDBJoin class to represent join operation in StoneDB
- add StoneDBSelect class to represent select operation  in StoneDB
- add implementation in StoneDBNoRECOracle.java