### PR TITLE
fix: drop features of StoneDB

### DIFF
--- a/src/sqlancer/stonedb/ast/StoneDBJoin.java
+++ b/src/sqlancer/stonedb/ast/StoneDBJoin.java
@@ -22,7 +22,7 @@ public class StoneDBJoin implements Node<StoneDBExpression> {
     }
 
     public enum NaturalJoinType {
-        FULL, LEFT, RIGHT;
+        LEFT, RIGHT;
 
         public static NaturalJoinType getRandom() {
             return Randomly.fromOptions(values());

--- a/src/sqlancer/stonedb/gen/StoneDBExpressionGenerator.java
+++ b/src/sqlancer/stonedb/gen/StoneDBExpressionGenerator.java
@@ -168,7 +168,7 @@ public class StoneDBExpressionGenerator extends UntypedExpressionGenerator<Node<
 
     // https://stonedb.io/docs/SQL-reference/functions/aggregate-functions/
     public enum StoneDBAggregateFunction {
-        MAX(1), MIN(1), AVG(1), COUNT(1), FIRST(1), SUM(1);
+        MAX(1), MIN(1), AVG(1), COUNT(1), SUM(1);
 
         private int nrArgs;
 
@@ -253,7 +253,10 @@ public class StoneDBExpressionGenerator extends UntypedExpressionGenerator<Node<
      */
     public enum StoneDBBinaryLogicalOperator implements Operator {
 
-        AND("AND"), OR("OR"), XOR("XOR");
+        AND("AND"), OR("OR");
+
+        // In some cases, XOR operator will lead to StoneDB crash, so we do not test it
+        // XOR("XOR")
 
         private final String textRepr;
 
@@ -300,7 +303,7 @@ public class StoneDBExpressionGenerator extends UntypedExpressionGenerator<Node<
      * Bitwise operators supported by StoneDB: https://stonedb.io/docs/SQL-reference/operators/bitwise-operators
      */
     public enum StoneDBBinaryBitwiseOperator implements Operator {
-        AND("&"), OR("|"), XOR("^"), LEFTSHIFT("<<"), RIGHTSHIFT(">>");
+        AND("&"), OR("|"), LEFTSHIFT("<<"), RIGHTSHIFT(">>");
 
         private final String textRepr;
 

--- a/src/sqlancer/stonedb/gen/StoneDBIndexCreateGenerator.java
+++ b/src/sqlancer/stonedb/gen/StoneDBIndexCreateGenerator.java
@@ -28,7 +28,8 @@ public class StoneDBIndexCreateGenerator {
 
     private SQLQueryAdapter getQuery() {
         sb.append("CREATE ");
-        sb.append(Randomly.fromOptions("UNIQUE", "FULLTEXT", "SPATIAL"));
+        // Tianmu engine does not support fulltext index.
+        sb.append(Randomly.fromOptions("UNIQUE" /* "FULLTEXT" */, "SPATIAL"));
         sb.append(" INDEX ");
         sb.append(globalState.getSchema().getFreeIndexName());
         if (Randomly.getBoolean()) {


### PR DESCRIPTION
fix: drop features that StoneDB not supported or crash causing

In this PR, we delete some features that StoneDB does not support or some features that will lead to the crash of StoneDB.