### PR TITLE
Fix some bugs in Doris implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -488,15 +488,17 @@ jobs:
       - name: Set up Apache Doris
         run: |
           sudo sysctl -w vm.max_map_count=2000000
-          LASTEST_TAG=$(curl -s GET https://api.github.com/repos/apache/doris/releases | jq -r '.[].tag_name' | sed -n 1p)
-          LASTEST_TAG_BIG_VERSION=$(echo ${LASTEST_TAG} | awk '{split($1, arr, "."); print arr[1]"."arr[2]}')
-          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LASTEST_TAG_BIG_VERSION}/${LASTEST_TAG}/apache-doris-fe-${LASTEST_TAG}-bin-x86_64.tar.xz"
-          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LASTEST_TAG_BIG_VERSION}/${LASTEST_TAG}/apache-doris-be-${LASTEST_TAG}-bin-x86_64.tar.xz"
-          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LASTEST_TAG_BIG_VERSION}/${LASTEST_TAG}/apache-doris-dependencies-${LASTEST_TAG}-bin-x86_64.tar.xz"
+          LATEST_TAG=$(curl -s GET https://api.github.com/repos/apache/doris/releases | jq -r '.[].tag_name' | sed -n 1p)
+          LATEST_TAG_BIG_VERSION=$(echo ${LATEST_TAG} | awk '{split($1, arr, "."); print arr[1]"."arr[2]}')
+          echo "Apache Doris latest version tag: ${LATEST_TAG_BIG_VERSION}, ${LATEST_TAG}"
+          echo -e "Now try to download Apache Doris, including 3 parts: \n -- doris-fe https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-fe-${LATEST_TAG}-bin-x86_64.tar.xz \n -- doris-be https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-be-${LATEST_TAG}-bin-x86_64.tar.xz \n -- doris-dependencies https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-dependencies-${LATEST_TAG}-bin-x86_64.tar.xz"
+          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-fe-${LATEST_TAG}-bin-x86_64.tar.xz"
+          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-be-${LATEST_TAG}-bin-x86_64.tar.xz"
+          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-dependencies-${LATEST_TAG}-bin-x86_64.tar.xz"
           mkdir ./doris
-          tar xf apache-doris-fe-${LASTEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-fe-${LASTEST_TAG}-bin-x86_64 doris/fe
-          tar xf apache-doris-be-${LASTEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-be-${LASTEST_TAG}-bin-x86_64 doris/be
-          tar xf apache-doris-dependencies-${LASTEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-dependencies-${LASTEST_TAG}-bin-x86_64 doris/dependencies
+          tar -xf apache-doris-fe-${LATEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-fe-${LATEST_TAG}-bin-x86_64 doris/fe
+          tar -xf apache-doris-be-${LATEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-be-${LATEST_TAG}-bin-x86_64 doris/be
+          tar -xf apache-doris-dependencies-${LATEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-dependencies-${LATEST_TAG}-bin-x86_64 doris/dependencies
           cp doris/dependencies/*.jar doris/be/lib/
           doris/fe/bin/start_fe.sh --daemon
           doris/be/bin/start_be.sh --daemon

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -488,22 +488,33 @@ jobs:
       - name: Set up Apache Doris
         run: |
           sudo sysctl -w vm.max_map_count=2000000
-          LATEST_TAG=$(curl -s GET https://api.github.com/repos/apache/doris/releases | jq -r '.[].tag_name' | sed -n 1p)
-          LATEST_TAG_BIG_VERSION=$(echo ${LATEST_TAG} | awk '{split($1, arr, "."); print arr[1]"."arr[2]}')
-          echo "Apache Doris latest version tag: ${LATEST_TAG_BIG_VERSION}, ${LATEST_TAG}"
-          echo -e "Now try to download Apache Doris, including 3 parts: \n -- doris-fe https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-fe-${LATEST_TAG}-bin-x86_64.tar.xz \n -- doris-be https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-be-${LATEST_TAG}-bin-x86_64.tar.xz \n -- doris-dependencies https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-dependencies-${LATEST_TAG}-bin-x86_64.tar.xz"
-          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-fe-${LATEST_TAG}-bin-x86_64.tar.xz"
-          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-be-${LATEST_TAG}-bin-x86_64.tar.xz"
-          curl -LJO "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=doris/${LATEST_TAG_BIG_VERSION}/${LATEST_TAG}/apache-doris-dependencies-${LATEST_TAG}-bin-x86_64.tar.xz"
-          mkdir ./doris
-          tar -xf apache-doris-fe-${LATEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-fe-${LATEST_TAG}-bin-x86_64 doris/fe
-          tar -xf apache-doris-be-${LATEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-be-${LATEST_TAG}-bin-x86_64 doris/be
-          tar -xf apache-doris-dependencies-${LATEST_TAG}-bin-x86_64.tar.xz -C ./doris && mv doris/apache-doris-dependencies-${LATEST_TAG}-bin-x86_64 doris/dependencies
-          cp doris/dependencies/*.jar doris/be/lib/
-          doris/fe/bin/start_fe.sh --daemon
-          doris/be/bin/start_be.sh --daemon
           sudo apt install libnet-ifconfig-wrapper-perl --assume-yes
           IP=$(ifconfig eth0 | grep inet | grep -v inet6 | awk '{print $2}')
+
+          docker pull apache/doris:2.0.0_alpha-fe-x86_64
+          docker pull apache/doris:2.0.0_alpha-be-x86_64
+
+          docker run -itd \
+          --name=fe \
+          --env FE_SERVERS="fe1:${IP}:9010" \
+          --env FE_ID=1 \
+          -p 8030:8030 \
+          -p 9030:9030 \
+          -v /data/fe/doris-meta:/opt/apache-doris/fe/doris-meta \
+          -v /data/fe/log:/opt/apache-doris/fe/log \
+          --net=host \
+          apache/doris:2.0.0_alpha-fe-x86_64
+
+          docker run -itd \
+          --name=be \
+          --env FE_SERVERS="fe1:${IP}:9010" \
+          --env BE_ADDR="${IP}:9050" \
+          -p 8040:8040 \
+          -v /data/be/storage:/opt/apache-doris/be/storage \
+          -v /data/be/log:/opt/apache-doris/be/log \
+          --net=host \
+          apache/doris:2.0.0_alpha-be-x86_64
+
           mysql -u root -h 127.0.0.1 --port 9030 -e "ALTER SYSTEM ADD BACKEND '${IP}:9050';"
           mysql -u root -h 127.0.0.1 --port 9030 -e "CREATE USER 'sqlancer' IDENTIFIED BY 'sqlancer'; GRANT ALL ON *.* TO sqlancer;"
       - name: Build SQLancer

--- a/src/sqlancer/doris/DorisBugs.java
+++ b/src/sqlancer/doris/DorisBugs.java
@@ -2,38 +2,38 @@ package sqlancer.doris;
 
 public final class DorisBugs {
     // https://github.com/apache/doris/issues/17697
-    // Logical bug about where true not in (columns)
-    public static boolean bug17697 = true;
+    // [fixed] Logical bug about where true not in (columns)
+    public static boolean bug17697 = false;
 
     // https://github.com/apache/doris/issues/17700
-    // Cannot use between and in boolean column
-    public static boolean bug17700 = true;
+    // [fixed] Cannot use between and in boolean column
+    public static boolean bug17700 = false;
 
     // https://github.com/apache/doris/issues/17701
     // Wrong result of `where column not in (values)`
     public static boolean bug17701 = true;
 
     // https://github.com/apache/doris/issues/17705
-    // Different result caused by `where` split and union all
-    public static boolean bug17705 = true;
+    // [fixed] Different result caused by `where` split and union all
+    public static boolean bug17705 = false;
 
     // https://github.com/apache/doris/issues/19370
-    // Internal Error occur in GroupBy&Having sql
+    // [fixed] Internal Error occur in GroupBy&Having sql
     // fixed by https://github.com/apache/doris/pull/19559
-    public static boolean bug19370 = true;
+    public static boolean bug19370 = false;
 
     // https://github.com/apache/doris/issues/19374
-    // Different result of having not ($value in column) and having ($value not in column)
+    // [fixed] Different result of having not ($value in column) and having ($value not in column)
     // fixed by https://github.com/apache/doris/pull/19471
-    public static boolean bug19374 = true;
+    public static boolean bug19374 = false;
 
     // https://github.com/apache/doris/issues/19611
-    // ERROR occur in nested subqueries with same column name and union
-    public static boolean bug19611 = true;
+    // [fixed] ERROR occur in nested subqueries with same column name and union
+    public static boolean bug19611 = false;
 
     // https://github.com/apache/doris/issues/19613
-    // Wrong result when right outer join and where false
-    public static boolean bug19613 = true;
+    // [fixed] Wrong result when right outer join and where false
+    public static boolean bug19613 = false;
 
     // https://github.com/apache/doris/issues/19614
     // Wrong result when value like column from table_join

--- a/src/sqlancer/doris/DorisErrors.java
+++ b/src/sqlancer/doris/DorisErrors.java
@@ -19,6 +19,8 @@ public final class DorisErrors {
         errors.add("ordinal exceeds number");
         errors.add("items in select list");
         errors.add("java.lang.IllegalStateException: null");
+        errors.add("list expression not");
+        errors.add("missing from");
 
         // Not in line with Doris' logic
         errors.add("Unexpected exception: null");

--- a/src/sqlancer/doris/DorisErrors.java
+++ b/src/sqlancer/doris/DorisErrors.java
@@ -13,6 +13,12 @@ public final class DorisErrors {
         errors.add("Please check your sql, we meet an error when parsing");
         errors.add("but returns type");
         errors.add("is not a number");
+        errors.add("not produced by aggregation output");
+        errors.add("Can not set null default value to non nullable column");
+        errors.add("ordinal must be");
+        errors.add("ordinal exceeds number");
+        errors.add("items in select list");
+        errors.add("java.lang.IllegalStateException: null");
 
         // Not in line with Doris' logic
         errors.add("Unexpected exception: null");
@@ -24,6 +30,7 @@ public final class DorisErrors {
         errors.add("cannot combine"); // cannot combine SELECT DISTINCT with aggregate functions or GROUP BY
         errors.add("Invalid type");
         errors.add("cannot be cast to");
+        errors.add("Duplicated inline view column");
 
         // functions
         errors.add("No matching function with signature");

--- a/src/sqlancer/doris/DorisSchema.java
+++ b/src/sqlancer/doris/DorisSchema.java
@@ -112,8 +112,25 @@ public class DorisSchema extends AbstractSchema<DorisGlobalState, DorisTable> {
             return size;
         }
 
-        public static DorisCompositeDataType getRandomWithoutNull() {
+        public static DorisCompositeDataType getRandomWithoutNull(DorisGlobalState globalState) {
             DorisDataType type = DorisDataType.getRandomWithoutNull();
+            if (globalState != null) {
+                boolean typeIsQualified = false;
+                while (!typeIsQualified) {
+                    if (type == DorisDataType.INT && globalState.getDbmsSpecificOptions().testIntConstants
+                    || type == DorisDataType.BOOLEAN && globalState.getDbmsSpecificOptions().testBooleanConstants
+                    || type == DorisDataType.DECIMAL && globalState.getDbmsSpecificOptions().testDecimalConstants
+                    || type == DorisDataType.FLOAT && globalState.getDbmsSpecificOptions().testFloatConstants
+                    || type == DorisDataType.DATE && globalState.getDbmsSpecificOptions().testDateConstants
+                    || type == DorisDataType.DATETIME && globalState.getDbmsSpecificOptions().testDateTimeConstants
+                    || type == DorisDataType.VARCHAR && globalState.getDbmsSpecificOptions().testStringConstants
+                    ) {
+                        typeIsQualified = true;
+                    } else {
+                        type = DorisDataType.getRandomWithoutNull();
+                    }
+                }
+            }
             int size = -1;
             switch (type) {
             case INT:

--- a/src/sqlancer/doris/DorisSchema.java
+++ b/src/sqlancer/doris/DorisSchema.java
@@ -57,12 +57,31 @@ public class DorisSchema extends AbstractSchema<DorisGlobalState, DorisTable> {
         private int decimalPrecision;
         private int varcharLength;
 
-        public static DorisDataType getRandomWithoutNull() {
-            DorisDataType dt;
-            do {
-                dt = Randomly.fromOptions(values());
-            } while (dt == DorisDataType.NULL);
-            return dt;
+        public static DorisDataType getRandomWithoutNull(DorisOptions options) {
+            List<DorisDataType> validTypes = new ArrayList<>();
+            if (options.testIntConstants) {
+                validTypes.add(DorisDataType.INT);
+            }
+            if (options.testFloatConstants) {
+                validTypes.add(DorisDataType.FLOAT);
+            }
+            if (options.testDecimalConstants) {
+                validTypes.add(DorisDataType.DECIMAL);
+            }
+            if (options.testDateConstants) {
+                validTypes.add(DorisDataType.DATE);
+            }
+            if (options.testDateTimeConstants) {
+                validTypes.add(DorisDataType.DATETIME);
+            }
+            if (options.testStringConstants) {
+                validTypes.add(DorisDataType.VARCHAR);
+            }
+            if (options.testBooleanConstants) {
+                validTypes.add(DorisDataType.BOOLEAN);
+            }
+
+            return Randomly.fromList(validTypes);
         }
 
         public int getDecimalScale() {
@@ -113,24 +132,7 @@ public class DorisSchema extends AbstractSchema<DorisGlobalState, DorisTable> {
         }
 
         public static DorisCompositeDataType getRandomWithoutNull(DorisGlobalState globalState) {
-            DorisDataType type = DorisDataType.getRandomWithoutNull();
-            if (globalState != null) {
-                boolean typeIsQualified = false;
-                while (!typeIsQualified) {
-                    if (type == DorisDataType.INT && globalState.getDbmsSpecificOptions().testIntConstants
-                    || type == DorisDataType.BOOLEAN && globalState.getDbmsSpecificOptions().testBooleanConstants
-                    || type == DorisDataType.DECIMAL && globalState.getDbmsSpecificOptions().testDecimalConstants
-                    || type == DorisDataType.FLOAT && globalState.getDbmsSpecificOptions().testFloatConstants
-                    || type == DorisDataType.DATE && globalState.getDbmsSpecificOptions().testDateConstants
-                    || type == DorisDataType.DATETIME && globalState.getDbmsSpecificOptions().testDateTimeConstants
-                    || type == DorisDataType.VARCHAR && globalState.getDbmsSpecificOptions().testStringConstants
-                    ) {
-                        typeIsQualified = true;
-                    } else {
-                        type = DorisDataType.getRandomWithoutNull();
-                    }
-                }
-            }
+            DorisDataType type = DorisDataType.getRandomWithoutNull(globalState.getDbmsSpecificOptions());
             int size = -1;
             switch (type) {
             case INT:

--- a/src/sqlancer/doris/DorisSchema.java
+++ b/src/sqlancer/doris/DorisSchema.java
@@ -57,6 +57,14 @@ public class DorisSchema extends AbstractSchema<DorisGlobalState, DorisTable> {
         private int decimalPrecision;
         private int varcharLength;
 
+        public static DorisDataType getRandomWithoutNull() {
+            DorisDataType dt;
+            do {
+                dt = Randomly.fromOptions(values());
+            } while (dt == DorisDataType.NULL);
+            return dt;
+        }
+
         public static DorisDataType getRandomWithoutNull(DorisOptions options) {
             List<DorisDataType> validTypes = new ArrayList<>();
             if (options.testIntConstants) {

--- a/src/sqlancer/doris/gen/DorisAlterTableGenerator.java
+++ b/src/sqlancer/doris/gen/DorisAlterTableGenerator.java
@@ -29,13 +29,13 @@ public final class DorisAlterTableGenerator {
             String columnName = table.getFreeColumnName();
             sb.append(columnName);
             sb.append(" ");
-            sb.append(DorisCompositeDataType.getRandomWithoutNull().toString());
+            sb.append(DorisCompositeDataType.getRandomWithoutNull(globalState).toString());
             break;
         case ALTER_COLUMN:
             sb.append("MODIFY COLUMN ");
             sb.append(table.getRandomColumn().getName());
             sb.append(" ");
-            sb.append(DorisCompositeDataType.getRandomWithoutNull().toString());
+            sb.append(DorisCompositeDataType.getRandomWithoutNull(globalState).toString());
             break;
         case DROP_COLUMN:
             sb.append("DROP COLUMN ");

--- a/src/sqlancer/doris/gen/DorisTableGenerator.java
+++ b/src/sqlancer/doris/gen/DorisTableGenerator.java
@@ -81,7 +81,7 @@ public class DorisTableGenerator {
         List<DorisColumn> columns = new ArrayList<>();
         for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
             String columnName = String.format("c%d", i);
-            DorisCompositeDataType columnType = DorisCompositeDataType.getRandomWithoutNull();
+            DorisCompositeDataType columnType = DorisCompositeDataType.getRandomWithoutNull(globalState);
             columnType.initColumnArgs(); // set decimalAndVarchar
 
             boolean iskey = columnType.canBeKey() && Randomly.getBoolean();

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningAggregateTester.java
@@ -17,6 +17,7 @@ import sqlancer.common.ast.newast.Node;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.databend.DatabendExprToNode;
 import sqlancer.doris.DorisErrors;
 import sqlancer.doris.DorisProvider.DorisGlobalState;
 import sqlancer.doris.DorisSchema.DorisCompositeDataType;
@@ -185,8 +186,11 @@ public class DorisQueryPartitioningAggregateTester extends DorisQueryPartitionin
         leftSelect.setFromList(from);
         leftSelect.setWhereClause(whereClause);
         leftSelect.setJoinList(joinList);
+        Randomly r = new Randomly();
         if (Randomly.getBooleanWithSmallProbability()) {
-            leftSelect.setGroupByExpressions(groupByExpression);
+            //leftSelect.setGroupByExpressions(groupByExpression);    // todo: something maybe error in here
+            DorisConstant groupByColumn = DorisConstant.createIntConstant(r.getInteger(1, targetTables.getColumns().size()));
+            leftSelect.setGroupByExpressions(List.of(DorisExprToNode.cast(groupByColumn)));
         }
         return leftSelect;
     }

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningAggregateTester.java
@@ -186,10 +186,9 @@ public class DorisQueryPartitioningAggregateTester extends DorisQueryPartitionin
         leftSelect.setFromList(from);
         leftSelect.setWhereClause(whereClause);
         leftSelect.setJoinList(joinList);
-        Randomly r = new Randomly();
         if (Randomly.getBooleanWithSmallProbability()) {
             //leftSelect.setGroupByExpressions(groupByExpression);    // todo: something maybe error in here
-            DorisConstant groupByColumn = DorisConstant.createIntConstant(r.getInteger(1, targetTables.getColumns().size()));
+            DorisConstant groupByColumn = DorisConstant.createIntConstant(state.getRandomly().getInteger(1, targetTables.getColumns().size()));
             leftSelect.setGroupByExpressions(List.of(DorisExprToNode.cast(groupByColumn)));
         }
         return leftSelect;

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningBase.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningBase.java
@@ -46,13 +46,14 @@ public class DorisQueryPartitioningBase extends TernaryLogicPartitioningOracleBa
         s = state.getSchema();
         targetTables = s.getRandomTableNonEmptyTables();
         gen = new DorisNewExpressionGenerator(state).setColumns(targetTables.getColumns());
+        List<DorisColumnValue> allColumnValues = targetTables.getColumns().stream().map(c -> new DorisColumnValue(c, null))
+                .collect(Collectors.toList());
         HashSet<DorisColumnValue> columnOfLeafNode = new HashSet<>();
         gen.setColumnOfLeafNode(columnOfLeafNode);
         initializeTernaryPredicateVariants();
         select = new DorisSelect();
-        columnOfLeafNode.addAll(targetTables.getColumns().stream().map(c -> new DorisColumnValue(c, null))
-                .collect(Collectors.toList()));
-        groupByExpression = new ArrayList<>(columnOfLeafNode);
+        columnOfLeafNode.addAll(allColumnValues);
+        groupByExpression = new ArrayList<>(allColumnValues);
         select.setFetchColumns(generateFetchColumns());
         List<DorisTable> tables = targetTables.getTables();
         List<TableReferenceNode<DorisExpression, DorisTable>> tableList = tables.stream()

--- a/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningGroupByTester.java
+++ b/src/sqlancer/doris/oracle/tlp/DorisQueryPartitioningGroupByTester.java
@@ -40,7 +40,7 @@ public class DorisQueryPartitioningGroupByTester extends DorisQueryPartitioningB
         select.setWhereClause(DorisExprToNode.cast(isNullPredicate));
         String thirdQueryString = DorisToStringVisitor.asString(select);
         List<String> combinedString = new ArrayList<>();
-        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString,
                 secondQueryString, thirdQueryString, combinedString, true, state, errors);
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
                 state, ComparatorHelper::canonicalizeResultValue);


### PR DESCRIPTION
Hi all.
Thanks to Sqlancer, I found a lot of logic bugs in Doris, some of them have been fixed by the Doris community.
Now I found some unexpected bugs in the implementation of dors, see below:
1. `CAST(0.19511769711971283 AS NULL)` , cast a value or column to null
2. `CREATE TABLE t0(c0 DATETIME NOT NULL DEFAULT NULL)`, assign the default value NULL to the non-nullable columns in the CREATE TABLE statement
3. When testing oracle, UNION ALL should be used instead of UNION in some cases
4. `SELECT t0.c0 FROM t1, t0 GROUP BY t1.c0`, select fields not in group by

This PR tries to fix them.

Thanks for your review and thanks again for the Sqlancer tool!