### PR TITLE
feat: write log when running statement reducer

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -5,6 +5,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -130,6 +132,7 @@ public final class Main {
                     reduceFileDir.mkdir();
                 }
                 this.reduceFile = new File(reduceFileDir, databaseName + "-reduce.log");
+
             }
             this.databaseProvider = provider;
         }
@@ -265,6 +268,16 @@ public final class Main {
             }
             try {
                 reduceFileWriter.write(sb.toString());
+
+                File symbolicLinkToReduceFile = new File(LOG_DIRECTORY, "current-reduce.log");
+                Path reduceFilePath = reduceFile.toPath().toAbsolutePath();
+                Path symbolicPath = symbolicLinkToReduceFile.toPath().toAbsolutePath();
+                if(!Files.readSymbolicLink(symbolicLinkToReduceFile.toPath()).toAbsolutePath().equals(reduceFilePath)) {
+                    Files.deleteIfExists(symbolicPath);
+                    Files.createSymbolicLink(symbolicPath, reduceFilePath);
+                    System.out.println("Create symbolic link from " + symbolicPath + " linked " + reduceFilePath);
+                }
+
             } catch (IOException e) {
                 throw new AssertionError(e);
             }finally {

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -5,7 +5,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -266,21 +265,6 @@ public final class Main {
             }
             try {
                 reduceFileWriter.write(sb.toString());
-
-                File symbolicLinkToReduceFile = new File(LOG_DIRECTORY, "current-reduce.log");
-                Path reduceFilePath = reduceFile.toPath().toAbsolutePath();
-                Path symbolicPath = symbolicLinkToReduceFile.toPath().toAbsolutePath();
-
-                if(symbolicLinkToReduceFile.exists() && !Files.isSymbolicLink(symbolicLinkToReduceFile.toPath())) {
-                    throw new AssertionError("symbolic file conflict");
-                }
-
-                if (!symbolicLinkToReduceFile.exists() || !Files.readSymbolicLink(symbolicLinkToReduceFile.toPath()).toAbsolutePath()
-                        .equals(reduceFilePath)) {
-                    Files.deleteIfExists(symbolicPath);
-                    Files.createSymbolicLink(symbolicPath, reduceFilePath);
-                    System.out.println("Create symbolic link from " + symbolicPath + " linked " + reduceFilePath);
-                }
 
             } catch (IOException e) {
                 throw new AssertionError(e);

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -93,7 +93,8 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
             try (C con2 = provider.createDatabase(newGlobalState)) {
                 newGlobalState.setConnection(con2);
                 List<Query<C>> candidateStatements = new ArrayList<>(statements);
-                candidateStatements.subList(start, start + subLength).clear();
+                int endPoint = Math.min(start + subLength, candidateStatements.size());
+                candidateStatements.subList(start, endPoint).clear();
                 newGlobalState.getState().setStatements(new ArrayList<>(candidateStatements));
 
                 for (Query<C> s : candidateStatements) {

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -48,7 +48,7 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
         // Main.StateLogger logger = newGlobalState.getLogger();
         // printQueries(knownToReproduceBugStatements);
         // System.out.println();
-        state.getLogger().logReduced(newGlobalState.getState(), "Original queries:");
+
         if (knownToReproduceBugStatements.size() <= 1) {
             return;
         }
@@ -77,7 +77,7 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
         // System.out.println("Reduced query:");
         // printQueries(knownToReproduceBugStatements);
         newGlobalState.getState().setStatements(new ArrayList<>(knownToReproduceBugStatements));
-        state.getLogger().logReduced(newGlobalState.getState(), "Reduced queries:");
+        newGlobalState.getLogger().logReduced(newGlobalState.getState());
     }
 
     private List<Query<C>> tryReduction(G state, // NOPMD
@@ -110,7 +110,7 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
                         statements = candidateStatements;
                         partitionNum = Math.max(partitionNum - 1, 2);
                         // reproducer.outputHook((SQLite3GlobalState) newGlobalState);
-                        state.getLogger().logReduced(newGlobalState.getState(), "Current reduced result:");
+                        newGlobalState.getLogger().logReduced(newGlobalState.getState());
                         break;
 
                     }

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -1,5 +1,10 @@
 package sqlancer;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -78,6 +83,8 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
         // printQueries(knownToReproduceBugStatements);
         newGlobalState.getState().setStatements(new ArrayList<>(knownToReproduceBugStatements));
         newGlobalState.getLogger().logReduced(newGlobalState.getState());
+
+
     }
 
     private List<Query<C>> tryReduction(G state, // NOPMD

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -1,10 +1,5 @@
 package sqlancer;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -83,7 +78,6 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
         // printQueries(knownToReproduceBugStatements);
         newGlobalState.getState().setStatements(new ArrayList<>(knownToReproduceBugStatements));
         newGlobalState.getLogger().logReduced(newGlobalState.getState());
-
 
     }
 

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -13,6 +13,14 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
     private boolean observedChange;
     private int partitionNum;
 
+    private long currentReduceSteps;
+    private long currentReduceTime;
+
+    private long maxReduceSteps;
+    private long maxReduceTime;
+
+    Instant timeOfReductionBegins;
+
     public StatementReducer(DatabaseProvider<G, O, C> provider) {
         this.provider = provider;
     }
@@ -28,25 +36,26 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
     @Override
     public void reduce(G state, Reproducer<G> reproducer, G newGlobalState) throws Exception {
 
-        long maxReduceTime = state.getOptions().getMaxStatementReduceTime();
-        long maxReduceSteps = state.getOptions().getMaxStatementReduceSteps();
+        maxReduceTime = state.getOptions().getMaxStatementReduceTime();
+        maxReduceSteps = state.getOptions().getMaxStatementReduceSteps();
 
         List<Query<C>> knownToReproduceBugStatements = new ArrayList<>();
         for (Query<?> stat : state.getState().getStatements()) {
             knownToReproduceBugStatements.add((Query<C>) stat);
         }
 
-        System.out.println("Starting query:");
-        printQueries(knownToReproduceBugStatements);
-        System.out.println();
-
+        // System.out.println("Starting query:");
+        // Main.StateLogger logger = newGlobalState.getLogger();
+        // printQueries(knownToReproduceBugStatements);
+        // System.out.println();
+        state.getLogger().logReduced(newGlobalState.getState(), "Original queries:");
         if (knownToReproduceBugStatements.size() <= 1) {
             return;
         }
 
-        Instant timeOfReductionBegins = Instant.now();
-        long currentReduceSteps = 0;
-        long currentReduceTime = 0;
+        timeOfReductionBegins = Instant.now();
+        currentReduceSteps = 0;
+        currentReduceTime = 0;
         partitionNum = 2;
 
         while (knownToReproduceBugStatements.size() >= 2 && hasNotReachedLimit(currentReduceSteps, maxReduceSteps)
@@ -55,23 +64,20 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
 
             knownToReproduceBugStatements = tryReduction(state, reproducer, newGlobalState,
                     knownToReproduceBugStatements);
+
             if (!observedChange) {
                 if (partitionNum == knownToReproduceBugStatements.size()) {
                     break;
                 }
                 // increase the search granularity
                 partitionNum = Math.min(partitionNum * 2, knownToReproduceBugStatements.size());
-
-                currentReduceSteps++;
-                Instant currentInstant = Instant.now();
-                currentReduceTime = Duration.between(currentInstant, timeOfReductionBegins).getSeconds();
             }
-
         }
 
-        System.out.println("Reduced query:");
-        printQueries(knownToReproduceBugStatements);
+        // System.out.println("Reduced query:");
+        // printQueries(knownToReproduceBugStatements);
         newGlobalState.getState().setStatements(new ArrayList<>(knownToReproduceBugStatements));
+        state.getLogger().logReduced(newGlobalState.getState(), "Reduced queries:");
     }
 
     private List<Query<C>> tryReduction(G state, // NOPMD
@@ -102,19 +108,32 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
                         observedChange = true;
                         statements = candidateStatements;
                         partitionNum = Math.max(partitionNum - 1, 2);
-                        break;
                         // reproducer.outputHook((SQLite3GlobalState) newGlobalState);
-                        // state.getLogger().logReduced(newGlobalState.getState());
+                        state.getLogger().logReduced(newGlobalState.getState(), "Current reduced result:");
+                        break;
+
                     }
                 } catch (Throwable ignoredException) {
 
                 }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+            currentReduceSteps++;
+            Instant currentInstant = Instant.now();
+
+            currentReduceTime = Duration.between(timeOfReductionBegins, currentInstant).getSeconds();
+            if (!hasNotReachedLimit(currentReduceSteps, maxReduceSteps)
+                    || !hasNotReachedLimit(currentReduceTime, maxReduceTime)) {
+                return statements;
             }
             start = start + subLength;
         }
         return statements;
     }
 
+    @SuppressWarnings("unused")
     private void printQueries(List<Query<C>> statements) {
         System.out.println("===============================");
         for (Query<?> q : statements) {
@@ -122,5 +141,4 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
         }
         System.out.println("===============================");
     }
-
 }

--- a/test/sqlancer/reducer/TestEnvironment.java
+++ b/test/sqlancer/reducer/TestEnvironment.java
@@ -103,6 +103,7 @@ public class TestEnvironment {
             newGlobalState = createGlobalState();
             Main.StateLogger newLogger = new Main.StateLogger(databaseName, provider, options);
             newGlobalState.setStateLogger(newLogger);
+            state.setStateLogger(newLogger);
             newGlobalState.setState(stateToReproduce);
             newGlobalState.setDatabaseName(databaseName);
             newGlobalState.setMainOptions(options);

--- a/test/sqlancer/reducer/TestEnvironment.java
+++ b/test/sqlancer/reducer/TestEnvironment.java
@@ -6,6 +6,7 @@ import sqlancer.reducer.VirtualDB.VirtualDBGlobalState;
 import sqlancer.reducer.VirtualDB.VirtualDBProvider;
 import sqlancer.reducer.VirtualDB.VirtualDBQuery;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -88,6 +89,10 @@ public class TestEnvironment {
 
         state.setState(stateToReproduce);
         state.setDatabaseName(databaseName);
+        // A really hacky way to enable reducer...
+        Field field = options.getClass().getDeclaredField("useReducer");
+        field.setAccessible(true);
+        field.set(options, true);
         state.setMainOptions(options);
 
         // Main.StateLogger logger = new Main.StateLogger(databaseName, provider, options);
@@ -96,8 +101,8 @@ public class TestEnvironment {
         try (SQLConnection con = provider.createDatabase(state)) {
             state.setConnection(con);
             newGlobalState = createGlobalState();
-            // Main.StateLogger newLogger = new Main.StateLogger(databaseName, provider, options);
-            // newGlobalState.setStateLogger(newLogger);
+            Main.StateLogger newLogger = new Main.StateLogger(databaseName, provider, options);
+            newGlobalState.setStateLogger(newLogger);
             newGlobalState.setState(stateToReproduce);
             newGlobalState.setDatabaseName(databaseName);
             newGlobalState.setMainOptions(options);

--- a/test/sqlancer/reducer/TestStatementReducer.java
+++ b/test/sqlancer/reducer/TestStatementReducer.java
@@ -1,6 +1,7 @@
 package sqlancer.reducer;
 
 import org.junit.jupiter.api.Test;
+import sqlancer.Main;
 import sqlancer.common.query.Query;
 
 import java.util.ArrayList;
@@ -70,6 +71,12 @@ public class TestStatementReducer {
         List<Query<?>> reducedQueries = env.getReducedStatements();
         String queriesString = TestEnvironment.getQueriesString(reducedQueries);
         assertEquals(queriesString, "Statement_2;\nStatement_318;\nStatement_990;");
+    }
+
+    @Test
+    void testSQLite3WithStatementReducer() {
+        Main.executeMain(new String[] { "--random-seed", "0", "--use-reducer", "--num-threads", "4", "sqlite3",
+                "--oracle", "NoREC" });
     }
 
 }

--- a/test/sqlancer/reducer/TestStatementReducer.java
+++ b/test/sqlancer/reducer/TestStatementReducer.java
@@ -75,7 +75,7 @@ public class TestStatementReducer {
 
     @Test
     void testSQLite3WithStatementReducer() {
-        Main.executeMain(new String[] { "--random-seed", "0", "--use-reducer", "--num-threads", "4", "sqlite3",
+        Main.executeMain(new String[] { "--random-seed", "0", "--use-reducer", "--timeout-seconds", "60", "--num-threads", "4", "sqlite3",
                 "--oracle", "NoREC" });
     }
 

--- a/test/sqlancer/reducer/TestStatementReducer.java
+++ b/test/sqlancer/reducer/TestStatementReducer.java
@@ -75,8 +75,8 @@ public class TestStatementReducer {
 
     @Test
     void testSQLite3WithStatementReducer() {
-        Main.executeMain(new String[] { "--random-seed", "0", "--use-reducer", "--timeout-seconds", "60", "--num-threads", "4", "sqlite3",
-                "--oracle", "NoREC" });
+        Main.executeMain(new String[] { "--random-seed", "0", "--use-reducer", "--timeout-seconds", "60",
+                "--num-threads", "4", "sqlite3", "--oracle", "NoREC" });
     }
 
 }


### PR DESCRIPTION
Closes #865 

+ write log when start reducing, finish reducing and when a reduction step is successfully performed
log is saved into `logs/<database_>/reduce/<database_name>-reduce.log`, for example: When running statement reducer for sqlite3, the log of databse0 is stored at `logs/sqlite3/reduce/database0-reduce.log`
The format is like:
```
Original queries:
====================
xxx original statements
====================
Current reduced result:
====================
xxx
====================
Current reduced result:
====================
xxx
...
====================
Current reduced result:
====================
xxx
====================
Reduced queries:
====================
CREATE VIRTUAL TABLE rt0 USING rtree_i32(c0, c1, c2);
CREATE TEMP TABLE t1 (c0 INTEGER );
INSERT OR IGNORE INTO rt0(c0, c1, c2) VALUES ('-1e500', '', x'');
INSERT OR FAIL INTO t1(c0) VALUES (NULL), (0.9692699099404161), ('');
INSERT OR IGNORE INTO rt0(c2) VALUES (''), (x''), ('');
====================

```
+ fix some bugs of the statement reducer.
Adjust the code about options of time limit and step limit, making it more reasonable