### PR TITLE
feat: refactor AST-based reducer

### DIFF
--- a/docs/testCaseReduction.md
+++ b/docs/testCaseReduction.md
@@ -12,9 +12,9 @@ The AST-based reducer can shorten a statement by applying AST level transformati
 The transformations are implemented by [JSQLParser](https://github.com/JSQLParser/JSqlParser), a RDBMS agnostic SQL statement parser that can translate SQL statements into a traversable hierarchy of Java classes. JSQLParser provides support for the SQL standard as well as major SQL dialects. The AST-based reducer works for any SQL dialects that can be parsed by this tool.
 
 ## Enable reducers
-Test-case reduction is disabled by default. The statement reducer can be enabled by passing `--use-reducer` when starting SQLancer. If you wish to further shorten each statements, you need to additionally pass the `--reduce-AST` parameter so that the AST-based reduction is applied. 
+Test-case reduction is disabled by default. The statement reducer can be enabled by passing `--use-reducer` when starting SQLancer. If you wish to further shorten each statements, you need to additionally pass the `--reduce-ast` parameter so that the AST-based reduction is applied. 
 
-Note: if `--reduce-AST` is set, `--use-reducer` option must be enabled first.
+Note: if `--reduce-ast` is set, `--use-reducer` option must be enabled first.
 
 There are also options to define timeout seconds and max steps of reduction for both statement reducer and AST-based reducer.
 

--- a/src/sqlancer/ASTBasedReducer.java
+++ b/src/sqlancer/ASTBasedReducer.java
@@ -1,101 +1,21 @@
 package sqlancer;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiConsumer;
 
-import net.sf.jsqlparser.expression.BinaryExpression;
-import net.sf.jsqlparser.expression.CaseExpression;
-import net.sf.jsqlparser.expression.DoubleValue;
-import net.sf.jsqlparser.expression.Expression;
-import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
-import net.sf.jsqlparser.expression.LongValue;
-import net.sf.jsqlparser.expression.NullValue;
-import net.sf.jsqlparser.expression.Parenthesis;
-import net.sf.jsqlparser.expression.StringValue;
-import net.sf.jsqlparser.expression.WhenClause;
-import net.sf.jsqlparser.expression.operators.relational.Between;
-import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
-import net.sf.jsqlparser.expression.operators.relational.InExpression;
-import net.sf.jsqlparser.expression.operators.relational.ItemsList;
-import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
-import net.sf.jsqlparser.statement.StatementVisitorAdapter;
-import net.sf.jsqlparser.statement.select.GroupByElement;
-import net.sf.jsqlparser.statement.select.PlainSelect;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.select.SelectBody;
-import net.sf.jsqlparser.statement.select.SelectExpressionItem;
-import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
-import net.sf.jsqlparser.statement.select.SetOperationList;
-import net.sf.jsqlparser.statement.select.SubSelect;
-import net.sf.jsqlparser.statement.select.WithItem;
 import sqlancer.common.query.Query;
 import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.transformations.JSQLParserBasedTransformation;
+import sqlancer.transformations.RemoveClausesOfSelect;
+import sqlancer.transformations.RemoveColumnsOfSelect;
+import sqlancer.transformations.RemoveElementsOfExpressionList;
+import sqlancer.transformations.RemoveRowsOfInsert;
+import sqlancer.transformations.RemoveUnions;
+import sqlancer.transformations.SimplifyConstant;
+import sqlancer.transformations.SimplifyExpressions;
+import sqlancer.transformations.Transformation;
 
-final class ExpressionTransformer {
-
-    private static List<Expression> flattenChildren(BinaryExpression expr) {
-        List<Expression> candidates = new ArrayList<>();
-        Expression lhs = expr.getLeftExpression();
-        Expression rhs = expr.getRightExpression();
-        candidates.add(lhs);
-        candidates.add(rhs);
-        return candidates;
-    }
-
-    private static List<Expression> flattenChildren(Between expr) {
-        Expression lhs = expr.getBetweenExpressionStart();
-        Expression rhs = expr.getBetweenExpressionEnd();
-        return List.of(lhs, rhs);
-    }
-
-    public static List<Expression> candidateExpressions(Expression expr) {
-        if (expr instanceof Parenthesis) {
-            // try removing a pair of brackets.
-            Parenthesis paren = (Parenthesis) expr;
-            return List.of(paren.getExpression());
-        } else if (expr instanceof BinaryExpression) {
-            return flattenChildren((BinaryExpression) expr);
-        } else if (expr instanceof Between) {
-            return flattenChildren((Between) expr);
-        } else if (expr instanceof LongValue) {
-            LongValue longValue = (LongValue) expr;
-            if (String.valueOf(longValue).length() >= 4) {
-                return List.of(new NullValue(), new LongValue(10), new LongValue(0), new LongValue(1));
-            }
-            return new ArrayList<>();
-        } else if (expr instanceof DoubleValue) {
-            DoubleValue doubleValue = (DoubleValue) expr;
-            double literal = doubleValue.getValue();
-            if (String.valueOf(literal).length() <= 4) {
-                return new ArrayList<>();
-            }
-            double roundedValue = Math.round(literal * 10.0) / 10.0;
-            return List.of(new NullValue(), new DoubleValue(String.valueOf(roundedValue)));
-        } else if (expr instanceof StringValue) {
-            StringValue sv = (StringValue) expr;
-            String str = sv.getValue();
-            if (str.length() > 4) {
-                return List.of(new NullValue(), new StringValue(" "));
-            }
-            return new ArrayList<>();
-        } else if (expr instanceof CaseExpression) {
-            CaseExpression caseExpression = (CaseExpression) expr;
-            return List.of(caseExpression.getSwitchExpression(), caseExpression.getElseExpression());
-        } else {
-            return new ArrayList<>();
-        }
-    }
-
-    private ExpressionTransformer() throws Exception {
-        throw new AssertionError("Do not initialize the util class");
-    }
-}
-
-@SuppressWarnings("unchecked")
 public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpecificOptions<?>, C extends SQLancerDBConnection>
         implements Reducer<G> {
 
@@ -105,383 +25,22 @@ public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpeci
     private G state;
     private G newGlobalState;
     private Reproducer<G> reproducer;
-    private int reduceTargetIndex;
-    private Statement targetStatement;
 
-    // statement after reduction.
     private List<Query<C>> reducedStatements;
+    // statement after reduction.
 
     public ASTBasedReducer(DatabaseProvider<G, O, C> provider) {
         this.provider = provider;
     }
 
-    private void updateStatements() {
-        String queryString = targetStatement.toString();
+    @SuppressWarnings("unchecked")
+    private void updateStatements(Statement statement, int index) {
+        String queryString = statement.toString();
         boolean couldAffectSchema = queryString.contains("CREATE TABLE") || queryString.contains("EXPLAIN");
-        reducedStatements.set(reduceTargetIndex, (Query<C>) new SQLQueryAdapter(queryString, couldAffectSchema));
+        reducedStatements.set(index, (Query<C>) new SQLQueryAdapter(queryString, couldAffectSchema));
     }
 
-    public <P> void expressionReduce(P parent, Expression subExpr, // NOPMD
-            BiConsumer<P, Expression> setter) {
-        boolean observeChange;
-        do {
-            observeChange = false;
-            List<Expression> candidates = ExpressionTransformer.candidateExpressions(subExpr);
-            for (Expression candidate : candidates) {
-                try {
-                    setter.accept(parent, candidate);
-                    if (bugStillTriggers()) {
-                        subExpr = candidate;
-                        observeChange = true;
-                    }
-                } catch (Exception ignoredException) {
-                }
-            }
-            setter.accept(parent, subExpr);
-        } while (observeChange);
-    }
-
-    public <P, T> void listElementRemovingReduce(P parent, List<T> elms, // NOPMD
-            BiConsumer<P, List<T>> setter) {
-        // TODO: For AST-Reducer, is delta-debugging needed ? Or just use the naive approach ?
-        boolean observeChange;
-        do {
-            observeChange = false;
-            for (int i = elms.size() - 1; i >= 0; i--) {
-                List<T> reducedElms = new ArrayList<>(elms);
-                reducedElms.subList(i, i + 1).clear();
-                setter.accept(parent, reducedElms);
-                try {
-                    if (bugStillTriggers()) {
-                        elms = reducedElms;
-                        observeChange = true;
-                    }
-                } catch (Exception e) {
-                    System.out.println("An error occurred when trying executing reduced statements");
-                    e.printStackTrace();
-                }
-            }
-            setter.accept(parent, elms);
-        } while (observeChange);
-
-    }
-
-    ExpressionVisitorAdapter expressionReducerVisitor = new ExpressionVisitorAdapter() {
-
-        @Override
-        public void visit(InExpression expr) {
-            Expression rhs = expr.getRightExpression();
-
-            if (rhs instanceof SubSelect) {
-                SubSelect subSelect = (SubSelect) rhs;
-                subSelect.getSelectBody().accept(selectReducerVisitor);
-            } else {
-                ItemsList itemslist = expr.getRightItemsList();
-                itemslist.accept(this);
-            }
-        }
-
-        @Override
-        protected void visitBinaryExpression(BinaryExpression expr) {
-            Expression lhs = expr.getLeftExpression();
-            Expression rhs = expr.getRightExpression();
-            expressionReduce(expr, lhs, (expression, candidate) -> {
-                expression.setLeftExpression(candidate);
-                updateStatements();
-            });
-            expressionReduce(expr, rhs, (expression, candidate) -> {
-                expression.setRightExpression(candidate);
-                updateStatements();
-            });
-            lhs.accept(this);
-            rhs.accept(this);
-        }
-
-        // @Override
-        // public void visit(DateValue value) {
-        // super.visit(value);
-        // }
-        //
-        // @Override
-        // public void visit(TimeValue value) {
-        // super.visit(value);
-        // }
-        //
-        // @Override
-        // public void visit(LikeExpression expr) {
-        // super.visit(expr);
-        // }
-
-        @Override
-        public void visit(CaseExpression expr) {
-            Expression switchExpr = expr.getSwitchExpression();
-            Expression elseExpr = expr.getElseExpression();
-
-            expressionReduce(expr, switchExpr, (parent, sw) -> {
-                parent.setSwitchExpression(sw);
-                updateStatements();
-            });
-            expressionReduce(expr, elseExpr, (parent, els) -> {
-                parent.setElseExpression(els);
-                updateStatements();
-            });
-
-            super.visit(expr);
-        }
-
-        @Override
-        public void visit(WhenClause whenClause) {
-            Expression when = whenClause.getWhenExpression();
-            Expression then = whenClause.getThenExpression();
-
-            expressionReduce(whenClause, when, (wc, w) -> {
-                wc.setWhenExpression(w);
-                updateStatements();
-            });
-
-            expressionReduce(whenClause, then, (wc, t) -> {
-                wc.setThenExpression(t);
-                updateStatements();
-            });
-
-            super.visit(whenClause);
-        }
-
-        @Override
-        public void visit(Parenthesis parenthesis) {
-            Expression closedExpr = parenthesis.getExpression();
-            expressionReduce(parenthesis, closedExpr, (p, s) -> {
-                p.setExpression(s);
-                updateStatements();
-            });
-            closedExpr.accept(this);
-        }
-
-        // @Override
-        // public void visit(Function function) {
-        // super.visit(function);
-        // }
-
-        @Override
-        public void visit(ExpressionList expressionList) {
-            List<Expression> expressions = expressionList.getExpressions();
-            listElementRemovingReduce(expressionList, expressions, (l, es) -> {
-                l.setExpressions(es);
-                updateStatements();
-            });
-            expressions = expressionList.getExpressions();
-            for (int i = 0; i < expressions.size(); i++) {
-                Expression expr = expressions.get(i);
-                int index = i;
-                expressionReduce(expressions, expr, (l, e) -> {
-                    l.set(index, e);
-                    updateStatements();
-                });
-            }
-            super.visit(expressionList);
-        }
-
-        @Override
-        public void visit(SelectExpressionItem selectExpressionItem) {
-            Expression expr = selectExpressionItem.getExpression();
-            expressionReduce(selectExpressionItem, expr, (item, e) -> {
-                item.setExpression(e);
-                updateStatements();
-            });
-            super.visit(selectExpressionItem);
-        }
-
-        @Override
-        public void visit(SubSelect subSelect) {
-            subSelect.getSelectBody().accept(selectReducerVisitor);
-        }
-
-    };
-
-    SelectVisitorAdapter selectReducerVisitor = new SelectVisitorAdapter() {
-
-        // Clauses that would be tried removing.
-        // examples:
-        // Remove when: select * from table when 1 -> select * from table
-        // Remove limit: select * from table limit 1 -> select * from table
-        private final String[] removeList = { "Limit", "Offset", "Where", "Having", "GroupBy", "Distinct",
-                "OrderByElements", "Joins" };
-
-        // Clauses that would be tried transforming.
-        // examples:
-        // select * from t where a + b < c + d
-        // where clause might become one of the statement below after transformation:
-        // -> select * from table where c + d
-        // -> select * from table where a + b
-
-        private final String[] transformList = { "Where", "Having", "FromItem", "SelectItems", "GroupBy", "Joins" };
-
-        // Clauses that would be visited for further reduction.
-        // example:
-        // select * from t where a + b < c + d
-        // Assuming that the coexistence of a and c would trigger the bug.
-        // The where clause : a + b < c + d would be visited and a + b, c + d would be reduced respectively.
-        // a + b < c + d might become a + c
-        private final String[] descendList = { "Where", "Having", "FromItem", "SelectItems", "GroupBy" };
-
-        private String getterName(String astNodeName) {
-            return "get" + astNodeName;
-        }
-
-        private String setterName(String astNodeName) {
-            if (astNodeName.equals("GroupBy")) {
-                return "set" + astNodeName + "Element";
-            } else {
-                return "set" + astNodeName;
-            }
-        }
-
-        @Override
-        public void visit(WithItem withItem) {
-            // withItem.getItemsList();
-        }
-
-        @Override
-        public void visit(PlainSelect plainSelect) {
-            // transform section. Lists defined above would be iterated to get the corresponding clause name. Reflection
-            // is used to avoid repetitive code. e.g. The current astNodeName is When `getWhen`, `setWhen` would be
-            // called.
-            for (String astNodeName : removeList) {
-                try {
-                    Method nodeGetter = plainSelect.getClass().getMethod(getterName(astNodeName));
-                    Object astNode = nodeGetter.invoke(plainSelect);
-                    if (astNode == null) {
-                        continue;
-                    }
-                    Method nodeSetter = plainSelect.getClass().getMethod(setterName(astNodeName),
-                            nodeGetter.getReturnType());
-                    nodeSetter.invoke(plainSelect, new Object[] { null });
-                    updateStatements();
-                    if (!bugStillTriggers()) {
-                        nodeSetter.invoke(plainSelect, astNode);
-                        updateStatements();
-                    }
-                } catch (Exception e) {
-                    throw new AssertionError(e);
-                }
-            }
-
-            // Pull Up Section
-            for (String astNodeName : transformList) {
-                try {
-                    Method nodeGetter = plainSelect.getClass().getMethod(getterName(astNodeName));
-                    Object astNode = nodeGetter.invoke(plainSelect);
-                    if (astNode == null) {
-                        continue;
-                    }
-                    Method nodeSetter = plainSelect.getClass().getMethod(setterName(astNodeName),
-                            nodeGetter.getReturnType());
-
-                    if (astNode instanceof Expression) {
-                        Expression expr = (Expression) astNode;
-                        expressionReduce(plainSelect, expr, (select, expression) -> {
-                            try {
-                                nodeSetter.invoke(select, expression);
-                                updateStatements();
-                            } catch (IllegalAccessException | InvocationTargetException e) {
-                                e.printStackTrace();
-                            }
-                        });
-                    } else if (astNode instanceof List) {
-                        List<?> elms = (List<?>) astNode;
-                        if (elms.size() <= 1) {
-                            continue;
-                        }
-                        listElementRemovingReduce(plainSelect, elms, (select, items) -> {
-                            try {
-                                nodeSetter.invoke(select, items);
-                                updateStatements();
-                            } catch (IllegalAccessException | InvocationTargetException e) {
-                                e.printStackTrace();
-                            }
-                        });
-                    } else if (astNode instanceof GroupByElement) {
-                        GroupByElement groupByElement = (GroupByElement) astNode;
-                        ExpressionList expressionList = groupByElement.getGroupByExpressionList();
-                        if (expressionList == null) {
-                            groupByElement.getGroupingSets();
-                            // TODO: TO BE IMPLEMENTED.
-                        } else {
-                            List<Expression> elms = expressionList.getExpressions();
-                            if (elms.size() <= 1) {
-                                continue;
-                            }
-                            listElementRemovingReduce(groupByElement, elms, (select, items) -> {
-                                groupByElement.setGroupByExpressionList(new ExpressionList(items));
-                                updateStatements();
-                            });
-                        }
-                    }
-                } catch (Exception e) {
-                    throw new AssertionError(e);
-                }
-            }
-
-            for (String astNodeName : descendList) {
-                try {
-                    Method nodeGetter = plainSelect.getClass().getMethod(getterName(astNodeName));
-                    Object astNode = nodeGetter.invoke(plainSelect);
-                    if (astNode == null) {
-                        continue;
-                    }
-                    if (astNode instanceof Expression) {
-                        ((Expression) astNode).accept(expressionReducerVisitor);
-                    } else if (astNode instanceof List) {
-                        // Really hacky... Some other ways to simplify it ?
-                        List<?> elms = (List<?>) astNode;
-                        for (Object obj : elms) {
-                            if (obj instanceof SelectExpressionItem) {
-                                ((SelectExpressionItem) obj).accept(expressionReducerVisitor);
-                            } else if (obj instanceof Expression) {
-                                ((Expression) obj).accept(expressionReducerVisitor);
-                            }
-                        }
-                    } else if (astNode instanceof GroupByElement) {
-                        GroupByElement groupByElement = (GroupByElement) astNode;
-                        ExpressionList expressionList = groupByElement.getGroupByExpressionList();
-                        if (expressionList != null) {
-                            expressionList.accept(expressionReducerVisitor);
-                        }
-                        // TODO: groupByElement.getGroupingSets() TO BE IMPLEMENTED
-
-                    }
-                } catch (Exception e) {
-                    throw new AssertionError(e);
-                }
-            }
-        }
-
-        @Override
-        public void visit(SetOperationList setOpList) {
-            List<SelectBody> selectBodies = setOpList.getSelects();
-            listElementRemovingReduce(setOpList, selectBodies, (optionList, selects) -> {
-                optionList.setSelects(selects);
-                updateStatements();
-            });
-            for (SelectBody selectBody : selectBodies) {
-                if (selectBody instanceof PlainSelect) {
-                    visit((PlainSelect) selectBody);
-                }
-            }
-        }
-
-    };
-
-    StatementVisitorAdapter statementReducerVisitor = new StatementVisitorAdapter() {
-        @Override
-        public void visit(Select select) {
-            SelectBody selectBody = select.getSelectBody();
-            if (selectBody != null) {
-                selectBody.accept(selectReducerVisitor);
-            }
-        }
-    };
-
+    @SuppressWarnings("unchecked")
     @Override
     public void reduce(G state, Reproducer<G> reproducer, G newGlobalState) throws Exception {
         this.state = state;
@@ -489,22 +48,60 @@ public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpeci
         this.reproducer = reproducer;
 
         List<Query<?>> initialBugInducingStatements = state.getState().getStatements();
+        newGlobalState.getState().setStatements(new ArrayList<>(initialBugInducingStatements));
+
+        List<Transformation> transformations = new ArrayList<>();
+
+        transformations.add(new RemoveUnions());
+        transformations.add(new RemoveClausesOfSelect());
+        transformations.add(new RemoveRowsOfInsert());
+        transformations.add(new RemoveColumnsOfSelect());
+        transformations.add(new RemoveElementsOfExpressionList());
+        transformations.add(new SimplifyExpressions());
+        transformations.add(new SimplifyConstant());
+
+        Transformation.setBugJudgement(() -> {
+            try {
+                return this.bugStillTriggers();
+            } catch (Exception ignored) {
+            }
+            return false;
+        });
+
+        boolean observeChange;
         reducedStatements = new ArrayList<>();
         for (Query<?> query : initialBugInducingStatements) {
             reducedStatements.add((Query<C>) query);
         }
 
-        for (int i = 0; i < reducedStatements.size(); i++) {
-            reduceTargetIndex = i;
-            Query<C> query = reducedStatements.get(reduceTargetIndex);
-            targetStatement = CCJSqlParserUtil.parse(query.getQueryString());
-            targetStatement.accept(statementReducerVisitor);
-        }
+        do {
+            observeChange = false;
+            for (Transformation t : transformations) {
+                for (int i = 0; i < reducedStatements.size(); i++) {
+                    Query<?> query = reducedStatements.get(i);
+                    boolean initFlag = t.init(query.getQueryString());
+                    int index = i;
+                    if (t instanceof JSQLParserBasedTransformation) {
+                        JSQLParserBasedTransformation jt = (JSQLParserBasedTransformation) t;
+                        jt.setStatementChangedCallBack((statement) -> {
+                            updateStatements(statement, index);
+                        });
+                    }
+                    if (!initFlag) {
+                        System.out.println("Error when parsing the statement at transformer :" + t);
+                        continue;
+                    }
+                    t.apply();
+                    observeChange |= t.changed();
+                }
+            }
+        } while (observeChange);
 
         newGlobalState.getState().setStatements(new ArrayList<>(reducedStatements));
+        newGlobalState.getLogger().logReduced(newGlobalState.getState());
     }
 
-    private boolean bugStillTriggers() throws Exception {
+    public boolean bugStillTriggers() throws Exception {
         try (C con2 = provider.createDatabase(newGlobalState)) {
             newGlobalState.setConnection(con2);
             List<Query<C>> candidateStatements = new ArrayList<>(reducedStatements);
@@ -519,6 +116,7 @@ public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpeci
             }
             try {
                 if (reproducer.bugStillTriggers(newGlobalState)) {
+                    newGlobalState.getLogger().logReduced(newGlobalState.getState());
                     return true;
                 }
             } catch (Throwable ignoredException) {

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -459,6 +459,12 @@ public final class Main {
 
                     Reducer<G> reducer = new StatementReducer<>(provider);
                     reducer.reduce(state, reproducer, newGlobalState);
+
+                    if (options.reduceAST()) {
+                        Reducer<G> astBasedReducer = new ASTBasedReducer<>(provider);
+                        astBasedReducer.reduce(state, reproducer, newGlobalState);
+                    }
+
                     throw new AssertionError("Found a potential bug");
                 }
             }

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -444,6 +444,10 @@ public final class Main {
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }
+
+                if (options.reduceAST() && !options.useReducer()) {
+                    throw new AssertionError("To reduce AST, use-reducer option must be enabled first");
+                }
                 if (reproducer != null && options.useReducer()) {
                     System.out.println("EXPERIMENTAL: Trying to reduce queries using a simple reducer.");
                     // System.out.println("Reduced query will be output to stdout but not logs.");

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -132,7 +132,13 @@ public class MainOptions {
     @Parameter(names = "--statement-reducer-max-steps", description = "EXPERIMENTAL Maximum steps the statement reducer will do")
     private long maxStatementReduceSteps = NO_REDUCE_LIMIT; // NOPMD
 
-    @Parameter(names = "--statement-reducer-max-time", description = "EXPERIMENTAL Maximum time duration (secs) the statement reducer will do")
+    @Parameter(names = "--statement-reducer-max-time", description = "EXPERIMENTAL Maximum time duration (secs) the AST-based reducer will do")
+    private long maxASTReduceTime = NO_REDUCE_LIMIT; // NOPMD
+
+    @Parameter(names = "--ast-reducer-max-steps", description = "EXPERIMENTAL Maximum steps the AST-based reducer will do")
+    private long maxASTReduceSteps = NO_REDUCE_LIMIT; // NOPMD
+
+    @Parameter(names = "--ast-reducer-max-time", description = "EXPERIMENTAL Maximum time duration (secs) the statement reducer will do")
     private long maxStatementReduceTime = NO_REDUCE_LIMIT; // NOPMD
 
     public int getMaxExpressionDepth() {
@@ -307,4 +313,13 @@ public class MainOptions {
     public long getMaxStatementReduceTime() {
         return maxStatementReduceTime;
     }
+
+    public long getMaxASTReduceSteps() {
+        return maxASTReduceSteps;
+    }
+
+    public long getMaxASTReduceTime() {
+        return maxASTReduceTime;
+    }
+
 }

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -126,7 +126,7 @@ public class MainOptions {
     @Parameter(names = "--use-reducer", description = "EXPERIMENTAL Attempt to reduce queries using a simple reducer")
     private boolean useReducer = false; // NOPMD
 
-    @Parameter(names = "--reduce-AST", description = "EXPERIMENTAL perform AST reduction after statement reduction")
+    @Parameter(names = "--reduce-ast", description = "EXPERIMENTAL perform AST reduction after statement reduction")
     private boolean reduceAST = false; // NOPMD
 
     @Parameter(names = "--statement-reducer-max-steps", description = "EXPERIMENTAL Maximum steps the statement reducer will do")

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -126,6 +126,9 @@ public class MainOptions {
     @Parameter(names = "--use-reducer", description = "EXPERIMENTAL Attempt to reduce queries using a simple reducer")
     private boolean useReducer = false; // NOPMD
 
+    @Parameter(names = "--reduce-AST", description = "EXPERIMENTAL perform AST reduction after statement reduction")
+    private boolean reduceAST = false; // NOPMD
+
     @Parameter(names = "--statement-reducer-max-steps", description = "EXPERIMENTAL Maximum steps the statement reducer will do")
     private long maxStatementReduceSteps = NO_REDUCE_LIMIT; // NOPMD
 
@@ -291,6 +294,10 @@ public class MainOptions {
 
     public boolean useReducer() {
         return useReducer;
+    }
+
+    public boolean reduceAST() {
+        return reduceAST;
     }
 
     public long getMaxStatementReduceSteps() {

--- a/src/sqlancer/transformations/JSQLParserBasedTransformation.java
+++ b/src/sqlancer/transformations/JSQLParserBasedTransformation.java
@@ -1,0 +1,43 @@
+package sqlancer.transformations;
+
+import java.util.function.Consumer;
+
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+
+/**
+ * Transformations based on JSQLParser should be derived from this class.
+ */
+
+public class JSQLParserBasedTransformation extends Transformation {
+
+    protected Statement statement;
+    protected Consumer<Statement> statementChangedHandler;
+
+    public JSQLParserBasedTransformation(String desc) {
+        super(desc);
+    }
+
+    public void setStatementChangedCallBack(Consumer<Statement> statementChangedHandler) {
+        this.statementChangedHandler = statementChangedHandler;
+    }
+
+    @Override
+    protected void onStatementChanged() {
+        if (statementChangedHandler != null) {
+            statementChangedHandler.accept(this.statement);
+        }
+    }
+
+    @Override
+    public boolean init(String sql) {
+        this.current = sql;
+        try {
+            statement = CCJSqlParserUtil.parse(current);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/sqlancer/transformations/JSQLParserBasedTransformation.java
+++ b/src/sqlancer/transformations/JSQLParserBasedTransformation.java
@@ -1,7 +1,5 @@
 package sqlancer.transformations;
 
-import java.util.function.Consumer;
-
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 
@@ -12,20 +10,15 @@ import net.sf.jsqlparser.statement.Statement;
 public class JSQLParserBasedTransformation extends Transformation {
 
     protected Statement statement;
-    protected Consumer<Statement> statementChangedHandler;
 
     public JSQLParserBasedTransformation(String desc) {
         super(desc);
     }
 
-    public void setStatementChangedCallBack(Consumer<Statement> statementChangedHandler) {
-        this.statementChangedHandler = statementChangedHandler;
-    }
-
     @Override
     protected void onStatementChanged() {
         if (statementChangedHandler != null) {
-            statementChangedHandler.accept(this.statement);
+            statementChangedHandler.accept(this.statement.toString());
         }
     }
 

--- a/src/sqlancer/transformations/RemoveClausesOfSelect.java
+++ b/src/sqlancer/transformations/RemoveClausesOfSelect.java
@@ -1,0 +1,80 @@
+package sqlancer.transformations;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.select.Distinct;
+import net.sf.jsqlparser.statement.select.GroupByElement;
+import net.sf.jsqlparser.statement.select.Limit;
+import net.sf.jsqlparser.statement.select.Offset;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+
+/**
+ * remove clauses of a select, such as join, where, group by, distinct, offset, limit e.g. select * from t where a = b
+ * offset 1 limit 1 -> select * from t;
+ */
+
+public class RemoveClausesOfSelect extends JSQLParserBasedTransformation {
+    private final SelectDeParser remover = new SelectDeParser() {
+        @Override
+        public void visit(PlainSelect plainSelect) {
+            handleSelect(plainSelect);
+            super.visit(plainSelect);
+        }
+    };
+
+    public RemoveClausesOfSelect() {
+        super("remove clauses of select");
+    }
+
+    @Override
+    public boolean init(String original) {
+
+        boolean baseSuc = super.init(original);
+        if (!baseSuc) {
+            return false;
+        }
+
+        this.remover.setExpressionVisitor(new ExpressionDeParser(remover, new StringBuilder()));
+        return true;
+    }
+
+    @Override
+    public void apply() {
+        super.apply();
+        if (statement instanceof Select) {
+            Select select = (Select) statement;
+            select.getSelectBody().accept(remover);
+        }
+    }
+
+    private void handleSelect(PlainSelect plainSelect) {
+
+        Expression where = plainSelect.getWhere();
+        if (where != null) {
+            tryRemove(plainSelect, where, PlainSelect::setWhere);
+        }
+
+        GroupByElement groupByElement = plainSelect.getGroupBy();
+        if (groupByElement != null) {
+            tryRemove(plainSelect, groupByElement, PlainSelect::setGroupByElement);
+        }
+
+        Distinct distinct = plainSelect.getDistinct();
+        if (distinct != null) {
+            tryRemove(plainSelect, distinct, PlainSelect::setDistinct);
+        }
+
+        Offset offset = plainSelect.getOffset();
+        if (offset != null) {
+            tryRemove(plainSelect, offset, PlainSelect::setOffset);
+        }
+
+        Limit limit = plainSelect.getLimit();
+        if (offset != null) {
+            tryRemove(plainSelect, limit, PlainSelect::setLimit);
+        }
+    }
+
+}

--- a/src/sqlancer/transformations/RemoveClausesOfSelect.java
+++ b/src/sqlancer/transformations/RemoveClausesOfSelect.java
@@ -15,8 +15,9 @@ import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
 /**
- * remove clauses of a select, such as join, where, group by, distinct, offset, limit e.g. select * from t where a = b
- * offset 1 limit 1 -> select * from t;
+ * remove clauses of a select, such as join, where, group by, distinct, offset, limit.
+ *
+ * e.g. select * from t where a = b offset 1 limit 1 -> select * from t;
  */
 
 public class RemoveClausesOfSelect extends JSQLParserBasedTransformation {

--- a/src/sqlancer/transformations/RemoveClausesOfSelect.java
+++ b/src/sqlancer/transformations/RemoveClausesOfSelect.java
@@ -1,5 +1,7 @@
 package sqlancer.transformations;
 
+import java.util.List;
+
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.statement.select.Distinct;
 import net.sf.jsqlparser.statement.select.GroupByElement;
@@ -7,6 +9,8 @@ import net.sf.jsqlparser.statement.select.Limit;
 import net.sf.jsqlparser.statement.select.Offset;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SubSelect;
+import net.sf.jsqlparser.statement.select.WithItem;
 import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
@@ -46,6 +50,23 @@ public class RemoveClausesOfSelect extends JSQLParserBasedTransformation {
         if (statement instanceof Select) {
             Select select = (Select) statement;
             select.getSelectBody().accept(remover);
+
+            List<WithItem> withItemsList = select.getWithItemsList();
+            if (withItemsList == null) {
+                return;
+            }
+            tryRemoveElms(select, withItemsList, Select::setWithItemsList);
+
+            for (WithItem withItem : withItemsList) {
+                SubSelect subSelect = withItem.getSubSelect();
+                if (subSelect == null) {
+                    return;
+                }
+
+                if (subSelect.getSelectBody() != null) {
+                    subSelect.getSelectBody().accept(remover);
+                }
+            }
         }
     }
 

--- a/src/sqlancer/transformations/RemoveColumnsOfSelect.java
+++ b/src/sqlancer/transformations/RemoveColumnsOfSelect.java
@@ -10,7 +10,7 @@ import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
 /**
- * remove columns of a select: e.g. select a, b, c from t -> select a from t;
+ * remove columns of a select: e.g. select a, b, c from t -> select a from t.
  */
 public class RemoveColumnsOfSelect extends JSQLParserBasedTransformation {
 

--- a/src/sqlancer/transformations/RemoveColumnsOfSelect.java
+++ b/src/sqlancer/transformations/RemoveColumnsOfSelect.java
@@ -1,0 +1,44 @@
+package sqlancer.transformations;
+
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+
+/**
+ * remove columns of a select: e.g. select a, b, c from t -> select a from t;
+ */
+public class RemoveColumnsOfSelect extends JSQLParserBasedTransformation {
+
+    private final SelectDeParser remover = new SelectDeParser() {
+        @Override
+        public void visit(PlainSelect plainSelect) {
+            tryRemoveElms(plainSelect, plainSelect.getSelectItems(), PlainSelect::setSelectItems);
+            super.visit(plainSelect);
+        }
+    };
+
+    public RemoveColumnsOfSelect() {
+        super("remove columns of a select");
+    }
+
+    @Override
+    public boolean init(String original) {
+
+        boolean baseSucc = super.init(original);
+        if (!baseSucc) {
+            return false;
+        }
+        this.remover.setExpressionVisitor(new ExpressionDeParser(remover, new StringBuilder()));
+        return true;
+    }
+
+    @Override
+    public void apply() {
+        super.apply();
+        if (statement instanceof Select) {
+            Select select = (Select) statement;
+            select.getSelectBody().accept(remover);
+        }
+    }
+}

--- a/src/sqlancer/transformations/RemoveColumnsOfSelect.java
+++ b/src/sqlancer/transformations/RemoveColumnsOfSelect.java
@@ -1,7 +1,11 @@
 package sqlancer.transformations;
 
+import java.util.List;
+
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SubSelect;
+import net.sf.jsqlparser.statement.select.WithItem;
 import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
@@ -39,6 +43,22 @@ public class RemoveColumnsOfSelect extends JSQLParserBasedTransformation {
         if (statement instanceof Select) {
             Select select = (Select) statement;
             select.getSelectBody().accept(remover);
+
+            List<WithItem> withItemsList = select.getWithItemsList();
+            if (withItemsList == null) {
+                return;
+            }
+            for (WithItem withItem : withItemsList) {
+                SubSelect subSelect = withItem.getSubSelect();
+                if (subSelect == null) {
+                    return;
+                }
+
+                if (subSelect.getSelectBody() != null) {
+                    subSelect.getSelectBody().accept(remover);
+                }
+            }
+
         }
     }
 }

--- a/src/sqlancer/transformations/RemoveElementsOfExpressionList.java
+++ b/src/sqlancer/transformations/RemoveElementsOfExpressionList.java
@@ -1,0 +1,86 @@
+package sqlancer.transformations;
+
+import java.util.List;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.statement.select.GroupByElement;
+import net.sf.jsqlparser.statement.select.Join;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.InsertDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+
+/**
+ * remove elements of an expression list NOTE: this only works for select statements. works for ExpressionList type in
+ * JSQLParser, such as groupBy list
+ */
+public class RemoveElementsOfExpressionList extends JSQLParserBasedTransformation {
+    private final ExpressionDeParser expressionHandler = new ExpressionDeParser();
+    private final SelectDeParser simplifier = new SelectDeParser() {
+        @Override
+        public void visit(PlainSelect plainSelect) {
+            handleSelect(plainSelect);
+            super.visit(plainSelect);
+        }
+
+        @Override
+        public void visit(ExpressionList expressionList) {
+            List<Expression> expressions = expressionList.getExpressions();
+            tryRemoveElms(expressionList, expressions, ExpressionList::setExpressions);
+            super.visit(expressionList);
+        }
+    };
+    private final InsertDeParser insertDeParser = new InsertDeParser() {
+        @Override
+        public void visit(ExpressionList expressionList) {
+            List<Expression> expressions = expressionList.getExpressions();
+            tryRemoveElms(expressionList, expressions, ExpressionList::setExpressions);
+            super.visit(expressionList);
+        }
+    };
+
+    public RemoveElementsOfExpressionList() {
+        super("remove elements of expression lists");
+    }
+
+    @Override
+    public boolean init(String sql) {
+        boolean baseSuc = super.init(sql);
+        if (!baseSuc) {
+            return false;
+        }
+        this.simplifier.setExpressionVisitor(expressionHandler);
+        this.expressionHandler.setSelectVisitor(simplifier);
+
+        this.insertDeParser.setExpressionVisitor(expressionHandler);
+        this.insertDeParser.setSelectVisitor(simplifier);
+        return true;
+    }
+
+    @Override
+    public void apply() {
+        super.apply();
+        if (statement instanceof Select) {
+            Select select = (Select) statement;
+            select.getSelectBody().accept(simplifier);
+        }
+    }
+
+    private void handleSelect(PlainSelect plainSelect) {
+
+        GroupByElement groupByElement = plainSelect.getGroupBy();
+
+        if (groupByElement != null && groupByElement.getGroupByExpressionList() != null) {
+            ExpressionList expressionList = groupByElement.getGroupByExpressionList();
+            List<Expression> list = expressionList.getExpressions();
+            tryRemoveElms(expressionList, list, ExpressionList::setExpressions);
+        }
+
+        List<Join> expressionList = plainSelect.getJoins();
+        if (expressionList != null) {
+            tryRemoveElms(plainSelect, expressionList, PlainSelect::setJoins);
+        }
+    }
+}

--- a/src/sqlancer/transformations/RemoveElementsOfExpressionList.java
+++ b/src/sqlancer/transformations/RemoveElementsOfExpressionList.java
@@ -13,8 +13,9 @@ import net.sf.jsqlparser.util.deparser.InsertDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
 /**
- * remove elements of an expression list NOTE: this only works for select statements. works for ExpressionList type in
- * JSQLParser, such as groupBy list
+ * remove elements of an expression list.
+ *
+ * NOTE: this only works for select statements and targets at ExpressionList type in JSQLParser, such as groupBy list
  */
 public class RemoveElementsOfExpressionList extends JSQLParserBasedTransformation {
     private final ExpressionDeParser expressionHandler = new ExpressionDeParser();

--- a/src/sqlancer/transformations/RemoveRowsOfInsert.java
+++ b/src/sqlancer/transformations/RemoveRowsOfInsert.java
@@ -1,6 +1,7 @@
 package sqlancer.transformations;
 
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.select.SelectBody;
 import net.sf.jsqlparser.statement.select.SetOperationList;
@@ -19,21 +20,25 @@ public class RemoveRowsOfInsert extends JSQLParserBasedTransformation {
     @Override
     public void apply() {
         super.apply();
-        if (statement instanceof Insert) {
-            Insert insert = (Insert) statement;
-            SelectBody selectBody = insert.getSelect().getSelectBody();
-            if (selectBody instanceof SetOperationList) {
-                SetOperationList insertingList = (SetOperationList) selectBody;
-                for (SelectBody selBody : insertingList.getSelects()) {
-                    if (selBody instanceof ValuesStatement) {
-                        ValuesStatement valuesStatement = (ValuesStatement) selBody;
-                        if (valuesStatement.getExpressions() instanceof ExpressionList) {
-                            ExpressionList itemsList = (ExpressionList) valuesStatement.getExpressions();
-                            tryRemoveElms(itemsList, itemsList.getExpressions(), ExpressionList::setExpressions);
-                        }
-                    }
-                }
+        if (!(statement instanceof Insert)) {
+            return;
+        }
+        SelectBody selectBody = ((Insert) statement).getSelect().getSelectBody();
+        if (!(selectBody instanceof SetOperationList)) {
+            return;
+        }
+        SetOperationList insertingList = (SetOperationList) selectBody;
+        for (SelectBody selBody : insertingList.getSelects()) {
+            if (!(selBody instanceof ValuesStatement)) {
+                continue;
             }
+            ValuesStatement valuesStatement = (ValuesStatement) selBody;
+            ItemsList itemsList = valuesStatement.getExpressions();
+            if (!(itemsList instanceof ExpressionList)) {
+                continue;
+            }
+            tryRemoveElms((ExpressionList) itemsList, ((ExpressionList) itemsList).getExpressions(),
+                    ExpressionList::setExpressions);
         }
     }
 }

--- a/src/sqlancer/transformations/RemoveRowsOfInsert.java
+++ b/src/sqlancer/transformations/RemoveRowsOfInsert.java
@@ -8,9 +8,10 @@ import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.statement.values.ValuesStatement;
 
 /**
- * This Transformer remove rows of insert. For example: INSERT INTO t1(c2, c0) VALUES (1508438260, 2929), (1508438260,
- * TIMESTAMP '1969-12-26 01:57:21'), (0.5347171705591047, 398662142); -> INSERT INTO t1 (c2, c0) VALUES
- * (0.5347171705591047, 398662142); might be reduced to INSERT INTO rt0 VALUES ('A');
+ * This Transformer remove rows of insert. Given a sql statement:
+ *
+ * INSERT INTO t1(c2, c0) VALUES (1508438260, 2929), (1508438260, TIMESTAMP '1969-12-26 01:57:21'), (0.5347171705591047,
+ * 398662142); -> INSERT INTO t1 (c2, c0) VALUES (0.5347171705591047, 398662142);
  */
 public class RemoveRowsOfInsert extends JSQLParserBasedTransformation {
     public RemoveRowsOfInsert() {

--- a/src/sqlancer/transformations/RemoveRowsOfInsert.java
+++ b/src/sqlancer/transformations/RemoveRowsOfInsert.java
@@ -1,0 +1,39 @@
+package sqlancer.transformations;
+
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.select.SelectBody;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.statement.values.ValuesStatement;
+
+/**
+ * This Transformer remove rows of insert. For example: INSERT INTO t1(c2, c0) VALUES (1508438260, 2929), (1508438260,
+ * TIMESTAMP '1969-12-26 01:57:21'), (0.5347171705591047, 398662142); -> INSERT INTO t1 (c2, c0) VALUES
+ * (0.5347171705591047, 398662142); might be reduced to INSERT INTO rt0 VALUES ('A');
+ */
+public class RemoveRowsOfInsert extends JSQLParserBasedTransformation {
+    public RemoveRowsOfInsert() {
+        super("remove rows of an insert statement");
+    }
+
+    @Override
+    public void apply() {
+        super.apply();
+        if (statement instanceof Insert) {
+            Insert insert = (Insert) statement;
+            SelectBody selectBody = insert.getSelect().getSelectBody();
+            if (selectBody instanceof SetOperationList) {
+                SetOperationList insertingList = (SetOperationList) selectBody;
+                for (SelectBody selBody : insertingList.getSelects()) {
+                    if (selBody instanceof ValuesStatement) {
+                        ValuesStatement valuesStatement = (ValuesStatement) selBody;
+                        if (valuesStatement.getExpressions() instanceof ExpressionList) {
+                            ExpressionList itemsList = (ExpressionList) valuesStatement.getExpressions();
+                            tryRemoveElms(itemsList, itemsList.getExpressions(), ExpressionList::setExpressions);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/sqlancer/transformations/RemoveUnions.java
+++ b/src/sqlancer/transformations/RemoveUnions.java
@@ -9,7 +9,9 @@ import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
 /**
- * try removing sub selects of a union statement e.g. select 1 union select 2 -> select 1
+ * try removing sub selects of a union statement.
+ *
+ * e.g. select 1 union select 2 -> select 1
  */
 
 public class RemoveUnions extends JSQLParserBasedTransformation {

--- a/src/sqlancer/transformations/RemoveUnions.java
+++ b/src/sqlancer/transformations/RemoveUnions.java
@@ -1,0 +1,50 @@
+package sqlancer.transformations;
+
+import java.util.List;
+
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectBody;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+
+/**
+ * try removing sub selects of a union statement e.g. select 1 union select 2 -> select 1
+ */
+
+public class RemoveUnions extends JSQLParserBasedTransformation {
+
+    private final SelectDeParser remover = new SelectDeParser() {
+        @Override
+        public void visit(SetOperationList list) {
+            List<SelectBody> selectBodyList = list.getSelects();
+            tryRemoveElms(list, selectBodyList, SetOperationList::setSelects);
+            super.visit(list);
+        }
+    };
+
+    public RemoveUnions() {
+        super("remove union selects");
+    }
+
+    @Override
+    public boolean init(String sql) {
+
+        boolean baseSuc = super.init(sql);
+        if (!baseSuc) {
+            return false;
+        }
+
+        this.remover.setExpressionVisitor(new ExpressionDeParser(remover, new StringBuilder()));
+        return true;
+    }
+
+    @Override
+    public void apply() {
+        super.apply();
+        if (statement instanceof Select) {
+            Select select = (Select) statement;
+            select.getSelectBody().accept(remover);
+        }
+    }
+}

--- a/src/sqlancer/transformations/RoundDoubleConstant.java
+++ b/src/sqlancer/transformations/RoundDoubleConstant.java
@@ -1,0 +1,74 @@
+package sqlancer.transformations;
+
+import java.text.DecimalFormat;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Round double values which are longer than a certain length. e.g. 2.4782565267 -> 2.478.
+ *
+ * This transformation is not based on JSQLParser.
+ */
+public class RoundDoubleConstant extends Transformation {
+
+    private Set<String> doubleValueCollector;
+
+    private String currentString;
+
+    private static final int ROUND_LENGTH = 3;
+    private DecimalFormat decimalFormat;
+
+    public RoundDoubleConstant() {
+        super("round double constant values");
+    }
+
+    @Override
+    public boolean init(String sql) {
+        super.init(sql);
+        decimalFormat = new DecimalFormat("#." + "#".repeat(ROUND_LENGTH));
+
+        currentString = sql;
+        doubleValueCollector = new HashSet<>();
+
+        String regex = "\\b-?\\d+\\.\\d+\\b";
+
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(sql);
+
+        while (matcher.find()) {
+            String matchedText = matcher.group();
+            String decimalPart = matchedText.replaceAll("\\d+\\.", "");
+            int decimalPlaces = decimalPart.length();
+            if (decimalPlaces > ROUND_LENGTH) {
+                doubleValueCollector.add(matchedText);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void apply() {
+        for (String doubleValue : doubleValueCollector) {
+
+            double targetNumber = Double.parseDouble(doubleValue);
+            String roundedNumberStr = decimalFormat.format(targetNumber);
+
+            String replacement = currentString.replace(doubleValue, roundedNumberStr);
+            String original = currentString;
+
+            tryReplace(null, original, replacement, (p, r) -> {
+                currentString = r;
+            });
+        }
+        super.apply();
+    }
+
+    @Override
+    protected void onStatementChanged() {
+        if (statementChangedHandler != null) {
+            statementChangedHandler.accept(currentString);
+        }
+    }
+}

--- a/src/sqlancer/transformations/SimplifyConstant.java
+++ b/src/sqlancer/transformations/SimplifyConstant.java
@@ -1,0 +1,105 @@
+package sqlancer.transformations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.jsqlparser.expression.DoubleValue;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+
+/**
+ * Shorten the constant of a statement e.g. "a_very_long_str" -> "", 12341234->1;
+ * <p>
+ * Note: Since the API of JSQLParser may have some problems with double values: when `setValue` is called, it doesn't
+ * change the string of the statement, double values are not handled here.
+ * <p>
+ * TODO: consider more candidate numbers or strings.
+ */
+public class SimplifyConstant extends JSQLParserBasedTransformation {
+    static class ConstantCollector extends ExpressionDeParser {
+        private final List<Expression> candidates = new ArrayList<>();
+
+        @Override
+        public void visit(DoubleValue doubleValue) {
+            candidates.add(doubleValue);
+            super.visit(doubleValue);
+        }
+
+        @Override
+        public void visit(LongValue longValue) {
+            candidates.add(longValue);
+            super.visit(longValue);
+        }
+
+        @Override
+        public void visit(StringValue stringValue) {
+            candidates.add(stringValue);
+            super.visit(stringValue);
+        }
+
+        public List<Expression> getCandidates() {
+            return candidates;
+        }
+    }
+
+    public SimplifyConstant() {
+        super("simplify constant expressions");
+    }
+
+    @Override
+    public void apply() {
+        super.apply();
+        ConstantCollector collector = new ConstantCollector();
+        StringBuilder buffer = new StringBuilder();
+        SelectDeParser collectorDeParser = new SelectDeParser(collector, buffer);
+        collector.setSelectVisitor(collectorDeParser);
+        collector.setBuffer(buffer);
+
+        List<Expression> candidates = collector.getCandidates();
+
+        StatementVisitorAdapter statementVisitor = new StatementVisitorAdapter() {
+            @Override
+            public void visit(Insert insert) {
+                insert.getSelect().getSelectBody().accept(collectorDeParser);
+                super.visit(insert);
+            }
+
+            @Override
+            public void visit(Select select) {
+                select.getSelectBody().accept(collectorDeParser);
+                super.visit(select);
+            }
+        };
+
+        statement.accept(statementVisitor);
+
+        for (Expression e : candidates) {
+            if (e instanceof LongValue) {
+                simplify((LongValue) e);
+            } else if (e instanceof StringValue) {
+                simplify((StringValue) e);
+            }
+        }
+    }
+
+    private void simplify(LongValue longValue) {
+        long variant = 0;
+        if (!longValue.getStringValue().equals(String.valueOf(variant))) {
+            tryReplace(longValue, longValue.getStringValue(), String.valueOf(variant), LongValue::setStringValue);
+        }
+    }
+
+    private void simplify(StringValue stringValue) {
+        String variant = "";
+        if (!stringValue.getValue().equals(variant)) {
+            tryReplace(stringValue, stringValue.getValue(), variant, StringValue::setValue);
+        }
+    }
+
+}

--- a/src/sqlancer/transformations/SimplifyConstant.java
+++ b/src/sqlancer/transformations/SimplifyConstant.java
@@ -14,12 +14,9 @@ import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
 /**
- * Shorten the constant of a statement e.g. "a_very_long_str" -> "", 12341234->1;
- * <p>
- * Note: Since the API of JSQLParser may have some problems with double values: when `setValue` is called, it doesn't
- * change the string of the statement, double values are not handled here.
- * <p>
- * TODO: consider more candidate numbers or strings.
+ * Shorten the constant of a statement e.g. "a_very_long_str" -> "", 12341234->1; Note: The API of JSQLParser may have
+ * some problems with double values: `setValue` can't change the literal value of a DoubleValue object. Therefore,
+ * double values are not handled here. TODO: consider more candidate numbers or strings.
  */
 public class SimplifyConstant extends JSQLParserBasedTransformation {
     static class ConstantCollector extends ExpressionDeParser {
@@ -96,7 +93,7 @@ public class SimplifyConstant extends JSQLParserBasedTransformation {
     }
 
     private void simplify(StringValue stringValue) {
-        String variant = "";
+        String variant = "_";
         if (!stringValue.getValue().equals(variant)) {
             tryReplace(stringValue, stringValue.getValue(), variant, StringValue::setValue);
         }

--- a/src/sqlancer/transformations/SimplifyConstant.java
+++ b/src/sqlancer/transformations/SimplifyConstant.java
@@ -14,9 +14,10 @@ import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 
 /**
- * Shorten the constant of a statement e.g. "a_very_long_str" -> "", 12341234->1; Note: The API of JSQLParser may have
- * some problems with double values: `setValue` can't change the literal value of a DoubleValue object. Therefore,
- * double values are not handled here. TODO: consider more candidate numbers or strings.
+ * Shorten the constant of a statement e.g. "a_very_long_str" -> "_", 12341234->1.
+ *
+ * Note: The API of JSQLParser may have some problems with double values: `setValue` can't change the literal value of a
+ * DoubleValue object. Therefore, double values are handled at RoundDoubleConstant class.
  */
 public class SimplifyConstant extends JSQLParserBasedTransformation {
     static class ConstantCollector extends ExpressionDeParser {

--- a/src/sqlancer/transformations/SimplifyExpressions.java
+++ b/src/sqlancer/transformations/SimplifyExpressions.java
@@ -1,0 +1,98 @@
+package sqlancer.transformations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import net.sf.jsqlparser.expression.BinaryExpression;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Parenthesis;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+
+/**
+ * This transformation simplifies complicated expressions e.g: a + (b + c) -> b.
+ */
+
+public class SimplifyExpressions extends JSQLParserBasedTransformation {
+    public SimplifyExpressions() {
+        super("simplify expressions. e.g. a + b -> a");
+    }
+
+    @Override
+    public boolean init(String sql) {
+        boolean baseSuc = super.init(sql);
+        if (!baseSuc) {
+            return false;
+        }
+        this.simplifier.setExpressionVisitor(expressionHandler);
+        this.expressionHandler.setSelectVisitor(simplifier);
+        return true;
+    }
+
+    private final ExpressionDeParser expressionHandler = new ExpressionDeParser() {
+        @Override
+        protected void visitBinaryExpression(BinaryExpression binaryExpression, String operator) {
+
+            Expression lhs = binaryExpression.getLeftExpression();
+            Expression rhs = binaryExpression.getRightExpression();
+
+            handleExpression(binaryExpression, lhs, BinaryExpression::setLeftExpression);
+            handleExpression(binaryExpression, rhs, BinaryExpression::setRightExpression);
+
+            super.visitBinaryExpression(binaryExpression, operator);
+        }
+
+    };
+    private final SelectDeParser simplifier = new SelectDeParser() {
+
+        @Override
+        public void visit(PlainSelect plainSelect) {
+            handleSelect(plainSelect);
+            super.visit(plainSelect);
+        }
+    };
+
+    @Override
+    public void apply() {
+        super.apply();
+        if (statement instanceof Select) {
+            Select select = (Select) statement;
+            select.getSelectBody().accept(simplifier);
+        }
+    }
+
+    private void handleSelect(PlainSelect plainSelect) {
+        Expression where = plainSelect.getWhere();
+        if (where != null) {
+            handleExpression(plainSelect, where, PlainSelect::setWhere);
+        }
+        Expression having = plainSelect.getHaving();
+        if (having != null) {
+            handleExpression(plainSelect, having, PlainSelect::setHaving);
+        }
+    }
+
+    private List<Expression> flattenExpression(Expression expression) {
+        if (expression instanceof BinaryExpression) {
+            BinaryExpression binaryExpression = (BinaryExpression) expression;
+            return List.of(binaryExpression.getLeftExpression(), binaryExpression.getRightExpression());
+        } else if (expression instanceof Parenthesis) {
+            return List.of(((Parenthesis) expression).getExpression());
+        }
+        return new ArrayList<>();
+    }
+
+    private <P> void handleExpression(P parent, Expression expr, BiConsumer<P, Expression> setter) {
+
+        List<Expression> expressions = flattenExpression(expr);
+        for (Expression variant : expressions) {
+            boolean suc = tryReplace(parent, expr, variant, setter);
+            if (suc) {
+                break;
+            }
+        }
+    }
+}

--- a/src/sqlancer/transformations/Transformation.java
+++ b/src/sqlancer/transformations/Transformation.java
@@ -16,10 +16,6 @@ public class Transformation {
     protected boolean isChanged;
     String current;
     Statement statement;
-    // public enum StatusCode {
-    // FAIL, SUCCESS, TERMINATE
-    // }
-    // private String name = "";
     private String desc = "";
 
     public Transformation(String desc) {

--- a/src/sqlancer/transformations/Transformation.java
+++ b/src/sqlancer/transformations/Transformation.java
@@ -13,10 +13,12 @@ import net.sf.jsqlparser.statement.Statement;
 public class Transformation {
 
     private static Supplier<Boolean> bugJudgement;
+    private static long reduceSteps;
+
     protected boolean isChanged;
-    String current;
-    Statement statement;
-    private String desc = "";
+    protected String current;
+    protected Statement statement;
+    protected String desc = "";
 
     public Transformation(String desc) {
         this.desc = desc;
@@ -48,6 +50,7 @@ public class Transformation {
             onStatementChanged();
             return false;
         }
+        reduceSteps++;
         isChanged = true;
         return true;
     }
@@ -60,6 +63,7 @@ public class Transformation {
             onStatementChanged();
             return false;
         }
+        reduceSteps++;
         isChanged = true;
         return true;
     }
@@ -82,6 +86,7 @@ public class Transformation {
             }
             isChanged |= observeChange;
             setter.accept(parent, elms);
+            reduceSteps++;
             onStatementChanged();
         } while (observeChange);
 
@@ -107,6 +112,11 @@ public class Transformation {
         return isChanged;
     }
 
+    public static long getReduceSteps() {
+        return reduceSteps;
+    }
+
     protected void onStatementChanged() {
     }
+
 }

--- a/src/sqlancer/transformations/Transformation.java
+++ b/src/sqlancer/transformations/Transformation.java
@@ -1,0 +1,116 @@
+package sqlancer.transformations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import net.sf.jsqlparser.statement.Statement;
+
+/**
+ * The base class of transformations Defines APIs to remove, replace, remove elements of a list.
+ */
+public class Transformation {
+
+    private static Supplier<Boolean> bugJudgement;
+    protected boolean isChanged;
+    String current;
+    Statement statement;
+    // public enum StatusCode {
+    // FAIL, SUCCESS, TERMINATE
+    // }
+    // private String name = "";
+    private String desc = "";
+
+    public Transformation(String desc) {
+        this.desc = desc;
+    }
+
+    @SuppressWarnings("unused")
+    protected Transformation() {
+    }
+
+    public static void setBugJudgement(Supplier<Boolean> judgement) {
+        bugJudgement = judgement;
+    }
+
+    @Override
+    public String toString() {
+        return desc;
+    }
+
+    public boolean init(String sql) {
+        isChanged = false;
+        return true;
+    }
+
+    public <P, T> boolean tryRemove(P parent, T target, BiConsumer<P, T> setter) {
+        setter.accept(parent, null);
+        onStatementChanged();
+        if (!bugStillTriggers()) {
+            setter.accept(parent, target);
+            onStatementChanged();
+            return false;
+        }
+        isChanged = true;
+        return true;
+    }
+
+    public <P, T> boolean tryReplace(P parent, T original, T vari, BiConsumer<P, T> setter) {
+        setter.accept(parent, vari);
+        onStatementChanged();
+        if (!bugStillTriggers()) {
+            setter.accept(parent, original);
+            onStatementChanged();
+            return false;
+        }
+        isChanged = true;
+        return true;
+    }
+
+    public <P, T> void tryRemoveElms(P parent, List<T> elms, // NOPMD
+            BiConsumer<P, List<T>> setter) {
+        boolean observeChange;
+        do {
+            observeChange = false;
+            for (int i = elms.size() - 1; i >= 0; i--) {
+                List<T> reducedElms = new ArrayList<>(elms);
+                reducedElms.subList(i, i + 1).clear();
+                setter.accept(parent, reducedElms);
+                onStatementChanged();
+                if (bugStillTriggers()) {
+                    elms = reducedElms;
+                    onStatementChanged();
+                    observeChange = true;
+                }
+            }
+            isChanged |= observeChange;
+            setter.accept(parent, elms);
+            onStatementChanged();
+        } while (observeChange);
+
+    }
+
+    public boolean bugStillTriggers() {
+        try {
+            return Transformation.bugJudgement.get();
+        } catch (Exception ignored) {
+        }
+        return false;
+    }
+
+    public void apply() {
+        isChanged = false;
+    }
+
+    public String getResult() {
+        return statement.toString();
+    }
+
+    public boolean changed() {
+        return isChanged;
+    }
+
+    protected void onStatementChanged() {
+    }
+}

--- a/src/sqlancer/transformations/Transformation.java
+++ b/src/sqlancer/transformations/Transformation.java
@@ -3,12 +3,11 @@ package sqlancer.transformations;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import net.sf.jsqlparser.statement.Statement;
-
 /**
- * The base class of transformations Defines APIs to remove, replace, remove elements of a list.
+ * The base class of transformations. Defines APIs to remove, replace, remove elements of a list.
  */
 public class Transformation {
 
@@ -17,8 +16,9 @@ public class Transformation {
 
     protected boolean isChanged;
     protected String current;
-    protected Statement statement;
     protected String desc = "";
+
+    protected Consumer<String> statementChangedHandler;
 
     public Transformation(String desc) {
         this.desc = desc;
@@ -104,10 +104,6 @@ public class Transformation {
         isChanged = false;
     }
 
-    public String getResult() {
-        return statement.toString();
-    }
-
     public boolean changed() {
         return isChanged;
     }
@@ -117,6 +113,10 @@ public class Transformation {
     }
 
     protected void onStatementChanged() {
+    }
+
+    public void setStatementChangedCallBack(Consumer<String> statementChangedHandler) {
+        this.statementChangedHandler = statementChangedHandler;
     }
 
 }

--- a/test/sqlancer/reducer/TestASTBasedReducer.java
+++ b/test/sqlancer/reducer/TestASTBasedReducer.java
@@ -5,12 +5,15 @@ import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import org.junit.jupiter.api.Test;
 import sqlancer.common.query.Query;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestASTBasedReducer {
     @Test
-    void testLongStatement() throws Exception {
+    void testRemovingClauses() throws Exception {
         TestEnvironment env = TestEnvironment.getASTBasedReducerEnv();
 
         String[] queriesStr = {
@@ -27,8 +30,8 @@ public class TestASTBasedReducer {
         });
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStr));
-        System.out.println(reducedResult);
+        String outcome = TestEnvironment.getQueriesString(reducedResult);
+        assertEquals(outcome, "SELECT * FROM v0 WHERE v0.c && v0.c;");
     }
 
     @Test
@@ -49,8 +52,7 @@ public class TestASTBasedReducer {
         });
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStr));
-        System.out.println(reducedResult);
+        assertEquals(TestEnvironment.getQueriesString(reducedResult), "SELECT row_id FROM v0 WHERE v0.rowid || 0;");
     }
 
     @Test
@@ -75,12 +77,12 @@ public class TestASTBasedReducer {
         });
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStrs));
-        System.out.println(reducedResult);
+        assertEquals(TestEnvironment.getQueriesString(reducedResult),
+                "SELECT row_id FROM v0;\nSELECT row_id FROM v0 UNION SELECT * FROM v0;");
     }
 
     @Test
-    void testJoin() throws Exception {
+    void removeJoins() throws Exception {
         TestEnvironment env = TestEnvironment.getASTBasedReducerEnv();
 
         String[] queriesStrs = { "SELECT * FROM t0, t1, t2, t3, t4 Where t2.val = t1.val" };
@@ -93,14 +95,18 @@ public class TestASTBasedReducer {
             } catch (JSQLParserException e) {
                 return false;
             }
-
             String queriesString = TestEnvironment.getQueriesString(statements);
-            return queriesString.contains("t1") && queriesString.contains("WHERE");
+            if (!queriesString.contains("WHERE")) {
+                return false;
+            }
+            String[] split = queriesString.split("WHERE");
+            String columns = split[0];
+            String condition = split[1];
+            return columns.contains("t1") && condition.contains("t1");
         });
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStrs));
-        System.out.println(reducedResult);
+        assertEquals(TestEnvironment.getQueriesString(reducedResult), "SELECT * FROM t0, t1 WHERE t1.val;");
     }
 
     @Test
@@ -110,7 +116,7 @@ public class TestASTBasedReducer {
         String[] queriesStrs = {
                 "SELECT STRING_AGG(v0.c2) FROM t0, v0 WHERE (CASE true WHEN (ABS(true) BETWEEN (v0.c0 LIKE NULL ESCAPE v0.c2) AND (DATE '1970-01-23' NOT IN (v0.c2))) THEN (0.07914839711718646 NOT BETWEEN '' AND ((v0.c0)OR(v0.c2))) WHEN v0.c1 THEN ((v0.c1)-(v0.c0)) WHEN t0.c1 THEN (TIMESTAMP '1969-12-29 20:22:33' IN (PI(), v0.c2, (v0.c1 BETWEEN '' AND v0.rowid))) WHEN v0.c1 THEN TIMESTAMP '1969-12-16 17:24:43' WHEN ((((v0.c1)-(t0.c0)))||(t0.c0)) THEN true ELSE ((0.279978719843174)/(((v0.c1)>(DATE '1969-12-19')))) END ) GROUP BY ((DATE '1970-01-24') IS NULL), t0.c1, (CASE (v0.c1 LIKE ((0.9833120083624495)SIMILAR TO(t0.rowid)) ESCAPE CEIL(TIMESTAMP '1970-01-11 16:38:26')) WHEN t0.rowid THEN 0.27742217994251717 ELSE ((v0.c0) IS NOT NULL) END );" };
         env.setInitialStatementsFromStrings(List.of(queriesStrs));
-        env.setBugInducingCondition(statements -> {
+        Function<List<Query<?>>, Boolean> condition = statements -> {
             String queriesString = TestEnvironment.getQueriesString(statements);
             try {
                 CCJSqlParserUtil.parse(queriesString);
@@ -118,19 +124,18 @@ public class TestASTBasedReducer {
                 return false;
             }
             return queriesString.toUpperCase().contains("CASE");
-        });
+        };
+        env.setBugInducingCondition(condition);
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStrs));
-        System.out.println(reducedResult);
+        assertTrue(condition.apply(reducedResult));
     }
 
     @Test
-    void testConstantVar() throws Exception {
+    void testSimplifyingConstantStringValue() throws Exception {
         TestEnvironment env = TestEnvironment.getASTBasedReducerEnv();
 
-        String[] queriesStrs = {
-                "SELECT * FROM t0 GROUP BY ( (CASE (t0.rowid) WHEN t0.rowid THEN 27742217994251717 ELSE ((v0.c0) IS NOT NULL) END) )" };
+        String[] queriesStrs = { "SELECT * FROM t0 WHERE v LIKE '[vQ3㭫oQ';" };
         env.setInitialStatementsFromStrings(List.of(queriesStrs));
         env.setBugInducingCondition(statements -> {
             try {
@@ -142,12 +147,34 @@ public class TestASTBasedReducer {
             }
 
             String queriesString = TestEnvironment.getQueriesString(statements);
-            return queriesString.toUpperCase().contains("CASE");
+            return queriesString.contains("LIKE");
         });
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStrs));
-        System.out.println(reducedResult);
+        assertEquals("SELECT * FROM t0 WHERE v LIKE '_';", TestEnvironment.getQueriesString(reducedResult));
+    }
+
+    @Test
+    void testSimplifyingConstantLongValue() throws Exception {
+        TestEnvironment env = TestEnvironment.getASTBasedReducerEnv();
+
+        String[] queriesStrs = { "SELECT * FROM t0 where t0.v = 314598267;" };
+        env.setInitialStatementsFromStrings(List.of(queriesStrs));
+        env.setBugInducingCondition(statements -> {
+            try {
+                for (Query<?> s : statements) {
+                    CCJSqlParserUtil.parse(s.getQueryString());
+                }
+            } catch (JSQLParserException e) {
+                return false;
+            }
+
+            String queriesString = TestEnvironment.getQueriesString(statements);
+            return queriesString.contains("t0.v = ");
+        });
+        env.runReduce();
+        List<Query<?>> reducedResult = env.getReducedStatements();
+        assertEquals("SELECT * FROM t0 WHERE t0.v = 0", TestEnvironment.getQueriesString(reducedResult));
     }
 
     @Test
@@ -155,9 +182,7 @@ public class TestASTBasedReducer {
         TestEnvironment env = TestEnvironment.getASTBasedReducerEnv();
 
         String[] queriesStrs = {
-                // "SELECT AVG(sum_column1) FROM (SELECT SUM(column1) AS sum_column1 FROM t1 GROUP BY column1 LIMIT 32
-                // OFFSET 128) AS t1;",
-                "WITH cte1 AS (SELECT a, b FROM table1), cte2 AS (SELECT c, d FROM table2) SELECT b, d FROM cte1 JOIN cte2 WHERE cte1.a = cte2.c" };
+                "SELECT AVG(c0) FROM (SELECT SUM(c1) AS c0 FROM t1 GROUP BY c2 LIMIT 32 OFFSET 128) AS t1;" };
         env.setInitialStatementsFromStrings(List.of(queriesStrs));
         env.setBugInducingCondition(statements -> {
             String queriesString = TestEnvironment.getQueriesString(statements);
@@ -168,12 +193,12 @@ public class TestASTBasedReducer {
             } catch (JSQLParserException e) {
                 return false;
             }
-            return queriesString.contains("cte2");
+            return queriesString.contains("AVG");
         });
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStrs));
-        System.out.println(reducedResult);
+        assertEquals("SELECT AVG(c0) FROM (SELECT SUM(c1) AS c0 FROM t1) AS t1;",
+                TestEnvironment.getQueriesString(reducedResult));
     }
 
     @Test
@@ -190,12 +215,12 @@ public class TestASTBasedReducer {
             } catch (JSQLParserException e) {
                 return false;
             }
-            return queriesString.toUpperCase().contains("0.5347171705591047");
+            return queriesString.contains("(0.5347171705591047, 398662142)");
         });
         env.runReduce();
         List<Query<?>> reducedResult = env.getReducedStatements();
-        System.out.println(Arrays.toString(queriesStrs));
-        System.out.println(reducedResult);
+        assertEquals("INSERT INTO t1 (c2, c0) VALUES (0.5347171705591047, 398662142);",
+                TestEnvironment.getQueriesString(reducedResult));
     }
 
 }


### PR DESCRIPTION
* different kinds of transformers are defined separately, making the reducer more extenable.
  * To define different types of transformations, you simply need to create classes that inherit from `Transformation` and implement specific logic. The `Transformation` class defines some common APIs such as `tryRemove`, `tryReduce`.
  * Currently, the implemented transformations are based on JSQLParser, so they all inherit from `JSQLParserBasedTransformation`, which interacts with JSQLParser. However, It is possible to define transformations not based on this tool since the `Transformation` class doesn't rely on it.
* add options to enable AST Based Reducer