### PR TITLE
Add support for Presto

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ Since SQL dialects differ widely, each DBMS to be tested requires a separate imp
 | TDEngine                     | Removed     | Untyped                      | We removed the TDEngine implementation since all but one of our bug reports were still unaddressed five months after we reported them.                                                          |
 | OceanBase                    | Working     | Untyped                      |                                                                                                                                                                                                 |
 | YugabyteDB                   | Working     | Typed (YSQL), Untyped (YCQL) | YSQL implementation based on Postgres code. YCQL implementation is primitive for now and uses Cassandra JDBC driver as a proxy interface.                                                       |
-| Databend                    | Working     | Typed                      |  |
-| QuestDB                    | Working     | Untyped, Generic                      | The implementation of QuestDB is still WIP, current version covers very basic data types, operations and SQL keywords. |
+| Databend                     | Working     | Typed                      |  |
+| QuestDB                      | Working     | Untyped, Generic                      | The implementation of QuestDB is still WIP, current version covers very basic data types, operations and SQL keywords. |
 | CnosDB                       |Working      | Typed                        | The implementation of CnosDB currently uses Restful API.                                                                                                                                        |
 | Materialize                  |Working      | Typed                        |
-| Apache Doris                      | Preliminary | Typed                   | This is a preliminary implementation, which only contains the common logic of Doris. We have found some errors through it, and hope to improve it in the future.
+| Apache Doris                 | Preliminary | Typed                   | This is a preliminary implementation, which only contains the common logic of Doris. We have found some errors through it, and hope to improve it in the future.
+| Presto                       | Preliminary | Typed                   | This is a preliminary implementation, only basic types supported. 
+
 
 
 # Using SQLancer

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,11 @@
       <version>0.5.1</version>
     </dependency>
     <dependency>
+      <groupId>com.facebook.presto</groupId>
+      <artifactId>presto-jdbc</artifactId>
+      <version>0.283</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.9.1</version>

--- a/src/check_names.py
+++ b/src/check_names.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
     name_to_files["MySQL"] = get_java_files(os.path.join(cwd, "src", "sqlancer", "mysql"))
     name_to_files["OceanBase"] = get_java_files(os.path.join(cwd, "src", "sqlancer", "oceanbase"))
     name_to_files["Postgres"] = get_java_files(os.path.join(cwd, "src", "sqlancer", "postgres"))
+    name_to_files["Presto"] = get_java_files(os.path.join(cwd, "src", "sqlancer", "presto"))
     name_to_files["QuestDB"] = get_java_files(os.path.join(cwd, "src", "sqlancer", "questdb"))
     name_to_files["SQLite3"] = get_java_files(os.path.join(cwd, "src", "sqlancer", "sqlite3"))
     name_to_files["TiDB"] = get_java_files(os.path.join(cwd, "src", "sqlancer", "tidb"))

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -43,6 +43,7 @@ import sqlancer.mongodb.MongoDBProvider;
 import sqlancer.mysql.MySQLProvider;
 import sqlancer.oceanbase.OceanBaseProvider;
 import sqlancer.postgres.PostgresProvider;
+import sqlancer.presto.PrestoProvider;
 import sqlancer.questdb.QuestDBProvider;
 import sqlancer.sqlite3.SQLite3Provider;
 import sqlancer.stonedb.StoneDBProvider;
@@ -719,6 +720,7 @@ public final class Main {
             providers.add(new MongoDBProvider());
             providers.add(new MySQLProvider());
             providers.add(new OceanBaseProvider());
+            providers.add(new PrestoProvider());
             providers.add(new PostgresProvider());
             providers.add(new QuestDBProvider());
             providers.add(new SQLite3Provider());

--- a/src/sqlancer/presto/PrestoConstantUtils.java
+++ b/src/sqlancer/presto/PrestoConstantUtils.java
@@ -1,0 +1,40 @@
+package sqlancer.presto;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public final class PrestoConstantUtils {
+
+    private PrestoConstantUtils() {
+    }
+
+    public static String removeNoneAscii(String str) {
+        return str.replaceAll("[^\\x00-\\x7F]", "");
+    }
+
+    public static String removeNonePrintable(String str) { // All Control Char
+        return str.replaceAll("[\\p{C}]", "");
+    }
+
+    public static String removeOthersControlChar(String str) { // Some Control Char
+        return str.replaceAll("[\\p{Cntrl}\\p{Cc}\\p{Cf}\\p{Co}\\p{Cn}]", "");
+    }
+
+    public static String removeAllControlChars(String str) {
+        return removeOthersControlChar(removeNonePrintable(str)).replaceAll("[\\r\\n\\t]", "");
+    }
+
+    public static BigDecimal getDecimal(double val, int scale, int precision) {
+        int part = precision - scale;
+        // long part
+        long lng = (long) val;
+        // decimal places
+        double d1 = val - lng;
+        String xStr = Long.toString(lng);
+        String substring = xStr.substring(xStr.length() - part);
+        long newX = substring.isEmpty() ? 0 : Long.parseLong(substring);
+        double finalD = newX + d1;
+        return new BigDecimal(finalD).setScale(scale, RoundingMode.CEILING);
+    }
+
+}

--- a/src/sqlancer/presto/PrestoErrors.java
+++ b/src/sqlancer/presto/PrestoErrors.java
@@ -1,0 +1,127 @@
+package sqlancer.presto;
+
+import sqlancer.common.query.ExpectedErrors;
+
+public final class PrestoErrors {
+
+    private PrestoErrors() {
+    }
+
+    public static void addExpressionErrors(ExpectedErrors errors) {
+        // Presto errors
+        errors.add("cannot be applied to");
+        errors.add("LIKE expression must evaluate to a varchar");
+        errors.add("JOIN ON clause must evaluate to a boolean");
+        // errors.add("Unexpected parameters");
+
+        // SELECT SUM(count) FROM (SELECT
+        // CAST((-179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0000
+        // IS NOT NULL AND
+        // -179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0000)
+        // AS BIGINT)as count FROM t0) as res
+        errors.add("Decimal overflow");
+        errors.add("multiplication overflow");
+        errors.add("addition overflow");
+        errors.add("subtraction overflow");
+
+        // cast
+        // errors.add("Cannot cast");
+        errors.add("Value cannot be cast to");
+        errors.add("Cannot cast DECIMAL");
+        errors.add("Cannot cast BIGINT");
+        errors.add("Cannot cast INTEGER");
+
+        // TODO: check
+        errors.add("io.airlift.slice.Slice cannot be cast to java.lang.Number");
+        errors.add("Cannot cast java.lang.Long to io.airlift.slice.Slice");
+        errors.add("Unexpected subquery expression in logical plan");
+
+        // 9223372036854775808
+        errors.add("Invalid numeric literal");
+
+        errors.add("Division by zero");
+        errors.add("/ by zero");
+
+        errors.add("Cannot subtract hour, minutes or seconds from a date");
+        errors.add("Cannot add hour, minutes or seconds to a date");
+
+        errors.add("DECIMAL scale must be in range");
+        errors.add("multiplication overflow");
+        errors.add("addition overflow");
+        errors.add("subtraction overflow");
+        errors.add("Decimal overflow");
+        errors.add("IN value and list items must be the same type");
+        errors.add("is not a valid timestamp literal");
+        errors.add("Unknown time-zone ID");
+        errors.add("GROUP BY position");
+
+        // ARRAY
+        errors.add("Unknown type: ARRAY");
+    }
+
+    private static void addRegexErrors(ExpectedErrors errors) {
+        errors.add("missing ]");
+        errors.add("missing )");
+        errors.add("invalid escape sequence");
+        errors.add("no argument for repetition operator: ");
+        errors.add("bad repetition operator");
+        errors.add("trailing \\");
+        errors.add("invalid perl operator");
+        errors.add("invalid character class range");
+        errors.add("width is not integer");
+    }
+
+    private static void addFunctionErrors(ExpectedErrors errors) {
+        errors.add("SUBSTRING cannot handle negative lengths");
+        errors.add("is undefined outside [-1,1]"); // ACOS etc
+        errors.add("invalid type specifier"); // PRINTF
+        errors.add("argument index out of range"); // PRINTF
+        errors.add("invalid format string"); // PRINTF
+        errors.add("number is too big"); // PRINTF
+        errors.add("Like pattern must not end with escape character!"); // LIKE
+        errors.add("Could not choose a best candidate function for the function call \"date_part"); // date_part
+        errors.add("extract specifier"); // date_part
+        errors.add("not recognized"); // date_part
+        errors.add("not supported"); // date_part
+        errors.add("Failed to cast");
+        errors.add("Conversion Error");
+        errors.add("Could not cast value");
+        errors.add("Insufficient padding in RPAD"); // RPAD
+        errors.add("Could not choose a best candidate function for the function call"); // monthname
+        errors.add("expected a numeric precision field"); // ROUND
+        errors.add("with non-constant precision is not supported"); // ROUND
+    }
+
+    // TODO: cover presto error
+    public static void addInsertErrors(ExpectedErrors errors) {
+        addRegexErrors(errors);
+        addFunctionErrors(errors);
+
+        errors.add("NOT NULL constraint failed");
+        errors.add("PRIMARY KEY or UNIQUE constraint violated");
+        errors.add("duplicate key");
+        errors.add("can't be cast because the value is out of range for the destination type");
+        errors.add("Could not convert string");
+        errors.add("Unimplemented type for cast");
+        errors.add("field value out of range");
+        errors.add("CHECK constraint failed");
+        errors.add("Cannot explicitly insert values into rowid column"); // TODO: don't insert into rowid
+        errors.add(" Column with name rowid does not exist!"); // currently, there doesn't seem to way to determine if
+        // the table has a primary key
+        errors.add("Could not cast value");
+        errors.add("create unique index, table contains duplicate data");
+        errors.add("Failed to cast");
+
+        errors.add("Values rows have mismatched types");
+        errors.add("Mismatch at column");
+        errors.add("This connector does not support updates or deletes");
+        errors.add("Values rows have mismatched types");
+        errors.add("Invalid numeric literal");
+
+    }
+
+    public static void addGroupByErrors(ExpectedErrors errors) {
+        errors.add("must be an aggregate expression or appear in GROUP BY clause");
+    }
+
+}

--- a/src/sqlancer/presto/PrestoExpressionToNode.java
+++ b/src/sqlancer/presto/PrestoExpressionToNode.java
@@ -1,0 +1,25 @@
+package sqlancer.presto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.ast.PrestoExpression;
+
+public final class PrestoExpressionToNode {
+
+    private PrestoExpressionToNode() {
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Node<PrestoExpression> cast(PrestoExpression expression) {
+        return (Node<PrestoExpression>) expression;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<Node<PrestoExpression>> casts(List<PrestoExpression> expressions) {
+        return expressions.stream().map(e -> (Node<PrestoExpression>) e).collect(Collectors.toList());
+    }
+
+}

--- a/src/sqlancer/presto/PrestoGlobalState.java
+++ b/src/sqlancer/presto/PrestoGlobalState.java
@@ -1,0 +1,13 @@
+package sqlancer.presto;
+
+import java.sql.SQLException;
+
+import sqlancer.SQLGlobalState;
+
+public class PrestoGlobalState extends SQLGlobalState<PrestoOptions, PrestoSchema> {
+
+    @Override
+    protected PrestoSchema readSchema() throws SQLException {
+        return PrestoSchema.fromConnection(getConnection(), getDatabaseName());
+    }
+}

--- a/src/sqlancer/presto/PrestoOptions.java
+++ b/src/sqlancer/presto/PrestoOptions.java
@@ -1,0 +1,166 @@
+package sqlancer.presto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+import sqlancer.DBMSSpecificOptions;
+import sqlancer.OracleFactory;
+import sqlancer.common.oracle.CompositeTestOracle;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.presto.test.PrestoNoRECOracle;
+import sqlancer.presto.test.PrestoQueryPartitioningAggregateTester;
+import sqlancer.presto.test.PrestoQueryPartitioningDistinctTester;
+import sqlancer.presto.test.PrestoQueryPartitioningGroupByTester;
+import sqlancer.presto.test.PrestoQueryPartitioningHavingTester;
+import sqlancer.presto.test.PrestoQueryPartitioningWhereTester;
+
+@Parameters(commandDescription = "Presto")
+public class PrestoOptions implements DBMSSpecificOptions<PrestoOptions.PrestoOracleFactory> {
+
+    public static final String DEFAULT_HOST = "localhost";
+    public static final int DEFAULT_PORT = 8080;
+
+    @Parameter(names = "--test-collate", arity = 1)
+    public boolean testCollate = true;
+
+    @Parameter(names = "--test-check", description = "Allow generating CHECK constraints in tables", arity = 1)
+    public boolean testCheckConstraints = true;
+
+    @Parameter(names = "--test-default-values", description = "Allow generating DEFAULT values in tables", arity = 1)
+    public boolean testDefaultValues = true;
+
+    @Parameter(names = "--test-not-null", description = "Allow generating NOT NULL constraints in tables", arity = 1)
+    public boolean testNotNullConstraints = true;
+
+    @Parameter(names = "--test-functions", description = "Allow generating functions in expressions", arity = 1)
+    public boolean testFunctions = true;
+
+    @Parameter(names = "--test-casts", description = "Allow generating casts in expressions", arity = 1)
+    public boolean testCasts = true;
+
+    @Parameter(names = "--test-between", description = "Allow generating the BETWEEN operator in expressions (FALSE by default : Presto null handling in BETWEEN operator : https://prestodb.io/docs/current/functions/comparison.html )", arity = 1)
+    public boolean testBetween;
+
+    @Parameter(names = "--test-in", description = "Allow generating the IN operator in expressions", arity = 1)
+    public boolean testIn = true;
+
+    @Parameter(names = "--test-case", description = "Allow generating the CASE operator in expressions", arity = 1)
+    public boolean testCase = true;
+
+    @Parameter(names = "--test-binary-logicals", description = "Allow generating AND and OR in expressions", arity = 1)
+    public boolean testBinaryLogicals = true;
+
+    @Parameter(names = "--test-int-constants", description = "Allow generating INTEGER constants", arity = 1)
+    public boolean testIntConstants = true;
+
+    @Parameter(names = "--test-varchar-constants", description = "Allow generating VARCHAR constants", arity = 1)
+    public boolean testStringConstants = true;
+
+    @Parameter(names = "--test-time-constants", description = "Allow generating DATE constants", arity = 1)
+    public boolean testDateConstants = true;
+
+    @Parameter(names = "--test-date-constants", description = "Allow generating DATE constants", arity = 1)
+    public boolean testTimeConstants = true;
+
+    @Parameter(names = "--test-timestamp-constants", description = "Allow generating TIMESTAMP constants", arity = 1)
+    public boolean testTimestampConstants = true;
+
+    @Parameter(names = "--test-float-constants", description = "Allow generating floating-point constants", arity = 1)
+    public boolean testFloatConstants = true;
+
+    @Parameter(names = "--test-boolean-constants", description = "Allow generating boolean constants", arity = 1)
+    public boolean testBooleanConstants = true;
+
+    @Parameter(names = "--test-binary-comparisons", description = "Allow generating binary comparison operators (e.g., >= or LIKE)", arity = 1)
+    public boolean testBinaryComparisons = true;
+
+    @Parameter(names = "--test-indexes", description = "Allow explicit (i.e. CREATE INDEX) and implicit (i.e., UNIQUE and PRIMARY KEY) indexes", arity = 1)
+    public boolean testIndexes = true;
+
+    @Parameter(names = "--test-rowid", description = "Test tables' rowid columns", arity = 1)
+    public boolean testRowid = true;
+
+    @Parameter(names = "--max-num-views", description = "The maximum number of views that can be generated for a database", arity = 1)
+    public int maxNumViews = 1;
+
+    @Parameter(names = "--max-num-deletes", description = "The maximum number of DELETE statements that are issued for a database", arity = 1)
+    public int maxNumDeletes = 1;
+
+    @Parameter(names = "--max-num-updates", description = "The maximum number of UPDATE statements that are issued for a database", arity = 1)
+    public int maxNumUpdates = 5;
+
+    @Parameter(names = "--oracle")
+    public List<PrestoOracleFactory> oracles = List.of(PrestoOracleFactory.NOREC);
+
+    @Parameter(names = "--catalog")
+    public String catalog = "memory";
+
+    @Parameter(names = "--schema")
+    public String schema = "test";
+
+    @Parameter(names = "--typed-generator", description = "the expression generator type - typed and untyped ")
+    public boolean typedGenerator = true;
+
+    @Override
+    public List<PrestoOracleFactory> getTestOracleFactory() {
+        return oracles;
+    }
+
+    public enum PrestoOracleFactory implements OracleFactory<PrestoGlobalState> {
+        NOREC {
+            @Override
+            public TestOracle<PrestoGlobalState> create(PrestoGlobalState globalState) {
+                return new PrestoNoRECOracle(globalState);
+            }
+
+        },
+        HAVING {
+            @Override
+            public TestOracle<PrestoGlobalState> create(PrestoGlobalState globalState) {
+                return new PrestoQueryPartitioningHavingTester(globalState);
+            }
+        },
+        WHERE {
+            @Override
+            public TestOracle<PrestoGlobalState> create(PrestoGlobalState globalState) {
+                return new PrestoQueryPartitioningWhereTester(globalState);
+            }
+        },
+        GROUP_BY {
+            @Override
+            public TestOracle<PrestoGlobalState> create(PrestoGlobalState globalState) {
+                return new PrestoQueryPartitioningGroupByTester(globalState);
+            }
+        },
+        AGGREGATE {
+            @Override
+            public TestOracle<PrestoGlobalState> create(PrestoGlobalState globalState) {
+                return new PrestoQueryPartitioningAggregateTester(globalState);
+            }
+
+        },
+        DISTINCT {
+            @Override
+            public TestOracle<PrestoGlobalState> create(PrestoGlobalState globalState) {
+                return new PrestoQueryPartitioningDistinctTester(globalState);
+            }
+        },
+        QUERY_PARTITIONING {
+            @Override
+            public TestOracle<PrestoGlobalState> create(PrestoGlobalState globalState) {
+                List<TestOracle<PrestoGlobalState>> oracles = new ArrayList<>();
+                oracles.add(new PrestoQueryPartitioningWhereTester(globalState));
+                oracles.add(new PrestoQueryPartitioningHavingTester(globalState));
+                oracles.add(new PrestoQueryPartitioningAggregateTester(globalState));
+                oracles.add(new PrestoQueryPartitioningDistinctTester(globalState));
+                oracles.add(new PrestoQueryPartitioningGroupByTester(globalState));
+                return new CompositeTestOracle<>(oracles, globalState);
+            }
+        }
+
+    }
+
+}

--- a/src/sqlancer/presto/PrestoProvider.java
+++ b/src/sqlancer/presto/PrestoProvider.java
@@ -1,0 +1,195 @@
+package sqlancer.presto;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.auto.service.AutoService;
+
+import sqlancer.AbstractAction;
+import sqlancer.DatabaseProvider;
+import sqlancer.IgnoreMeException;
+import sqlancer.MainOptions;
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.SQLProviderAdapter;
+import sqlancer.StatementExecutor;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLQueryProvider;
+import sqlancer.presto.gen.PrestoInsertGenerator;
+import sqlancer.presto.gen.PrestoTableGenerator;
+
+@AutoService(DatabaseProvider.class)
+public class PrestoProvider extends SQLProviderAdapter<PrestoGlobalState, PrestoOptions> {
+
+    public PrestoProvider() {
+        super(PrestoGlobalState.class, PrestoOptions.class);
+    }
+
+    // TODO : check actions based on connector
+    // returns number of actions
+    private static int mapActions(PrestoGlobalState globalState, Action a) {
+        Randomly r = globalState.getRandomly();
+        if (Objects.requireNonNull(a) == Action.INSERT) {
+            return r.getInteger(0, globalState.getOptions().getMaxNumberInserts());
+            // case UPDATE:
+            // return r.getInteger(0, globalState.getDbmsSpecificOptions().maxNumUpdates + 1);
+            // case EXPLAIN:
+            // return r.getInteger(0, 2);
+            // case DELETE:
+            // return r.getInteger(0, globalState.getDbmsSpecificOptions().maxNumDeletes + 1);
+            // case CREATE_VIEW:
+            // return r.getInteger(0, globalState.getDbmsSpecificOptions().maxNumViews + 1);
+        }
+        throw new AssertionError(a);
+    }
+
+    @Override
+    public void generateDatabase(PrestoGlobalState globalState) throws Exception {
+        for (int i = 0; i < Randomly.fromOptions(1, 2); i++) {
+            boolean success;
+            do {
+                SQLQueryAdapter qt = new PrestoTableGenerator().getQuery(globalState);
+                success = globalState.executeStatement(qt);
+            } while (!success);
+        }
+        if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+            throw new IgnoreMeException(); // TODO
+        }
+        StatementExecutor<PrestoGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
+                PrestoProvider::mapActions, (q) -> {
+                    if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+                        throw new IgnoreMeException();
+                    }
+                });
+        se.executeStatements();
+    }
+
+    @Override
+    public SQLConnection createDatabase(PrestoGlobalState globalState) throws SQLException {
+        String username = globalState.getOptions().getUserName();
+        String password = globalState.getOptions().getPassword();
+        boolean useSSl = true;
+        if (globalState.getOptions().isDefaultUsername() && globalState.getOptions().isDefaultPassword()) {
+            username = "presto";
+            password = null;
+            useSSl = false;
+        }
+        String host = globalState.getOptions().getHost();
+        int port = globalState.getOptions().getPort();
+        if (host == null) {
+            host = PrestoOptions.DEFAULT_HOST;
+        }
+        if (port == MainOptions.NO_SET_PORT) {
+            port = PrestoOptions.DEFAULT_PORT;
+        }
+        String catalogName = globalState.getDbmsSpecificOptions().catalog;
+        String databaseName = globalState.getDatabaseName();
+        String url = String.format("jdbc:presto://%s:%d/%s?SSL=%b", host, port, catalogName, useSSl);
+        Connection con = DriverManager.getConnection(url, username, password);
+        List<String> schemaNames = getSchemaNames(con, catalogName, databaseName);
+        dropExistingTables(con, catalogName, databaseName, schemaNames);
+        dropSchema(globalState, con, catalogName, databaseName);
+        createSchema(globalState, con, catalogName, databaseName);
+        useSchema(globalState, con, catalogName, databaseName);
+        return new SQLConnection(con);
+
+    }
+
+    private static void useSchema(PrestoGlobalState globalState, Connection con, String catalogName,
+            String databaseName) throws SQLException {
+        globalState.getState().logStatement("USE " + catalogName + "." + databaseName);
+        try (Statement s = con.createStatement()) {
+            s.execute("USE " + catalogName + "." + databaseName);
+        }
+    }
+
+    private static void createSchema(PrestoGlobalState globalState, Connection con, String catalogName,
+            String databaseName) throws SQLException {
+        globalState.getState().logStatement("CREATE SCHEMA IF NOT EXISTS " + catalogName + "." + databaseName);
+        try (Statement s = con.createStatement()) {
+            s.execute("CREATE SCHEMA IF NOT EXISTS " + catalogName + "." + databaseName);
+        }
+    }
+
+    private static void dropSchema(PrestoGlobalState globalState, Connection con, String catalogName,
+            String databaseName) throws SQLException {
+        globalState.getState().logStatement("DROP SCHEMA IF EXISTS " + catalogName + "." + databaseName);
+        try (Statement s = con.createStatement()) {
+            s.execute("DROP SCHEMA IF EXISTS " + catalogName + "." + databaseName);
+        }
+    }
+
+    private static List<String> getSchemaNames(Connection con, String catalogName, String databaseName)
+            throws SQLException {
+        List<String> schemaNames = new ArrayList<>();
+        final String showSchemasSql = "SHOW SCHEMAS FROM " + catalogName + " LIKE '" + databaseName + "'";
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery(showSchemasSql)) {
+                while (rs.next()) {
+                    schemaNames.add(rs.getString("Schema"));
+                }
+            }
+        }
+        return schemaNames;
+    }
+
+    private static void dropExistingTables(Connection con, String catalogName, String databaseName,
+            List<String> schemaNames) throws SQLException {
+        if (!schemaNames.isEmpty()) {
+            List<String> tableNames = new ArrayList<>();
+            try (Statement s = con.createStatement()) {
+                try (ResultSet rs = s.executeQuery("SHOW TABLES FROM " + catalogName + "." + databaseName)) {
+                    while (rs.next()) {
+                        tableNames.add(rs.getString("Table"));
+                    }
+                }
+            }
+            try (Statement s = con.createStatement()) {
+                for (String tableName : tableNames) {
+                    s.execute("DROP TABLE IF EXISTS " + catalogName + "." + databaseName + "." + tableName);
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getDBMSName() {
+        return "presto";
+    }
+
+    public enum Action implements AbstractAction<PrestoGlobalState> {
+        // SHOW_TABLES((g) -> new SQLQueryAdapter("SHOW TABLES", new ExpectedErrors(), false, false)), //
+        INSERT(PrestoInsertGenerator::getQuery);
+        // TODO : check actions based on connector
+        // DELETE(PrestoDeleteGenerator::generate), //
+        // UPDATE(PrestoUpdateGenerator::getQuery), //
+        // CREATE_VIEW(PrestoViewGenerator::generate), //
+        // EXPLAIN((g) -> {
+        // ExpectedErrors errors = new ExpectedErrors();
+        // PrestoErrors.addExpressionErrors(errors);
+        // PrestoErrors.addGroupByErrors(errors);
+        // return new SQLQueryAdapter(
+        // "EXPLAIN " + PrestoToStringVisitor
+        // .asString(PrestoRandomQuerySynthesizer.generateSelect(g, Randomly.smallNumber() + 1)),
+        // errors);
+        // });
+
+        private final SQLQueryProvider<PrestoGlobalState> sqlQueryProvider;
+
+        Action(SQLQueryProvider<PrestoGlobalState> sqlQueryProvider) {
+            this.sqlQueryProvider = sqlQueryProvider;
+        }
+
+        @Override
+        public SQLQueryAdapter getQuery(PrestoGlobalState state) throws Exception {
+            return sqlQueryProvider.getQuery(state);
+        }
+    }
+
+}

--- a/src/sqlancer/presto/PrestoSchema.java
+++ b/src/sqlancer/presto/PrestoSchema.java
@@ -1,0 +1,484 @@
+package sqlancer.presto;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.common.schema.AbstractRelationalTable;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+import sqlancer.common.schema.TableIndex;
+
+public class PrestoSchema extends AbstractSchema<PrestoGlobalState, PrestoSchema.PrestoTable> {
+
+    public PrestoSchema(List<PrestoTable> databaseTables) {
+        super(databaseTables);
+    }
+
+    public static PrestoSchema fromConnection(SQLConnection con, String databaseName) throws SQLException {
+        List<PrestoTable> databaseTables = new ArrayList<>();
+        List<String> tableNames = getTableNames(con);
+        for (String tableName : tableNames) {
+            List<PrestoColumn> databaseColumns = getTableColumns(con, databaseName, tableName);
+            boolean isView = tableName.startsWith("v");
+            PrestoTable t = new PrestoTable(tableName, databaseColumns, isView);
+            for (PrestoColumn c : databaseColumns) {
+                c.setTable(t);
+            }
+            databaseTables.add(t);
+        }
+        return new PrestoSchema(databaseTables);
+    }
+
+    private static List<String> getTableNames(SQLConnection con) throws SQLException {
+        List<String> tableNames = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            // TODO: UPDATE
+            // SHOW TABLES [ FROM schema ] [ LIKE pattern [ ESCAPE 'escape_character' ] ]
+            try (ResultSet rs = s.executeQuery("SHOW TABLES")) {
+                while (rs.next()) {
+                    tableNames.add(rs.getString("Table"));
+                }
+            }
+        }
+        return tableNames;
+    }
+
+    private static List<PrestoColumn> getTableColumns(SQLConnection con, String databaseName, String tableName)
+            throws SQLException {
+        List<PrestoColumn> columns = new ArrayList<>();
+        try (Statement s = con.createStatement()) {
+            try (ResultSet rs = s.executeQuery(String.format("select " + " table_catalog " + " , table_schema "
+                    + " , table_name " + " , column_name " + " , is_nullable " + " , data_type "
+                    + " from information_schema.columns " + " where table_schema = '%s' and table_name = '%s'",
+                    databaseName, tableName))) {
+                while (rs.next()) {
+                    String columnName = rs.getString("column_name");
+                    String dataType = rs.getString("data_type");
+                    boolean isNullable = rs.getString("is_nullable").contentEquals("YES");
+                    PrestoColumn c = new PrestoColumn(columnName, getColumnType(dataType), false, isNullable);
+                    columns.add(c);
+                }
+            }
+        }
+
+        return columns;
+    }
+
+    private static PrestoCompositeDataType getColumnType(String typeString) {
+        int bracesStart = typeString.indexOf('(');
+        String type;
+        int size = 0;
+        int precision = 0;
+        if (bracesStart != -1) {
+            type = typeString.substring(0, bracesStart);
+        } else {
+            type = typeString;
+        }
+        type = type.toUpperCase();
+
+        PrestoDataType primitiveType;
+        switch (type) {
+        case "INTEGER":
+            primitiveType = PrestoDataType.INT;
+            size = 4;
+            break;
+        case "SMALLINT":
+            primitiveType = PrestoDataType.INT;
+            size = 2;
+            break;
+        case "BIGINT":
+            primitiveType = PrestoDataType.INT;
+            size = 8;
+            break;
+        case "TINYINT":
+            primitiveType = PrestoDataType.INT;
+            size = 1;
+            break;
+        case "VARCHAR":
+            primitiveType = PrestoDataType.VARCHAR;
+            break;
+        case "VARBINARY":
+            primitiveType = PrestoDataType.VARBINARY;
+            break;
+        case "CHAR":
+            primitiveType = PrestoDataType.CHAR;
+            break;
+        case "FLOAT":
+        case "REAL":
+            primitiveType = PrestoDataType.FLOAT;
+            size = 4;
+            break;
+        case "DOUBLE":
+            primitiveType = PrestoDataType.FLOAT;
+            size = 8;
+            break;
+        case "DECIMAL":
+            primitiveType = PrestoDataType.DECIMAL;
+            break;
+        case "BOOLEAN":
+            primitiveType = PrestoDataType.BOOLEAN;
+            break;
+        case "DATE":
+            primitiveType = PrestoDataType.DATE;
+            break;
+        case "TIME":
+            primitiveType = PrestoDataType.TIME;
+            break;
+        case "TIME WITH TIME ZONE":
+            primitiveType = PrestoDataType.TIME_WITH_TIME_ZONE;
+            break;
+        case "TIMESTAMP":
+            primitiveType = PrestoDataType.TIMESTAMP;
+            break;
+        case "TIMESTAMP WITH TIME ZONE":
+            primitiveType = PrestoDataType.TIMESTAMP_WITH_TIME_ZONE;
+            break;
+        case "INTERVAL DAY TO SECOND":
+            primitiveType = PrestoDataType.INTERVAL_DAY_TO_SECOND;
+            break;
+        case "INTERVAL YEAR TO MONTH":
+            primitiveType = PrestoDataType.INTERVAL_YEAR_TO_MONTH;
+            break;
+        case "JSON":
+            primitiveType = PrestoDataType.JSON;
+            break;
+        case "ARRAY":
+            primitiveType = PrestoDataType.ARRAY;
+            break;
+        case "NULL":
+            primitiveType = PrestoDataType.NULL;
+            break;
+        default:
+            throw new AssertionError(typeString);
+        }
+        return new PrestoCompositeDataType(primitiveType, size, precision);
+    }
+
+    public PrestoTables getRandomTableNonEmptyTables() {
+        return new PrestoTables(Randomly.nonEmptySubset(getDatabaseTables()));
+    }
+
+    public enum PrestoDataType {
+        BOOLEAN, INT, FLOAT, DECIMAL, VARCHAR, CHAR, VARBINARY, JSON, DATE, TIME, TIMESTAMP, TIME_WITH_TIME_ZONE,
+        TIMESTAMP_WITH_TIME_ZONE, INTERVAL_YEAR_TO_MONTH, INTERVAL_DAY_TO_SECOND, ARRAY,
+        // MAP,
+        // ROW,
+        // IPADDRESS,
+        // UID,
+        // IPPREFIX,
+        // HyperLogLog,
+        // P4HyperLogLog,
+        // KHyperLogLog,
+        // QDigest,
+        // TDigest,
+        NULL;
+
+        public static PrestoDataType getRandomWithoutNull() {
+            PrestoDataType dt;
+            do {
+                dt = Randomly.fromOptions(values());
+            } while (dt == PrestoDataType.NULL);
+            return dt;
+        }
+
+        public static List<PrestoDataType> getNumericTypes() {
+            return Arrays.asList(INT, FLOAT, DECIMAL, DATE, TIME, TIMESTAMP, TIME_WITH_TIME_ZONE,
+                    TIMESTAMP_WITH_TIME_ZONE);
+        }
+
+        public static List<PrestoDataType> getComparableTypes() {
+            return Arrays.asList(BOOLEAN, INT, FLOAT, DECIMAL, VARCHAR, CHAR, VARBINARY, JSON, DATE, TIME, TIMESTAMP,
+                    TIME_WITH_TIME_ZONE, TIMESTAMP_WITH_TIME_ZONE, INTERVAL_YEAR_TO_MONTH, INTERVAL_DAY_TO_SECOND);
+        }
+
+        public static List<PrestoDataType> getOrderableTypes() {
+            return Arrays.asList(BOOLEAN, INT, FLOAT, DECIMAL, VARCHAR, CHAR, VARBINARY,
+                    // JSON,
+                    DATE, TIME, TIMESTAMP, TIME_WITH_TIME_ZONE, TIMESTAMP_WITH_TIME_ZONE, INTERVAL_YEAR_TO_MONTH,
+                    INTERVAL_DAY_TO_SECOND, ARRAY);
+        }
+
+        public static List<PrestoDataType> getNumberTypes() {
+            return Arrays.asList(INT, FLOAT, DECIMAL);
+        }
+
+        public static List<PrestoDataType> getTemporalTypes() {
+            return Arrays.asList(DATE, TIME, TIMESTAMP, TIME_WITH_TIME_ZONE, TIMESTAMP_WITH_TIME_ZONE);
+        }
+
+        public static List<PrestoDataType> getIntervalTypes() {
+            return Arrays.asList(INTERVAL_YEAR_TO_MONTH, INTERVAL_DAY_TO_SECOND);
+        }
+
+        public static List<PrestoDataType> getTextTypes() {
+            return Arrays.asList(VARCHAR, CHAR, VARBINARY, JSON);
+        }
+
+        public boolean isNumeric() {
+            switch (this) {
+            case INT:
+            case FLOAT:
+            case DECIMAL:
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        public boolean isOrderable() {
+            return getOrderableTypes().contains(this);
+        }
+
+        public PrestoCompositeDataType get() {
+            return PrestoCompositeDataType.fromDataType(this);
+        }
+    }
+
+    public static class PrestoCompositeDataType {
+
+        private final PrestoDataType dataType;
+
+        private final int size;
+
+        private final int scale;
+
+        private final PrestoCompositeDataType elementType;
+
+        public PrestoCompositeDataType(PrestoDataType dataType, int dataSize, int dataScale) {
+            this.dataType = dataType;
+            this.size = dataSize;
+            this.scale = dataScale;
+            this.elementType = null;
+        }
+
+        public PrestoCompositeDataType(PrestoDataType dataType, PrestoCompositeDataType elementType) {
+            if (dataType != PrestoDataType.ARRAY) {
+                throw new IllegalArgumentException();
+            }
+            this.dataType = dataType;
+            this.size = -1;
+            this.scale = -1;
+            this.elementType = elementType;
+        }
+
+        public static PrestoCompositeDataType getRandomWithoutNull() {
+            PrestoDataType type = PrestoDataType.getRandomWithoutNull();
+            int size;
+            int scale = -1;
+            switch (type) {
+            case INT:
+                size = Randomly.fromOptions(1, 2, 4, 8);
+                break;
+            case FLOAT:
+                size = Randomly.fromOptions(4, 8);
+                break;
+            case DECIMAL:
+                size = Math.toIntExact(8);
+                scale = Math.toIntExact(4);
+                break;
+            case VARBINARY:
+            case JSON:
+            case VARCHAR:
+            case CHAR:
+                size = Math.toIntExact(Randomly.getNotCachedInteger(10, 250));
+                break;
+            case ARRAY:
+                return new PrestoCompositeDataType(type, PrestoCompositeDataType.getRandomWithoutNull());
+            case BOOLEAN:
+            case DATE:
+            case TIME:
+            case TIME_WITH_TIME_ZONE:
+            case TIMESTAMP:
+            case TIMESTAMP_WITH_TIME_ZONE:
+            case INTERVAL_DAY_TO_SECOND:
+            case INTERVAL_YEAR_TO_MONTH:
+                size = 0;
+                break;
+            default:
+                throw new AssertionError(type);
+            }
+
+            return new PrestoCompositeDataType(type, size, scale);
+        }
+
+        public static PrestoCompositeDataType fromDataType(PrestoDataType type) {
+            int size;
+            int scale = -1;
+            switch (type) {
+            case INT:
+                size = Randomly.fromOptions(1, 2, 4, 8);
+                break;
+            case FLOAT:
+                size = Randomly.fromOptions(4, 8);
+                break;
+            case DECIMAL:
+                size = Math.toIntExact(8);
+                scale = Math.toIntExact(4);
+                break;
+            case JSON:
+            case VARCHAR:
+            case CHAR:
+                size = Math.toIntExact(Randomly.getNotCachedInteger(10, 250));
+                break;
+            case ARRAY:
+                return new PrestoCompositeDataType(type, PrestoCompositeDataType.getRandomWithoutNull());
+            case BOOLEAN:
+            case VARBINARY:
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case TIMESTAMP_WITH_TIME_ZONE:
+            case TIME_WITH_TIME_ZONE:
+            case INTERVAL_DAY_TO_SECOND:
+            case INTERVAL_YEAR_TO_MONTH:
+                size = 0;
+                break;
+            default:
+                throw new AssertionError(type);
+            }
+
+            return new PrestoCompositeDataType(type, size, scale);
+        }
+
+        public PrestoDataType getPrimitiveDataType() {
+            return dataType;
+        }
+
+        public int getSize() {
+            if (size == -1) {
+                throw new AssertionError(this);
+            }
+            return size;
+        }
+
+        public int getScale() {
+            if (scale == -1) {
+                throw new AssertionError(this);
+            }
+            return scale;
+        }
+
+        @Override
+        public String toString() {
+            switch (getPrimitiveDataType()) {
+            case INT:
+                switch (size) {
+                case 8:
+                    return "BIGINT";
+                case 4:
+                    return "INTEGER";
+                case 2:
+                    return "SMALLINT";
+                case 1:
+                    return "TINYINT";
+                default:
+                    throw new AssertionError(size);
+                }
+            case VARBINARY:
+                return "VARBINARY";
+            case JSON:
+                return "JSON";
+            case VARCHAR:
+                return "VARCHAR" + "(" + size + ")";
+            case CHAR:
+                return "CHAR" + "(" + size + ")";
+            case FLOAT:
+                switch (size) {
+                case 4:
+                    return "REAL";
+                case 8:
+                    return "DOUBLE";
+                default:
+                    throw new AssertionError(size);
+                }
+            case DECIMAL:
+                return "DECIMAL" + "(" + size + ", " + scale + ")";
+            case BOOLEAN:
+                return "BOOLEAN";
+            case TIMESTAMP_WITH_TIME_ZONE:
+                return "TIMESTAMP WITH TIME ZONE";
+            case TIMESTAMP:
+                return "TIMESTAMP";
+            case INTERVAL_YEAR_TO_MONTH:
+                return "INTERVAL YEAR TO MONTH";
+            case INTERVAL_DAY_TO_SECOND:
+                return "INTERVAL DAY TO SECOND";
+            case DATE:
+                return "DATE";
+            case TIME:
+                return "TIME";
+            case TIME_WITH_TIME_ZONE:
+                return "TIME WITH TIME ZONE";
+            case ARRAY:
+                return "ARRAY(" + elementType + ")";
+            case NULL:
+                return "NULL";
+            default:
+                throw new AssertionError(getPrimitiveDataType());
+            }
+        }
+
+        public PrestoCompositeDataType getElementType() {
+            return elementType;
+        }
+
+        public boolean isOrderable() {
+            if (dataType == PrestoDataType.ARRAY) {
+                assert elementType != null;
+                return elementType.isOrderable();
+            }
+            return dataType.isOrderable();
+        }
+
+    }
+
+    public static class PrestoColumn extends AbstractTableColumn<PrestoTable, PrestoCompositeDataType> {
+
+        private final boolean isPrimaryKey;
+        private final boolean isNullable;
+
+        public PrestoColumn(String name, PrestoCompositeDataType columnType, boolean isPrimaryKey, boolean isNullable) {
+            super(name, null, columnType);
+            this.isPrimaryKey = isPrimaryKey;
+            this.isNullable = isNullable;
+        }
+
+        public boolean isPrimaryKey() {
+            return isPrimaryKey;
+        }
+
+        public boolean isNullable() {
+            return isNullable;
+        }
+
+        public boolean isOrderable() {
+            return getType().getPrimitiveDataType().isOrderable();
+        }
+
+    }
+
+    public static class PrestoTables extends AbstractTables<PrestoTable, PrestoColumn> {
+
+        public PrestoTables(List<PrestoTable> tables) {
+            super(tables);
+        }
+
+    }
+
+    public static class PrestoTable extends AbstractRelationalTable<PrestoColumn, TableIndex, PrestoGlobalState> {
+
+        public PrestoTable(String tableName, List<PrestoColumn> columns, boolean isView) {
+            super(tableName, columns, Collections.emptyList(), isView);
+        }
+
+    }
+
+}

--- a/src/sqlancer/presto/PrestoToStringVisitor.java
+++ b/src/sqlancer/presto/PrestoToStringVisitor.java
@@ -1,0 +1,149 @@
+package sqlancer.presto;
+
+import sqlancer.common.ast.newast.NewToStringVisitor;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.ast.PrestoAtTimeZoneOperator;
+import sqlancer.presto.ast.PrestoCastFunction;
+import sqlancer.presto.ast.PrestoConstant;
+import sqlancer.presto.ast.PrestoExpression;
+import sqlancer.presto.ast.PrestoFunctionWithoutParenthesis;
+import sqlancer.presto.ast.PrestoJoin;
+import sqlancer.presto.ast.PrestoMultiValuedComparison;
+import sqlancer.presto.ast.PrestoQuantifiedComparison;
+import sqlancer.presto.ast.PrestoSelect;
+
+public class PrestoToStringVisitor extends NewToStringVisitor<PrestoExpression> {
+
+    public static String asString(Node<PrestoExpression> expr) {
+        PrestoToStringVisitor visitor = new PrestoToStringVisitor();
+        visitor.visit(expr);
+        return visitor.get();
+    }
+
+    @Override
+    public void visitSpecific(Node<PrestoExpression> expr) {
+        if (expr instanceof PrestoConstant) {
+            visit((PrestoConstant) expr);
+        } else if (expr instanceof PrestoSelect) {
+            visit((PrestoSelect) expr);
+        } else if (expr instanceof PrestoJoin) {
+            visit((PrestoJoin) expr);
+        } else if (expr instanceof PrestoCastFunction) {
+            visit((PrestoCastFunction) expr);
+        } else if (expr instanceof PrestoFunctionWithoutParenthesis) {
+            visit((PrestoFunctionWithoutParenthesis) expr);
+        } else if (expr instanceof PrestoAtTimeZoneOperator) {
+            visit((PrestoAtTimeZoneOperator) expr);
+        } else if (expr instanceof PrestoMultiValuedComparison) {
+            visit((PrestoMultiValuedComparison) expr);
+        } else if (expr instanceof PrestoQuantifiedComparison) {
+            visit((PrestoQuantifiedComparison) expr);
+        } else {
+            throw new AssertionError(expr.getClass());
+        }
+    }
+
+    private void visit(PrestoJoin join) {
+        visit(join.getLeftTable());
+        sb.append(" ");
+        sb.append(join.getJoinType());
+        sb.append(" ");
+        if (join.getOuterType() != null) {
+            sb.append(join.getOuterType());
+        }
+        sb.append(" JOIN ");
+        visit(join.getRightTable());
+        if (join.getOnCondition() != null) {
+            sb.append(" ON ");
+            visit(join.getOnCondition());
+        }
+    }
+
+    private void visit(PrestoConstant constant) {
+        sb.append(constant.toString());
+    }
+
+    private void visit(PrestoAtTimeZoneOperator timeZoneOperator) {
+        visit(timeZoneOperator.getExpr());
+        sb.append(" AT TIME ZONE ");
+        sb.append(timeZoneOperator.getTimeZone());
+    }
+
+    private void visit(PrestoFunctionWithoutParenthesis prestoFunctionWithoutParenthesis) {
+        sb.append(prestoFunctionWithoutParenthesis.getExpr());
+    }
+
+    private void visit(PrestoSelect select) {
+        sb.append("SELECT ");
+        if (select.isDistinct()) {
+            sb.append("DISTINCT ");
+        }
+        visit(select.getFetchColumns());
+        sb.append(" FROM ");
+        visit(select.getFromList());
+        if (!select.getFromList().isEmpty() && !select.getJoinList().isEmpty()) {
+            sb.append(", ");
+        }
+        if (!select.getJoinList().isEmpty()) {
+            visit(select.getJoinList());
+        }
+        if (select.getWhereClause() != null) {
+            sb.append(" WHERE ");
+            visit(select.getWhereClause());
+        }
+        if (!select.getGroupByExpressions().isEmpty()) {
+            sb.append(" GROUP BY ");
+            visit(select.getGroupByExpressions());
+        }
+        if (select.getHavingClause() != null) {
+            sb.append(" HAVING ");
+            visit(select.getHavingClause());
+        }
+        if (!select.getOrderByExpressions().isEmpty()) {
+            sb.append(" ORDER BY ");
+            visit(select.getOrderByExpressions());
+        }
+        if (select.getLimitClause() != null) {
+            sb.append(" LIMIT ");
+            visit(select.getLimitClause());
+        }
+        if (select.getOffsetClause() != null) {
+            sb.append(" OFFSET ");
+            visit(select.getOffsetClause());
+        }
+    }
+
+    public void visit(PrestoCastFunction cast) {
+        sb.append("CAST((");
+        visit(cast.getExpr());
+        sb.append(") AS ");
+        sb.append(cast.getType().toString());
+        sb.append(")");
+    }
+
+    public void visit(PrestoMultiValuedComparison comp) {
+        sb.append("(");
+        visit(comp.getLeft());
+        sb.append(" ");
+        sb.append(comp.getOp().getStringRepresentation());
+        sb.append(" ");
+        sb.append(comp.getType());
+        sb.append(" (VALUES ");
+        visit(comp.getRight());
+        sb.append(")");
+        sb.append(")");
+    }
+
+    public void visit(PrestoQuantifiedComparison comp) {
+        sb.append("(");
+        visit(comp.getLeft());
+        sb.append(" ");
+        sb.append(comp.getOp().getStringRepresentation());
+        sb.append(" ");
+        sb.append(comp.getType());
+        sb.append(" ( ");
+        visit(comp.getRight());
+        sb.append(" ) ");
+        sb.append(")");
+    }
+}

--- a/src/sqlancer/presto/ast/PrestoAggregateFunction.java
+++ b/src/sqlancer/presto/ast/PrestoAggregateFunction.java
@@ -1,0 +1,714 @@
+package sqlancer.presto.ast;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoDataType;
+import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
+
+public enum PrestoAggregateFunction implements PrestoFunction {
+
+    // General Aggregate Functions
+
+    // arbitrary(x) → [same as input]
+    // Returns an arbitrary non-null value of x, if one exists.
+    ARBITRARY("arbitrary", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType() };
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return PrestoDataType.getRandomWithoutNull();
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType.fromDataType(getReturnType()));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+
+    },
+
+    // TODO:
+    //
+    // array_agg(x) → array<[same as input]>#
+    // Returns an array created from the input x elements.
+
+    // avg(x) → double
+    // Returns the average (arithmetic mean) of all input values.
+    AVG("avg", PrestoDataType.FLOAT) {
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] {
+                    Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT, PrestoDataType.DECIMAL) };
+        }
+    },
+    // avg(time interval type) → time interval type#
+    // Returns the average interval length of all input values.
+    AVG_INTERVAL_YM("avg", PrestoDataType.INTERVAL_YEAR_TO_MONTH, PrestoDataType.INTERVAL_YEAR_TO_MONTH),
+    AVG_INTERVAL_DS("avg", PrestoDataType.INTERVAL_DAY_TO_SECOND, PrestoDataType.INTERVAL_DAY_TO_SECOND),
+
+    // bool_and(boolean) → boolean#
+    // Returns TRUE if every input value is TRUE, otherwise FALSE.
+    BOOL_AND("bool_and", PrestoDataType.BOOLEAN, PrestoDataType.BOOLEAN),
+    // bool_or(boolean) → boolean#
+    // Returns TRUE if any input value is TRUE, otherwise FALSE.
+    BOOL_OR("bool_or", PrestoDataType.BOOLEAN, PrestoDataType.BOOLEAN),
+    // checksum(x) → varbinary#
+    // Returns an order-insensitive checksum of the given values.
+    CHECKSUM("checksum", PrestoDataType.VARBINARY) {
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromList(PrestoDataType.getComparableTypes()) };
+        }
+    },
+
+    // count(*) → bigint#
+    // Returns the number of input rows.
+    COUNT_ALL("count(*)", PrestoDataType.INT),
+    // count(x) → bigint#
+    // Returns the number of non-null input values.
+    COUNT_NOARGS("count", PrestoDataType.INT), COUNT("count", PrestoDataType.INT) {
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromOptions(PrestoDataType.getRandomWithoutNull()) };
+        }
+    },
+    // count_if(x) → bigint#
+    // Returns the number of TRUE input values. This function is equivalent to count(CASE WHEN x THEN 1 END).
+    COUNT_IF("count_if", PrestoDataType.INT) {
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromOptions(PrestoDataType.getRandomWithoutNull()) };
+        }
+    },
+    // every(boolean) → boolean#
+    // This is an alias for bool_and().
+    EVERY("every", PrestoDataType.BOOLEAN, PrestoDataType.BOOLEAN),
+    // geometric_mean(x) → double#
+    // Returns the geometric mean of all input values.
+    GEOMETRIC_MEAN("geometric_mean", PrestoDataType.FLOAT) {
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] {
+                    Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT, PrestoDataType.DECIMAL) };
+        }
+    },
+    // max_by(x, y) → [same as x]#
+    // Returns the value of x associated with the maximum value of y over all input values.
+    MAX_BY("max_by", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType(),
+                    Randomly.fromList(PrestoDataType.getOrderableTypes()) };
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromList(PrestoDataType.getOrderableTypes());
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType.fromDataType(getReturnType()));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+
+    },
+
+    // TODO:
+    //
+    // max_by(x, y, n) → array<[same as x]>#
+    // Returns n values of x associated with the n largest of all input values of y in descending order of y.
+
+    // min_by(x, y) → [same as x]#
+    // Returns the value of x associated with the minimum value of y over all input values.
+    MIN_BY("min_by", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType(),
+                    Randomly.fromList(PrestoDataType.getOrderableTypes()) };
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromList(PrestoDataType.getOrderableTypes());
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType.fromDataType(getReturnType()));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+
+    },
+    // TODO:
+    //
+    // min_by(x, y, n) → array<[same as x]>
+    // Returns n values of x associated with the n smallest of all input values of y in ascending order of y.
+
+    // max(x) → [same as input]
+    // Returns the maximum value of all input values.
+    MAX("max", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            boolean isCompatible = PrestoDataType.getOrderableTypes().contains(returnType.getPrimitiveDataType());
+            if (returnType.getPrimitiveDataType() == PrestoDataType.ARRAY && returnType.toString().contains("JSON")) {
+                isCompatible = false;
+            }
+            return isCompatible;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType() };
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromList(PrestoDataType.getOrderableTypes());
+        }
+
+        @Override
+        public PrestoCompositeDataType getCompositeReturnType() {
+            PrestoDataType dataType = Randomly.fromList(PrestoDataType.getOrderableTypes());
+            PrestoCompositeDataType returnType;
+            do {
+                returnType = PrestoCompositeDataType.fromDataType(dataType);
+            } while (!isCompatibleWithReturnType(returnType));
+            return returnType;
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType.fromDataType(getReturnType()));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, true);
+        }
+
+    },
+
+    // TODO:
+    //
+    // max(x, n) → array<[same as x]>#
+    // Returns n largest values of all input values of x.
+
+    // min(x) → [same as input]#
+    // Returns the minimum value of all input values.
+    MIN("min", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            boolean orderable = PrestoDataType.getOrderableTypes().contains(returnType.getPrimitiveDataType());
+            if (returnType.getPrimitiveDataType() == PrestoDataType.ARRAY && returnType.toString().contains("JSON")) {
+                orderable = false;
+            }
+            return orderable;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType() };
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromList(PrestoDataType.getOrderableTypes());
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType.fromDataType(getReturnType()));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+
+    },
+
+    // TODO:
+    //
+    // min(x, n) → array<[same as x]>#
+    // Returns n smallest values of all input values of x.
+
+    // TODO:
+    //
+    // reduce_agg(inputValue T, initialState S, inputFunction(S, T, S), combineFunction(S, S, S)) → S#
+    // Reduces all input values into a single value. inputFunction will be invoked for each input value. In addition to
+    // taking the input value, inputFunction takes the current state, initially initialState, and returns the new state.
+    // combineFunction will be invoked to combine two states into a new state. The final state is returned:
+    //
+    // SELECT id, reduce_agg(value, (a, b) -> a + b, (a, b) -> a + b)
+    // FROM (
+    // VALUES
+    // (1, 2),
+    // (1, 3),
+    // (1, 4),
+    // (2, 20),
+    // (2, 30),
+    // (2, 40)
+    // ) AS t(id, value)
+    // GROUP BY id;
+    // -- (1, 9)
+    // -- (2, 90)
+    //
+    // SELECT id, reduce_agg(value, (a, b) -> a * b, (a, b) -> a * b)
+    // FROM (
+    // VALUES
+    // (1, 2),
+    // (1, 3),
+    // (1, 4),
+    // (2, 20),
+    // (2, 30),
+    // (2, 40)
+    // ) AS t(id, value)
+    // GROUP BY id;
+    // -- (1, 24)
+    // -- (2, 24000)
+    // The state type must be a boolean, integer, floating-point, or date/time/interval.
+
+    // TODO:
+    //
+    // set_agg(x) → array<[same as input]>#
+    // Returns an array created from the distinct input x elements.
+
+    // TODO:
+    //
+    // set_union(array(T)) -> array(T)#
+    // Returns an array of all the distinct values contained in each array of the input
+    //
+    // Example:
+    //
+    // SELECT set_union(elements)
+    // FROM (
+    // VALUES
+    // ARRAY[1, 3],
+    // ARRAY[2, 4]
+    // ) AS t(elements);
+    // Returns ARRAY[1, 3, 4]
+
+    // sum(x) → [same as input]#
+    // Returns the sum of all input values.
+    SUM("sum", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return List.of(PrestoDataType.INT, PrestoDataType.FLOAT, PrestoDataType.DECIMAL)
+                    .contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType() };
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT, PrestoDataType.DECIMAL);
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType.fromDataType(getReturnType()));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+    },
+    // sum(time interval type) → time interval type#
+    // Returns the average interval length of all input values.
+    SUM_INTERVAL_YM("sum", PrestoDataType.INTERVAL_YEAR_TO_MONTH, PrestoDataType.INTERVAL_YEAR_TO_MONTH),
+    SUM_INTERVAL_DS("sum", PrestoDataType.INTERVAL_DAY_TO_SECOND, PrestoDataType.INTERVAL_DAY_TO_SECOND),
+
+    // Bitwise Aggregate Functions#
+
+    // bitwise_and_agg(x) → bigint#
+    // Returns the bitwise AND of all input values in 2’s complement representation.
+    BITWISE_AND_AGG("bitwise_and_agg", PrestoDataType.INT, PrestoDataType.INT),
+
+    // bitwise_or_agg(x) → bigint#
+    // Returns the bitwise OR of all input values in 2’s complement representation.
+    BITWISE_OR_AGG("bitwise_or_agg", PrestoDataType.INT, PrestoDataType.INT),
+
+    // TODO:
+    //
+    // Map Aggregate Functions
+
+    // histogram(x)#
+    // Returns a map containing the count of the number of times each input value occurs.
+    //
+    // map_agg(key, value)#
+    // Returns a map created from the input key / value pairs.
+    //
+    // map_union(x(K, V)) -> map(K, V)#
+    // Returns the union of all the input maps. If a key is found in multiple input maps, that key’s value in the
+    // resulting map comes from an arbitrary input map.
+    //
+    // map_union_sum(x(K, V)) -> map(K, V)#
+    // Returns the union of all the input maps summing the values of matching keys in all the maps. All null values in
+    // the original maps are coalesced to 0.
+    //
+    // multimap_agg(key, value)#
+    // Returns a multimap created from the input key / value pairs. Each key can be associated with multiple values.
+
+    // Approximate Aggregate Functions#
+    // approx_distinct(x) → bigint#
+    // Returns the approximate number of distinct input values. This function provides an approximation of
+    // count(DISTINCT x).
+    // Zero is returned if all input values are null.
+    // This function should produce a standard error of 2.3%, which is the standard deviation of the (approximately
+    // normal)
+    // error distribution over all possible sets. It does not guarantee an upper bound on the error for any specific
+    // input set.
+    APPROX_DISTINCT("approx_distinct", PrestoDataType.INT) {
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromList(PrestoDataType.getOrderableTypes()) };
+        }
+    },
+    //
+    // approx_distinct(x, e) → bigint#
+    // Returns the approximate number of distinct input values. This function provides an approximation of
+    // count(DISTINCT x). Zero is returned if all input values are null.
+    //
+    // This function should produce a standard error of no more than e, which is the standard deviation of the
+    // (approximately normal) error distribution over all possible sets. It does not guarantee an upper bound on the
+    // error for any specific input set. The current implementation of this function requires that e be in the range of
+    // [0.0040625, 0.26000].
+    APPROX_DISTINCT_2("approx_distinct", PrestoDataType.INT) {
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromList(PrestoDataType.getOrderableTypes()), PrestoDataType.FLOAT };
+        }
+    },
+    // approx_percentile(x, percentage) → [same as x]#
+    // Returns the approximate percentile for all input values of x at the given percentage.
+    // The value of percentage must be between zero and one and must be constant for all input rows.
+    APPROX_PERCENTILE("approx_percentile", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return List.of(PrestoDataType.INT, PrestoDataType.FLOAT).contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT),
+                    PrestoDataType.FLOAT };
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoDataType[] argumentTypes2, PrestoCompositeDataType returnType2) {
+            List<Node<PrestoExpression>> arguments = new ArrayList<>();
+            arguments.add(gen.generateExpression(returnType2, depth + 1));
+            arguments.add(new PrestoConstant.PrestoFloatConstant(Randomly.getPercentage()));
+            return arguments;
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT);
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType.fromDataType(getReturnType()));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+    },
+
+    // approx_percentile(x, percentage, accuracy) → [same as x]#
+    // As approx_percentile(x, percentage), but with a maximum rank error of accuracy.
+    // The value of accuracy must be between zero and one (exclusive) and must be constant for all input rows.
+    // Note that a lower “accuracy” is really a lower error threshold, and thus more accurate. The default accuracy is
+    // 0.01.
+    APPROX_PERCENTILE_ACCURACY("approx_percentile", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return List.of(PrestoDataType.INT, PrestoDataType.FLOAT).contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT),
+                    PrestoDataType.FLOAT, PrestoDataType.FLOAT };
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoDataType[] argumentTypes2, PrestoCompositeDataType returnType2) {
+            List<Node<PrestoExpression>> arguments = new ArrayList<>();
+            arguments.add(gen.generateExpression(returnType2, depth + 1));
+            arguments.add(new PrestoConstant.PrestoFloatConstant(Randomly.getPercentage()));
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                arguments.add(new PrestoConstant.PrestoFloatConstant(0.01D));
+            } else {
+                arguments.add(new PrestoConstant.PrestoFloatConstant(Randomly.getPercentage()));
+            }
+            return arguments;
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT);
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType
+                            .fromDataType(Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT)));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+    },
+
+    // TODO:
+    //
+    // approx_percentile(x, percentages) → array<[same as x]>#
+    // Returns the approximate percentile for all input values of x at each of the specified percentages. Each element
+    // of the percentages array must be between zero and one, and the array must be constant for all input rows.
+    //
+    // approx_percentile(x, percentages, accuracy) → array<[same as x]>#
+    // As approx_percentile(x, percentages), but with a maximum rank error of accuracy.
+
+    // approx_percentile(x, w, percentage) → [same as x]#
+    // Returns the approximate weighed percentile for all input values of x using the per-item weight w at the
+    // percentage p.
+    // The weight must be an integer value of at least one.
+    // It is effectively a replication count for the value x in the percentile set.
+    // The value of p must be between zero and one and must be constant for all input rows.
+    APPROX_PERCENTILE_WEIGHT("approx_percentile", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return List.of(PrestoDataType.INT, PrestoDataType.FLOAT).contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT),
+                    PrestoDataType.INT, PrestoDataType.FLOAT };
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoDataType[] argumentTypes2, PrestoCompositeDataType returnType2) {
+            List<Node<PrestoExpression>> arguments = new ArrayList<>();
+            arguments.add(gen.generateExpression(returnType2, depth + 1));
+            arguments.add(new PrestoConstant.PrestoFloatConstant(Randomly.getPercentage()));
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                arguments.add(new PrestoConstant.PrestoIntConstant(1));
+            } else {
+                arguments.add(new PrestoConstant.PrestoIntConstant(Randomly.smallNumber()));
+            }
+            return arguments;
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT);
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType
+                            .fromDataType(Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT)));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+    },
+
+    // approx_percentile(x, w, percentage, accuracy) → [same as x]#
+    // As approx_percentile(x, w, percentage), but with a maximum rank error of accuracy.
+    APPROX_PERCENTILE_PERCENTAGE_ACCURACY("approx_percentile", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return List.of(PrestoDataType.INT, PrestoDataType.FLOAT).contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT),
+                    PrestoDataType.INT, PrestoDataType.FLOAT, PrestoDataType.FLOAT };
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoDataType[] argumentTypes2, PrestoCompositeDataType returnType2) {
+            List<Node<PrestoExpression>> arguments = new ArrayList<>();
+            arguments.add(gen.generateExpression(returnType2, depth + 1));
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                arguments.add(new PrestoConstant.PrestoIntConstant(1));
+            } else {
+                arguments.add(new PrestoConstant.PrestoIntConstant(Randomly.smallNumber()));
+            }
+            arguments.add(new PrestoConstant.PrestoFloatConstant(Randomly.getPercentage()));
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                arguments.add(new PrestoConstant.PrestoFloatConstant(0.01D));
+            } else {
+                arguments.add(new PrestoConstant.PrestoFloatConstant(Randomly.getPercentage()));
+            }
+            return arguments;
+        }
+
+        @Override
+        public PrestoDataType getReturnType() {
+            return Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT);
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoCompositeDataType returnType, boolean orderable) {
+            PrestoCompositeDataType returnTypeLocal = Objects.requireNonNullElseGet(returnType,
+                    () -> PrestoCompositeDataType
+                            .fromDataType(Randomly.fromOptions(PrestoDataType.INT, PrestoDataType.FLOAT)));
+            return super.getArgumentsForReturnType(gen, depth, returnTypeLocal, orderable);
+        }
+    };
+
+    // TODO:
+    //
+    // approx_percentile(x, w, percentages) → array<[same as x]>#
+    // Returns the approximate weighed percentile for all input values of x using the per-item weight w at each of the
+    // given percentages specified in the array. The weight must be an integer value of at least one. It is effectively
+    // a replication count for the value x in the percentile set. Each element of the array must be between zero and
+    // one, and the array must be constant for all input rows.
+    //
+    // approx_percentile(x, w, percentages, accuracy) → array<[same as x]>#
+    // As approx_percentile(x, w, percentages), but with a maximum rank error of accuracy.
+    //
+    // approx_set(x) → HyperLogLog
+    // See HyperLogLog Functions.
+    //
+    // merge(x) → HyperLogLog
+    // See HyperLogLog Functions.
+    //
+    // khyperloglog_agg(x) → KHyperLogLog
+    // See KHyperLogLog Functions.
+
+    // TODO:
+    //
+    // merge(qdigest(T)) -> qdigest(T)
+    // See Quantile Digest Functions.
+    //
+    // qdigest_agg(x) → qdigest<[same as x]>
+    // See Quantile Digest Functions.
+    //
+    // qdigest_agg(x, w) → qdigest<[same as x]>
+    // See Quantile Digest Functions.
+    //
+    // qdigest_agg(x, w, accuracy) → qdigest<[same as x]>
+    // See Quantile Digest Functions.
+    //
+    // numeric_histogram(buckets, value, weight) → map<double, double>#
+    // Computes an approximate histogram with up to buckets number of buckets for all values with a per-item weight of
+    // weight.
+    // The keys of the returned map are roughly the center of the bin, and the entry is the total weight of the bin.
+    // The algorithm is based loosely on [BenHaimTomTov2010].
+    //
+    // buckets must be a bigint. value and weight must be numeric.
+    //
+    // numeric_histogram(buckets, value) → map<double, double>#
+    // Computes an approximate histogram with up to buckets number of buckets for all values. This function is
+    // equivalent to the variant of numeric_histogram() that takes a weight, with a per-item weight of 1. In this case,
+    // the total weight in the returned map is the count of items in the bin.
+
+    private final PrestoDataType returnType;
+    private final PrestoDataType[] argumentTypes;
+    private final String functionName;
+
+    PrestoAggregateFunction(String functionName, PrestoDataType returnType) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+        this.argumentTypes = new PrestoDataType[0];
+    }
+
+    PrestoAggregateFunction(String functionName, PrestoDataType returnType, PrestoDataType... argumentTypes) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+        this.argumentTypes = argumentTypes.clone();
+    }
+
+    public static PrestoAggregateFunction getRandomMetamorphicOracle() {
+        return Randomly.fromOptions(ARBITRARY, AVG, AVG_INTERVAL_YM, AVG_INTERVAL_DS, BOOL_AND, BOOL_OR, CHECKSUM,
+                COUNT_ALL, COUNT_NOARGS, COUNT, COUNT_IF, EVERY, GEOMETRIC_MEAN, MAX_BY, MIN_BY, MAX, MIN, SUM,
+                SUM_INTERVAL_YM, SUM_INTERVAL_DS, BITWISE_AND_AGG, BITWISE_OR_AGG);
+    }
+
+    public static PrestoAggregateFunction getRandom() {
+        return Randomly.fromOptions(values());
+    }
+
+    public static List<PrestoAggregateFunction> getFunctionsCompatibleWith(PrestoCompositeDataType returnType) {
+        return Stream.of(values()).filter(f -> f.isCompatibleWithReturnType(returnType)).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    @Override
+    public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+        return this.returnType == returnType.getPrimitiveDataType();
+    }
+
+    @Override
+    public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+        return argumentTypes.clone();
+    }
+
+    @Override
+    public int getNumberOfArguments() {
+        return 1;
+    }
+
+    public List<PrestoSchema.PrestoDataType> getReturnTypes(PrestoSchema.PrestoDataType dataType) {
+        return Collections.singletonList(dataType);
+    }
+
+    public PrestoDataType getReturnType() {
+        if (returnType == null) {
+            return PrestoDataType.getRandomWithoutNull();
+        }
+        return returnType;
+    }
+
+    public PrestoCompositeDataType getCompositeReturnType() {
+        PrestoDataType dataType = getReturnType();
+        return PrestoCompositeDataType.fromDataType(dataType);
+    }
+}

--- a/src/sqlancer/presto/ast/PrestoAtTimeZoneOperator.java
+++ b/src/sqlancer/presto/ast/PrestoAtTimeZoneOperator.java
@@ -1,0 +1,22 @@
+package sqlancer.presto.ast;
+
+import sqlancer.common.ast.newast.Node;
+
+public class PrestoAtTimeZoneOperator implements Node<PrestoExpression> {
+
+    private final Node<PrestoExpression> expr;
+    private final Node<PrestoExpression> timeZone;
+
+    public PrestoAtTimeZoneOperator(Node<PrestoExpression> expr, Node<PrestoExpression> timeZone) {
+        this.expr = expr;
+        this.timeZone = timeZone;
+    }
+
+    public Node<PrestoExpression> getExpr() {
+        return expr;
+    }
+
+    public Node<PrestoExpression> getTimeZone() {
+        return timeZone;
+    }
+}

--- a/src/sqlancer/presto/ast/PrestoCastFunction.java
+++ b/src/sqlancer/presto/ast/PrestoCastFunction.java
@@ -1,0 +1,24 @@
+package sqlancer.presto.ast;
+
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoSchema;
+
+public class PrestoCastFunction implements Node<PrestoExpression> {
+
+    private final Node<PrestoExpression> expr;
+    private final PrestoSchema.PrestoCompositeDataType type;
+
+    public PrestoCastFunction(Node<PrestoExpression> expr, PrestoSchema.PrestoCompositeDataType type) {
+        this.expr = expr;
+        this.type = type;
+    }
+
+    public Node<PrestoExpression> getExpr() {
+        return expr;
+    }
+
+    public PrestoSchema.PrestoCompositeDataType getType() {
+        return type;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoColumnReference.java
+++ b/src/sqlancer/presto/ast/PrestoColumnReference.java
@@ -1,0 +1,12 @@
+package sqlancer.presto.ast;
+
+import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.presto.PrestoSchema;
+
+public class PrestoColumnReference extends ColumnReferenceNode<PrestoExpression, PrestoSchema.PrestoColumn> {
+
+    public PrestoColumnReference(PrestoSchema.PrestoColumn column) {
+        super(column);
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoComparisonFunction.java
+++ b/src/sqlancer/presto/ast/PrestoComparisonFunction.java
@@ -1,0 +1,81 @@
+package sqlancer.presto.ast;
+
+import java.util.ArrayList;
+
+import sqlancer.Randomly;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoDataType;
+
+public enum PrestoComparisonFunction implements PrestoFunction {
+
+    // comparison
+
+    // Returns the largest of the provided values.
+    // → [same as input]
+    GREATEST("greatest", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return PrestoDataType.getOrderableTypes().contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public int getNumberOfArguments() {
+            return -1;
+        }
+
+        @Override
+        public PrestoSchema.PrestoDataType[] getArgumentTypes(PrestoSchema.PrestoCompositeDataType returnType) {
+            return new PrestoSchema.PrestoDataType[] { returnType.getPrimitiveDataType() };
+        }
+    },
+    // Returns the smallest of the provided values.
+    // → [same as input]#
+    LEAST("least", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return PrestoDataType.getOrderableTypes().contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public int getNumberOfArguments() {
+            return -1;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            ArrayList<PrestoDataType> prestoDataTypes = new ArrayList<>();
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                prestoDataTypes.add(returnType.getPrimitiveDataType());
+            }
+            return prestoDataTypes.toArray(new PrestoDataType[0]);
+        }
+    };
+
+    private final PrestoDataType returnType;
+    private final PrestoDataType[] argumentTypes;
+    private final String functionName;
+
+    PrestoComparisonFunction(String functionName, PrestoDataType returnType, PrestoDataType... argumentTypes) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+        this.argumentTypes = argumentTypes.clone();
+    }
+
+    @Override
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    @Override
+    public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+        return this.returnType == returnType.getPrimitiveDataType();
+    }
+
+    @Override
+    public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+        return argumentTypes.clone();
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoConditionalFunction.java
+++ b/src/sqlancer/presto/ast/PrestoConditionalFunction.java
@@ -1,0 +1,95 @@
+package sqlancer.presto.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoDataType;
+
+public enum PrestoConditionalFunction implements PrestoFunction {
+
+    // Conditional functions
+    IF_TRUE("if", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { PrestoDataType.BOOLEAN, returnType.getPrimitiveDataType() };
+        }
+    },
+
+    IF_TRUE_FALSE("if", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { PrestoDataType.BOOLEAN, returnType.getPrimitiveDataType(),
+                    returnType.getPrimitiveDataType() };
+        }
+    },
+
+    NULLIF("nullif", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType(), returnType.getPrimitiveDataType() };
+        }
+    },
+
+    COALESCE("coalesce", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public int getNumberOfArguments() {
+            return -1;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            List<PrestoDataType> prestoDataTypes = new ArrayList<>();
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                prestoDataTypes.add(returnType.getPrimitiveDataType());
+            }
+            return prestoDataTypes.toArray(new PrestoDataType[0]);
+        }
+    };
+
+    private final PrestoDataType returnType;
+    private final String functionName;
+
+    PrestoConditionalFunction(String functionName, PrestoDataType returnType) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+    }
+
+    @Override
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    @Override
+    public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+        return this.returnType == returnType.getPrimitiveDataType();
+    }
+
+    @Override
+    public int getNumberOfArguments() {
+        return getArgumentTypes(PrestoCompositeDataType.fromDataType(returnType)).length;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoConstant.java
+++ b/src/sqlancer/presto/ast/PrestoConstant.java
@@ -1,0 +1,810 @@
+package sqlancer.presto.ast;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoConstantUtils;
+import sqlancer.presto.PrestoSchema;
+
+public abstract class PrestoConstant implements Node<PrestoExpression>, PrestoExpression {
+
+    private static final String[] TIME_ZONES = { "Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa",
+            "Africa/Algiers", "Africa/Asmara", "Africa/Asmera", "Africa/Bamako", "Africa/Bangui", "Africa/Banjul",
+            "Africa/Bissau", "Africa/Blantyre", "Africa/Brazzaville", "Africa/Bujumbura", "Africa/Cairo",
+            "Africa/Casablanca", "Africa/Ceuta", "Africa/Conakry", "Africa/Dakar", "Africa/Dar_es_Salaam",
+            "Africa/Djibouti", "Africa/Douala", "Africa/El_Aaiun", "Africa/Freetown", "Africa/Gaborone",
+            "Africa/Harare", "Africa/Johannesburg", "Africa/Juba", "Africa/Kampala", "Africa/Khartoum", "Africa/Kigali",
+            "Africa/Kinshasa", "Africa/Lagos", "Africa/Libreville", "Africa/Lome", "Africa/Luanda", "Africa/Lubumbashi",
+            "Africa/Lusaka", "Africa/Malabo", "Africa/Maputo", "Africa/Maseru", "Africa/Mbabane", "Africa/Mogadishu",
+            "Africa/Monrovia", "Africa/Nairobi", "Africa/Ndjamena", "Africa/Niamey", "Africa/Nouakchott",
+            "Africa/Ouagadougou", "Africa/Porto-Novo", "Africa/Sao_Tome", "Africa/Timbuktu", "Africa/Tripoli",
+            "Africa/Tunis", "Africa/Windhoek", "America/Adak", "America/Anchorage", "America/Anguilla",
+            "America/Antigua", "America/Araguaina", "America/Argentina/Buenos_Aires", "America/Argentina/Catamarca",
+            "America/Argentina/ComodRivadavia", "America/Argentina/Cordoba", "America/Argentina/Jujuy",
+            "America/Argentina/La_Rioja", "America/Argentina/Mendoza", "America/Argentina/Rio_Gallegos",
+            "America/Argentina/Salta", "America/Argentina/San_Juan", "America/Argentina/San_Luis",
+            "America/Argentina/Tucuman", "America/Argentina/Ushuaia", "America/Aruba", "America/Asuncion",
+            "America/Atikokan", "America/Atka", "America/Bahia", "America/Barbados", "America/Belem", "America/Belize",
+            "America/Blanc-Sablon", "America/Boa_Vista", "America/Bogota", "America/Boise", "America/Buenos_Aires",
+            "America/Cambridge_Bay", "America/Campo_Grande", "America/Cancun", "America/Caracas", "America/Catamarca",
+            "America/Cayenne", "America/Cayman", "America/Chicago", "America/Chihuahua", "America/Coral_Harbour",
+            "America/Cordoba", "America/Costa_Rica", "America/Creston", "America/Cuiaba", "America/Curacao",
+            "America/Danmarkshavn", "America/Dawson", "America/Dawson_Creek", "America/Denver", "America/Detroit",
+            "America/Dominica", "America/Edmonton", "America/Eirunepe", "America/El_Salvador", "America/Ensenada",
+            "America/Fort_Nelson", "America/Fort_Wayne", "America/Fortaleza", "America/Glace_Bay", "America/Godthab",
+            "America/Goose_Bay", "America/Grand_Turk", "America/Grenada", "America/Guadeloupe", "America/Guatemala",
+            "America/Guayaquil", "America/Guyana", "America/Halifax", "America/Havana", "America/Hermosillo",
+            "America/Indiana/Indianapolis", "America/Indiana/Knox", "America/Indiana/Marengo",
+            "America/Indiana/Petersburg", "America/Indiana/Tell_City", "America/Indiana/Vevay",
+            "America/Indiana/Vincennes", "America/Indiana/Winamac", "America/Indianapolis", "America/Inuvik",
+            "America/Iqaluit", "America/Jamaica", "America/Jujuy", "America/Juneau", "America/Kentucky/Louisville",
+            "America/Kentucky/Monticello", "America/Knox_IN", "America/Kralendijk", "America/La_Paz", "America/Lima",
+            "America/Los_Angeles", "America/Louisville", "America/Lower_Princes", "America/Maceio", "America/Managua",
+            "America/Manaus", "America/Marigot", "America/Martinique", "America/Matamoros", "America/Mendoza",
+            "America/Menominee", "America/Merida", "America/Metlakatla", "America/Mexico_City", "America/Miquelon",
+            "America/Moncton", "America/Monterrey", "America/Montevideo", "America/Montreal", "America/Montserrat",
+            "America/Nassau", "America/New_York", "America/Nipigon", "America/Nome", "America/Noronha",
+            "America/North_Dakota/Beulah", "America/North_Dakota/Center", "America/North_Dakota/New_Salem",
+            "America/Nuuk", "America/Ojinaga", "America/Panama", "America/Pangnirtung", "America/Paramaribo",
+            "America/Phoenix", "America/Port-au-Prince", "America/Port_of_Spain", "America/Porto_Acre",
+            "America/Porto_Velho", "America/Puerto_Rico", "America/Punta_Arenas", "America/Rainy_River",
+            "America/Rankin_Inlet", "America/Recife", "America/Regina", "America/Resolute", "America/Rio_Branco",
+            "America/Rosario", "America/Santa_Isabel", "America/Santarem", "America/Santiago", "America/Santo_Domingo",
+            "America/Sao_Paulo", "America/Scoresbysund", "America/Shiprock", "America/Sitka", "America/St_Barthelemy",
+            "America/St_Johns", "America/St_Kitts", "America/St_Lucia", "America/St_Thomas", "America/St_Vincent",
+            "America/Swift_Current", "America/Tegucigalpa", "America/Thule", "America/Thunder_Bay", "America/Tijuana",
+            "America/Toronto", "America/Tortola", "America/Vancouver", "America/Virgin", "America/Whitehorse",
+            "America/Winnipeg", "America/Yakutat", "America/Yellowknife", "Antarctica/Casey", "Antarctica/Davis",
+            "Antarctica/DumontDUrville", "Antarctica/Macquarie", "Antarctica/Mawson", "Antarctica/McMurdo",
+            "Antarctica/Palmer", "Antarctica/Rothera", "Antarctica/South_Pole", "Antarctica/Syowa", "Antarctica/Troll",
+            "Antarctica/Vostok", "Arctic/Longyearbyen", "Asia/Aden", "Asia/Almaty", "Asia/Amman", "Asia/Anadyr",
+            "Asia/Aqtau", "Asia/Aqtobe", "Asia/Ashgabat", "Asia/Ashkhabad", "Asia/Atyrau", "Asia/Baghdad",
+            "Asia/Bahrain", "Asia/Baku", "Asia/Bangkok", "Asia/Barnaul", "Asia/Beirut", "Asia/Bishkek", "Asia/Brunei",
+            "Asia/Calcutta", "Asia/Chita", "Asia/Choibalsan", "Asia/Chongqing", "Asia/Chungking", "Asia/Colombo",
+            "Asia/Dacca", "Asia/Dhaka", "Asia/Dili", "Asia/Dubai", "Asia/Dushanbe", "Asia/Famagusta", "Asia/Gaza",
+            "Asia/Harbin", "Asia/Hebron", "Asia/Ho_Chi_Minh", "Asia/Hong_Kong", "Asia/Hovd", "Asia/Irkutsk",
+            "Asia/Istanbul", "Asia/Jakarta", "Asia/Jayapura", "Asia/Jerusalem", "Asia/Kabul", "Asia/Kamchatka",
+            "Asia/Karachi", "Asia/Kashgar", "Asia/Kathmandu", "Asia/Katmandu", "Asia/Khandyga", "Asia/Kolkata",
+            "Asia/Krasnoyarsk", "Asia/Kuala_Lumpur", "Asia/Kuching", "Asia/Kuwait", "Asia/Macao", "Asia/Macau",
+            "Asia/Magadan", "Asia/Makassar", "Asia/Manila", "Asia/Muscat", "Asia/Nicosia", "Asia/Novokuznetsk",
+            "Asia/Novosibirsk", "Asia/Omsk", "Asia/Oral", "Asia/Phnom_Penh", "Asia/Pontianak", "Asia/Pyongyang",
+            "Asia/Qatar", "Asia/Qostanay", "Asia/Qyzylorda", "Asia/Rangoon", "Asia/Riyadh", "Asia/Saigon",
+            "Asia/Sakhalin", "Asia/Samarkand", "Asia/Seoul", "Asia/Shanghai", "Asia/Singapore", "Asia/Srednekolymsk",
+            "Asia/Taipei", "Asia/Tashkent", "Asia/Tbilisi", "Asia/Tehran", "Asia/Tel_Aviv", "Asia/Thimbu",
+            "Asia/Thimphu", "Asia/Tokyo", "Asia/Tomsk", "Asia/Ujung_Pandang", "Asia/Ulaanbaatar", "Asia/Ulan_Bator",
+            "Asia/Urumqi", "Asia/Ust-Nera", "Asia/Vientiane", "Asia/Vladivostok", "Asia/Yakutsk", "Asia/Yangon",
+            "Asia/Yekaterinburg", "Asia/Yerevan", "Atlantic/Azores", "Atlantic/Bermuda", "Atlantic/Canary",
+            "Atlantic/Cape_Verde", "Atlantic/Faeroe", "Atlantic/Faroe", "Atlantic/Jan_Mayen", "Atlantic/Madeira",
+            "Atlantic/Reykjavik", "Atlantic/South_Georgia", "Atlantic/St_Helena", "Atlantic/Stanley", "Australia/ACT",
+            "Australia/Adelaide", "Australia/Brisbane", "Australia/Broken_Hill", "Australia/Canberra",
+            "Australia/Currie", "Australia/Darwin", "Australia/Eucla", "Australia/Hobart", "Australia/LHI",
+            "Australia/Lindeman", "Australia/Lord_Howe", "Australia/Melbourne", "Australia/North", "Australia/Perth",
+            "Australia/Queensland", "Australia/South", "Australia/Sydney", "Australia/Tasmania", "Australia/Victoria",
+            "Australia/West", "Australia/Yancowinna", "Brazil/Acre", "Brazil/DeNoronha", "Brazil/East", "Brazil/West",
+            "CET", "CST6CDT", "Canada/Atlantic", "Canada/Central", "Canada/Eastern", "Canada/Mountain",
+            "Canada/Newfoundland", "Canada/Pacific", "Canada/Saskatchewan", "Canada/Yukon", "Chile/Continental",
+            "Chile/EasterIsland", "Cuba", "EET", "EST5EDT", "Egypt", "Eire", "Etc/GMT", "Etc/GMT+0", "Etc/GMT+1",
+            "Etc/GMT+10", "Etc/GMT+11", "Etc/GMT+12", "Etc/GMT+2", "Etc/GMT+3", "Etc/GMT+4", "Etc/GMT+5", "Etc/GMT+6",
+            "Etc/GMT+7", "Etc/GMT+8", "Etc/GMT+9", "Etc/GMT-0", "Etc/GMT-1", "Etc/GMT-10", "Etc/GMT-11", "Etc/GMT-12",
+            "Etc/GMT-13", "Etc/GMT-14", "Etc/GMT-2", "Etc/GMT-3", "Etc/GMT-4", "Etc/GMT-5", "Etc/GMT-6", "Etc/GMT-7",
+            "Etc/GMT-8", "Etc/GMT-9", "Etc/GMT0", "Etc/Greenwich", "Etc/UCT", "Etc/UTC", "Etc/Universal", "Etc/Zulu",
+            "Europe/Amsterdam", "Europe/Andorra", "Europe/Astrakhan", "Europe/Athens", "Europe/Belfast",
+            "Europe/Belgrade", "Europe/Berlin", "Europe/Bratislava", "Europe/Brussels", "Europe/Bucharest",
+            "Europe/Budapest", "Europe/Busingen", "Europe/Chisinau", "Europe/Copenhagen", "Europe/Dublin",
+            "Europe/Gibraltar", "Europe/Guernsey", "Europe/Helsinki", "Europe/Isle_of_Man", "Europe/Istanbul",
+            "Europe/Jersey", "Europe/Kaliningrad", "Europe/Kiev", "Europe/Kirov", "Europe/Lisbon", "Europe/Ljubljana",
+            "Europe/London", "Europe/Luxembourg", "Europe/Madrid", "Europe/Malta", "Europe/Mariehamn", "Europe/Minsk",
+            "Europe/Monaco", "Europe/Moscow", "Europe/Nicosia", "Europe/Oslo", "Europe/Paris", "Europe/Podgorica",
+            "Europe/Prague", "Europe/Riga", "Europe/Rome", "Europe/Samara", "Europe/San_Marino", "Europe/Sarajevo",
+            "Europe/Saratov", "Europe/Simferopol", "Europe/Skopje", "Europe/Sofia", "Europe/Stockholm", "Europe/Tirane",
+            "Europe/Tiraspol", "Europe/Ulyanovsk", "Europe/Uzhgorod", "Europe/Vaduz", "Europe/Vatican", "Europe/Vienna",
+            "Europe/Vilnius", "Europe/Volgograd", "Europe/Warsaw", "Europe/Zagreb", "Europe/Zaporozhye",
+            "Europe/Zurich", "GB", "GB-Eire", "GMT", "GMT0", "Greenwich", "Hongkong", "Iceland", "Indian/Antananarivo",
+            "Indian/Chagos", "Indian/Christmas", "Indian/Cocos", "Indian/Comoro", "Indian/Kerguelen", "Indian/Mahe",
+            "Indian/Maldives", "Indian/Mauritius", "Indian/Mayotte", "Indian/Reunion", "Iran", "Israel", "Jamaica",
+            "Japan", "Kwajalein", "Libya", "MET", "MST7MDT", "Mexico/General", "NZ", "NZ-CHAT", "Navajo", "PRC",
+            "PST8PDT", "Pacific/Apia", "Pacific/Auckland", "Pacific/Bougainville", "Pacific/Chatham", "Pacific/Chuuk",
+            "Pacific/Easter", "Pacific/Efate", "Pacific/Enderbury", "Pacific/Fakaofo", "Pacific/Fiji",
+            "Pacific/Funafuti", "Pacific/Galapagos", "Pacific/Gambier", "Pacific/Guadalcanal", "Pacific/Guam",
+            "Pacific/Honolulu", "Pacific/Johnston", "Pacific/Kiritimati", "Pacific/Kosrae", "Pacific/Kwajalein",
+            "Pacific/Majuro", "Pacific/Marquesas", "Pacific/Midway", "Pacific/Nauru", "Pacific/Niue", "Pacific/Norfolk",
+            "Pacific/Noumea", "Pacific/Pago_Pago", "Pacific/Palau", "Pacific/Pitcairn", "Pacific/Pohnpei",
+            "Pacific/Ponape", "Pacific/Port_Moresby", "Pacific/Rarotonga", "Pacific/Saipan", "Pacific/Samoa",
+            "Pacific/Tahiti", "Pacific/Tarawa", "Pacific/Tongatapu", "Pacific/Truk", "Pacific/Wake", "Pacific/Wallis",
+            "Pacific/Yap", "Poland", "Portugal", "ROK", "Singapore", "Turkey", "UCT", "US/Alaska", "US/Aleutian",
+            "US/Arizona", "US/Central", "US/East-Indiana", "US/Eastern", "US/Hawaii", "US/Indiana-Starke",
+            "US/Michigan", "US/Mountain", "US/Pacific", "US/Samoa", "UTC", "Universal", "W-SU", "WET", "Zulu" };
+    private static final String FALSE = "false";
+    private static final String TRUE = "true";
+
+    private PrestoConstant() {
+    }
+
+    public static Node<PrestoExpression> createStringConstant(String text) {
+        return new PrestoTextConstant(text);
+    }
+
+    public static Node<PrestoExpression> createStringConstant(String text, int size) {
+        return new PrestoTextConstant(text, size);
+    }
+
+    public static Node<PrestoExpression> createJsonConstant() {
+        return new PrestoJsonConstant();
+    }
+
+    public static Node<PrestoExpression> createFloatConstant(PrestoSchema.PrestoCompositeDataType type, double val) {
+        assert type.getSize() == 4;
+        float floatValue = (float) val;
+        return new PrestoFloatConstant(floatValue);
+    }
+
+    public static Node<PrestoExpression> createFloatConstant(double val) {
+        return new PrestoFloatConstant(val);
+    }
+
+    public static Node<PrestoExpression> createDecimalConstant(double val) {
+        return new PrestoDecimalConstant(val);
+    }
+
+    public static Node<PrestoExpression> createDecimalConstant(PrestoSchema.PrestoCompositeDataType type, double val) {
+        int scale = type.getScale();
+        int precision = type.getSize();
+        BigDecimal finalBD = PrestoConstantUtils.getDecimal(val, scale, precision);
+        return new PrestoDecimalConstant(finalBD.doubleValue());
+    }
+
+    public static Node<PrestoExpression> createIntConstant(long val) {
+        return new PrestoIntConstant(val);
+    }
+
+    public static Node<PrestoExpression> createIntConstant(PrestoSchema.PrestoCompositeDataType type, long val,
+            boolean castInteger) {
+        PrestoIntConstant intConstant;
+        assert List.of(1, 2, 4, 8).contains(type.getSize());
+        switch (type.getSize()) {
+        case 1:
+            intConstant = new PrestoIntConstant((byte) val);
+            break;
+        case 2:
+            intConstant = new PrestoIntConstant((short) val);
+            break;
+        case 4:
+            intConstant = new PrestoIntConstant((int) val);
+            break;
+        default:
+            intConstant = new PrestoIntConstant(val);
+        }
+        if (castInteger) {
+            return new PrestoCastFunction(intConstant, type);
+        } else {
+            return intConstant;
+        }
+    }
+
+    public static Node<PrestoExpression> createNullConstant() {
+        return new PrestoNullConstant();
+    }
+
+    public static Node<PrestoExpression> createBooleanConstant(boolean val) {
+        return new PrestoBooleanConstant(val);
+    }
+
+    public static Node<PrestoExpression> createDateConstant(long integer) {
+        return new PrestoDateConstant(integer);
+    }
+
+    public static Node<PrestoExpression> createTimeConstant(long integer) {
+        return new PrestoTimeConstant(integer);
+    }
+
+    public static Node<PrestoExpression> createTimeWithTimeZoneConstant(long integer) {
+        return new PrestoTimeWithTimeZoneConstant(integer);
+    }
+
+    public static Node<PrestoExpression> createTimestampWithTimeZoneConstant(long integer) {
+        return new PrestoTimestampWithTimezoneConstant(integer);
+    }
+
+    public static Node<PrestoExpression> createIntervalDayToSecond(long integer) {
+        return new PrestoIntervalDayToSecondConstant();
+    }
+
+    public static Node<PrestoExpression> createIntervalYearToMonth(long integer) {
+        return new PrestoIntervalYearToMonthConstant();
+    }
+
+    public static Node<PrestoExpression> createTimestampConstant(long integer) {
+        return new PrestoTimestampConstant(integer);
+    }
+
+    public static Node<PrestoExpression> createVarbinaryConstant(String string) {
+        return new PrestoVarbinaryConstant(string);
+    }
+
+    public static Node<PrestoExpression> createTimezoneConstant() {
+        String string = Randomly.fromOptions(TIME_ZONES);
+        return new PrestoTextConstant(string);
+    }
+
+    public static Node<PrestoExpression> createArrayConstant(PrestoSchema.PrestoCompositeDataType type) {
+        PrestoSchema.PrestoCompositeDataType elementType = type.getElementType();
+        long size = Randomly.getNotCachedInteger(0, 10);
+
+        List<Node<PrestoExpression>> elements = new ArrayList<>();
+        for (int i = 0; i <= size; i++) {
+            if (elementType.getPrimitiveDataType() == PrestoSchema.PrestoDataType.ARRAY) {
+                elements.add(createArrayConstant(elementType));
+            } else {
+                elements.add(generateConstant(elementType, false));
+            }
+        }
+        return new PrestoArrayConstant(elements);
+    }
+
+    public static Node<PrestoExpression> createMapConstant(PrestoSchema.PrestoCompositeDataType type) {
+        PrestoSchema.PrestoCompositeDataType elementType = type.getElementType();
+        long size = Randomly.getNotCachedInteger(0, 10);
+
+        List<Node<PrestoExpression>> elements = new ArrayList<>();
+        for (int i = 0; i <= size; i++) {
+            if (elementType.getPrimitiveDataType() == PrestoSchema.PrestoDataType.ARRAY) {
+                elements.add(createArrayConstant(elementType));
+            } else {
+                elements.add(generateConstant(elementType, false));
+            }
+        }
+        return new PrestoArrayConstant(elements);
+    }
+
+    public static Node<PrestoExpression> generateConstant(PrestoSchema.PrestoCompositeDataType type,
+            boolean castInteger) {
+        Randomly randomly = new Randomly();
+        switch (type.getPrimitiveDataType()) {
+        case ARRAY:
+            return PrestoConstant.createArrayConstant(type);
+        case NULL:
+            return PrestoConstant.createNullConstant();
+        case CHAR:
+            return PrestoConstant.PrestoTextConstant.createStringConstant(randomly.getAlphabeticChar(), type.getSize());
+        case VARCHAR:
+            return PrestoConstant.PrestoTextConstant.createStringConstant(randomly.getString(), type.getSize());
+        case VARBINARY:
+            return PrestoConstant.createVarbinaryConstant(randomly.getString());
+        case JSON:
+            return PrestoConstant.PrestoJsonConstant.createJsonConstant();
+        case TIME:
+            return PrestoConstant.createTimeConstant(randomly.getLong(0, System.currentTimeMillis()));
+        case TIME_WITH_TIME_ZONE:
+            return PrestoConstant.createTimeWithTimeZoneConstant(randomly.getLong(0, System.currentTimeMillis()));
+        case TIMESTAMP:
+            return PrestoConstant.createTimestampConstant(randomly.getLong(0, System.currentTimeMillis()));
+        case TIMESTAMP_WITH_TIME_ZONE:
+            return PrestoConstant.createTimestampWithTimeZoneConstant(randomly.getLong(0, System.currentTimeMillis()));
+        case INTERVAL_YEAR_TO_MONTH:
+            return PrestoConstant.createIntervalYearToMonth(randomly.getLong(0, System.currentTimeMillis()));
+        case INTERVAL_DAY_TO_SECOND:
+            return PrestoConstant.createIntervalDayToSecond(randomly.getLong(0, System.currentTimeMillis()));
+        case INT:
+            return PrestoConstant.PrestoIntConstant.createIntConstant(type, Randomly.getNonCachedInteger(),
+                    castInteger);
+        case FLOAT:
+            return PrestoConstant.PrestoFloatConstant.createFloatConstant(randomly.getDouble());
+        case BOOLEAN:
+            return PrestoConstant.PrestoBooleanConstant.createBooleanConstant(Randomly.getBoolean());
+        case DATE:
+            return PrestoConstant.createDateConstant(randomly.getLong(0, System.currentTimeMillis()));
+        case DECIMAL:
+            return PrestoConstant.createDecimalConstant(type, randomly.getLong(0, System.currentTimeMillis()));
+        default:
+            throw new AssertionError("Unknown type: " + type);
+        }
+    }
+
+    public boolean isNull() {
+        return false;
+    }
+
+    public boolean isInt() {
+        return false;
+    }
+
+    public boolean isBoolean() {
+        return false;
+    }
+
+    public boolean isArray() {
+        return false;
+    }
+
+    public boolean isString() {
+        return false;
+    }
+
+    public boolean isFloat() {
+        return false;
+    }
+
+    public boolean asBoolean() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public long asInt() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public String asString() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public double asFloat() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public static class PrestoNullConstant extends PrestoConstant {
+
+        @Override
+        public String toString() {
+            return "NULL";
+        }
+
+        @Override
+        public boolean isNull() {
+            return true;
+        }
+
+    }
+
+    public static class PrestoIntConstant extends PrestoConstant {
+
+        private final long value;
+
+        public PrestoIntConstant(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        public long getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean isInt() {
+            return true;
+        }
+
+    }
+
+    public static class PrestoFloatConstant extends PrestoConstant {
+
+        private final double value;
+
+        public PrestoFloatConstant(double value) {
+            this.value = value;
+        }
+
+        public double getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            if (value == Double.POSITIVE_INFINITY) {
+                return "infinity()";
+            } else if (value == Double.NEGATIVE_INFINITY) {
+                return "-infinity()";
+            }
+            return String.valueOf(value);
+        }
+
+        @Override
+        public boolean isFloat() {
+            return true;
+        }
+
+        @Override
+        public double asFloat() {
+            return value;
+        }
+
+    }
+
+    public static class PrestoDecimalConstant extends PrestoConstant {
+
+        private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("###0.0000");
+
+        private final double value;
+
+        public PrestoDecimalConstant(double value) {
+            this.value = value;
+        }
+
+        public double getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            if (value == Double.POSITIVE_INFINITY) {
+                return "'+Inf'";
+            } else if (value == Double.NEGATIVE_INFINITY) {
+                return "'-Inf'";
+            }
+            return DECIMAL_FORMAT.format(value);
+        }
+
+        @Override
+        public double asFloat() {
+            return value;
+        }
+
+    }
+
+    public static class PrestoTextConstant extends PrestoConstant {
+
+        private final String value;
+
+        public PrestoTextConstant(String value) {
+            this.value = value;
+        }
+
+        public PrestoTextConstant(String value, int size) {
+            this.value = value.substring(0, Math.min(value.length(), size));
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return "'" + value.replace("'", "''") + "'";
+        }
+
+    }
+
+    public static class PrestoVarbinaryConstant extends PrestoConstant {
+
+        private final String value;
+
+        public PrestoVarbinaryConstant(String value) {
+            this.value = value.replace("'", "");
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("CAST ('%s' AS VARBINARY)", value);
+        }
+
+    }
+
+    public static class PrestoJsonConstant extends PrestoConstant {
+
+        private final String value;
+
+        public PrestoJsonConstant() {
+            Randomly rand = new Randomly();
+            JsonValueType jvt = Randomly.fromOptions(JsonValueType.values());
+            String val;
+            switch (jvt) {
+            case NULL:
+                val = "null";
+                value = "{\"val\":" + val + "}";
+                break;
+            case FALSE:
+                val = FALSE;
+                value = "{\"val\":" + val + "}";
+                break;
+            case TRUE:
+                val = TRUE;
+                value = "{\"val\":" + val + "}";
+                break;
+            case STRING:
+                String randString = rand.getString();
+                String string = randString.substring(0, Math.min(randString.length(), 250));
+                string = string.replace("'", "");
+                // https://www.rfc-editor.org/rfc/rfc8259#page-8
+                string = PrestoConstantUtils.removeAllControlChars(string);
+                string = string.replace("\\", "\\\\");
+
+                value = "{\"val\": \"" + string + "\"}";
+                break;
+            case NUMBER:
+                if (Randomly.getBoolean()) {
+                    int no = (int) rand.getInteger();
+                    val = String.valueOf(no);
+                } else {
+                    double no = rand.getDouble();
+                    val = String.valueOf(no);
+                }
+                value = "{\"val\": " + val + "}";
+                break;
+            case ARRAY:
+                value = "{\"employees\":[\"John\", \"Anna\", \"Peter\"]}";
+                break;
+            case OBJECT:
+                value = "{\"employee\":{\"name\":\"John\", \"age\":30, \"city\":\"New York\"}}";
+                break;
+            default:
+                value = "{}";
+            }
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return "JSON '" + value + "'";
+        }
+
+        private enum JsonValueType {
+            OBJECT, ARRAY, NUMBER, STRING, TRUE, FALSE, NULL
+        }
+
+    }
+
+    public static class PrestoDateConstant extends PrestoConstant {
+
+        private final String textRepresentation;
+
+        public PrestoDateConstant(long val) {
+            Timestamp timestamp = new Timestamp(val);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            textRepresentation = dateFormat.format(timestamp);
+        }
+
+        public String getValue() {
+            return textRepresentation;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("DATE '%s'", textRepresentation);
+        }
+
+    }
+
+    public static class PrestoTimeConstant extends PrestoConstant {
+
+        public final String textRepresentation;
+
+        public PrestoTimeConstant(long val) {
+            Timestamp timestamp = new Timestamp(val);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+            textRepresentation = dateFormat.format(timestamp);
+        }
+
+        public String getValue() {
+            return textRepresentation;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("TIME '%s'", textRepresentation);
+        }
+
+    }
+
+    public static class PrestoTimeWithTimeZoneConstant extends PrestoConstant {
+
+        private final String textRepresentation;
+        private final String timeZone;
+
+        public PrestoTimeWithTimeZoneConstant(long val) {
+            Timestamp timestamp = new Timestamp(val);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+            textRepresentation = dateFormat.format(timestamp);
+            this.timeZone = Randomly.fromOptions(TIME_ZONES);
+        }
+
+        public String getValue() {
+            return textRepresentation;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("TIME '%s %s'", textRepresentation, timeZone);
+        }
+
+    }
+
+    public static class PrestoTimestampConstant extends PrestoConstant {
+
+        private final String textRepresentation;
+
+        public PrestoTimestampConstant(long val) {
+            Timestamp timestamp = new Timestamp(val);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            this.textRepresentation = dateFormat.format(timestamp);
+        }
+
+        public String getValue() {
+            return textRepresentation;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("TIMESTAMP '%s'", textRepresentation);
+        }
+
+    }
+
+    public static class PrestoTimestampWithTimezoneConstant extends PrestoConstant {
+
+        private final String textRepresentation;
+        private final String timeZone;
+
+        public PrestoTimestampWithTimezoneConstant(long val) {
+            Timestamp timestamp = new Timestamp(val);
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            this.textRepresentation = dateFormat.format(timestamp);
+            this.timeZone = Randomly.fromOptions(TIME_ZONES);
+        }
+
+        public String getValue() {
+            return textRepresentation;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("TIMESTAMP '%s %s'", textRepresentation, timeZone);
+        }
+
+    }
+
+    public static class PrestoIntervalDayToSecondConstant extends PrestoConstant {
+
+        private final String textRepresentation;
+        private final Interval fromInterval;
+
+        public PrestoIntervalDayToSecondConstant() {
+            this.fromInterval = Randomly.fromOptions(Interval.values());
+            SimpleDateFormat dateFormat = new SimpleDateFormat("dd HH:mm:ss");
+            switch (fromInterval) {
+            case DAY:
+                dateFormat = new SimpleDateFormat("dd");
+                break;
+            case HOUR:
+                dateFormat = new SimpleDateFormat("HH");
+                break;
+            case MINUTE:
+                dateFormat = new SimpleDateFormat("mm");
+                break;
+            case SECOND:
+                dateFormat = new SimpleDateFormat("ss");
+                break;
+            default:
+                break;
+            }
+
+            Randomly rand = new Randomly();
+
+            Timestamp timestamp = new Timestamp(rand.getLong(0, System.currentTimeMillis()));
+            this.textRepresentation = dateFormat.format(timestamp);
+        }
+
+        public String getValue() {
+            return textRepresentation;
+        }
+
+        @Override
+        public String toString() {
+            // if (toInterval == null) {
+            return String.format("INTERVAL '%s' %s", textRepresentation, fromInterval.name());
+            // } else {
+            // return String.format("INTERVAL '%s' %s TO %s", textRepresentation, fromInterval, toInterval);
+            // }
+        }
+
+        private enum Interval {
+            DAY, HOUR, MINUTE, SECOND
+        }
+
+    }
+
+    public static class PrestoIntervalYearToMonthConstant extends PrestoConstant {
+
+        public String textRepresentation;
+        private final Interval fromInterval;
+
+        public PrestoIntervalYearToMonthConstant() {
+            fromInterval = Randomly.fromOptions(Interval.values());
+            SimpleDateFormat dateFormat;
+            switch (fromInterval) {
+            case YEAR:
+                dateFormat = new SimpleDateFormat("yyyy");
+                break;
+            case MONTH:
+                dateFormat = new SimpleDateFormat("MM");
+                break;
+            default:
+                dateFormat = new SimpleDateFormat("yyyy-MM");
+            }
+
+            Randomly rand = new Randomly();
+
+            Timestamp timestamp = new Timestamp(rand.getLong(0, System.currentTimeMillis()));
+            textRepresentation = dateFormat.format(timestamp);
+        }
+
+        public String getValue() {
+            return textRepresentation;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("INTERVAL '%s' %s", textRepresentation, fromInterval.name());
+        }
+
+        private enum Interval {
+            YEAR, MONTH
+        }
+
+    }
+
+    public static class PrestoBooleanConstant extends PrestoConstant {
+
+        private final boolean value;
+
+        public PrestoBooleanConstant(boolean value) {
+            this.value = value;
+        }
+
+        public boolean getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public boolean asBoolean() {
+            return value;
+        }
+
+        @Override
+        public boolean isBoolean() {
+            return true;
+        }
+
+    }
+
+    public static class PrestoArrayConstant extends PrestoConstant {
+
+        private final List<Node<PrestoExpression>> elements;
+
+        public PrestoArrayConstant(List<Node<PrestoExpression>> elements) {
+            this.elements = new ArrayList<>(elements);
+        }
+
+        @Override
+        public boolean isArray() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "ARRAY[" + elements.stream().map(Object::toString).collect(Collectors.joining(", ")) + "]";
+        }
+
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoDateFunction.java
+++ b/src/sqlancer/presto/ast/PrestoDateFunction.java
@@ -1,0 +1,523 @@
+package sqlancer.presto.ast;
+
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoDataType;
+
+public enum PrestoDateFunction implements PrestoFunction {
+
+    // Date and Time Functions#
+    // Returns the current date as of the start of the query.
+    CURRENT_DATE("current_date", PrestoDataType.DATE),
+
+    // Returns the current time as of the start of the query.
+    CURRENT_TIME("current_time", PrestoDataType.TIME_WITH_TIME_ZONE),
+
+    // Returns the current timestamp as of the start of the query.
+    CURRENT_TIMESTAMP("current_timestamp", PrestoDataType.TIMESTAMP_WITH_TIME_ZONE),
+
+    // Returns the current time zone in the format defined by IANA (e.g., America/Los_Angeles) or as fixed offset from
+    // UTC (e.g., +08:35)
+    CURRENT_TIMEZONE("current_timezone", PrestoDataType.VARCHAR),
+
+    // This is an alias for CAST(x AS date).
+    DATE("date", PrestoDataType.DATE, PrestoDataType.DATE, PrestoDataType.INT, PrestoDataType.VARCHAR),
+
+    // Returns the last day of the month.
+    LAST_DAY_OF_MONTH("last_day_of_month", PrestoDataType.DATE, PrestoDataType.DATE),
+
+    // Parses the ISO 8601 formatted string into a timestamp with time zone.
+    FROM_ISO8601_TIMESTAMP("from_iso8601_timestamp", PrestoDataType.TIMESTAMP_WITH_TIME_ZONE, PrestoDataType.VARCHAR),
+
+    // Parses the ISO 8601 formatted string into a date.
+    FROM_ISO8601_DATE("from_iso8601_date", PrestoDataType.DATE, PrestoDataType.VARCHAR),
+
+    // Returns the UNIX timestamp unixtime as a timestamp.
+    FROM_UNIXTIME("from_unixtime", PrestoDataType.TIMESTAMP, PrestoDataType.INT),
+
+    // Returns the UNIX timestamp unixtime as a timestamp with time zone using string for the time zone.
+    FROM_UNIXTIME_TIMEZONE("from_unixtime", PrestoDataType.TIMESTAMP_WITH_TIME_ZONE, PrestoDataType.INT,
+            PrestoDataType.VARCHAR) {
+        @Override
+        public boolean shouldPreserveOrderOfArguments() {
+            return true;
+        }
+    },
+
+    // Returns the UNIX timestamp unixtime as a timestamp with time zone using hours and minutes for the time zone
+    // offset.
+    FROM_UNIXTIME_HOURS_MINUTES("from_unixtime", PrestoDataType.TIMESTAMP_WITH_TIME_ZONE, PrestoDataType.INT,
+            PrestoDataType.INT) {
+        @Override
+        public boolean shouldPreserveOrderOfArguments() {
+            return true;
+        }
+    },
+
+    // Returns the current time as of the start of the query. -> time
+    LOCALTIME("localtime", PrestoDataType.TIME),
+
+    // Returns the current timestamp as of the start of the query. -> timestamp
+    LOCALTIMESTAMP("localtimestamp", PrestoDataType.TIMESTAMP),
+
+    // This is an alias for current_timestamp. → timestamp with time zone#
+    NOW("now", PrestoDataType.TIMESTAMP_WITH_TIME_ZONE),
+
+    // Formats x as an ISO 8601 string. x can be date, timestamp, or timestamp with time zone. → varchar#
+    TO_ISO8601("to_iso8601", PrestoDataType.VARCHAR, PrestoDataType.DATE, PrestoDataType.TIMESTAMP,
+            PrestoDataType.TIMESTAMP_WITH_TIME_ZONE),
+
+    // Returns the day-to-second interval as milliseconds. → bigint#
+    TO_MILLISECONDS("to_milliseconds", PrestoDataType.INT, PrestoDataType.INTERVAL_DAY_TO_SECOND),
+    TO_MILLISECONDS_2("to_milliseconds", PrestoDataType.INT, PrestoDataType.INTERVAL_YEAR_TO_MONTH),
+
+    // Returns timestamp as a UNIX timestamp. → double#
+    TO_UNIXTIME("to_unixtime", PrestoDataType.FLOAT, PrestoDataType.TIMESTAMP),
+    TO_UNIXTIME_2("to_unixtime", PrestoDataType.FLOAT, PrestoDataType.TIMESTAMP_WITH_TIME_ZONE),
+
+    // The following SQL-standard functions do not use parenthesis:
+    CURRENT_DATE_NA("current_date", PrestoDataType.DATE) {
+        @Override
+        public boolean isStandardFunction() {
+            return false;
+        }
+    },
+
+    CURRENT_TIME_NA("current_time", PrestoDataType.TIME) {
+        @Override
+        public boolean isStandardFunction() {
+            return false;
+        }
+    },
+
+    CURRENT_TIMESTAMP_NA("current_timestamp", PrestoDataType.TIMESTAMP) {
+        @Override
+        public boolean isStandardFunction() {
+            return false;
+        }
+    },
+
+    LOCALTIME_NA("localtime", PrestoDataType.TIME) {
+        @Override
+        public boolean isStandardFunction() {
+            return false;
+        }
+    },
+
+    LOCALTIMESTAMP_NA("localtimestamp", PrestoDataType.TIMESTAMP) {
+        @Override
+        public boolean isStandardFunction() {
+            return false;
+        }
+    },
+
+    // Truncation Function
+    // date_trunc(unit, x) → [same as input]
+    DATE_TRUNC_1("date_trunc", PrestoDataType.TIMESTAMP, PrestoDataType.VARCHAR, PrestoDataType.TIMESTAMP),
+    DATE_TRUNC_2("date_trunc", PrestoDataType.TIMESTAMP_WITH_TIME_ZONE, PrestoDataType.VARCHAR,
+            PrestoDataType.TIMESTAMP_WITH_TIME_ZONE),
+    DATE_TRUNC_3("date_trunc", PrestoDataType.DATE, PrestoDataType.VARCHAR, PrestoDataType.DATE),
+    DATE_TRUNC_4("date_trunc", PrestoDataType.TIME, PrestoDataType.VARCHAR, PrestoDataType.TIME);
+
+    /*
+     *
+     * Interval Functions# The functions in this section support the following interval units:
+     *
+     * Unit
+     *
+     * Description
+     *
+     * millisecond
+     *
+     * Milliseconds
+     *
+     * second
+     *
+     * Seconds
+     *
+     * minute
+     *
+     * Minutes
+     *
+     * hour
+     *
+     * Hours
+     *
+     * day
+     *
+     * Days
+     *
+     * week
+     *
+     * Weeks
+     *
+     * month
+     *
+     * Months
+     *
+     * quarter
+     *
+     * Quarters of a year
+     *
+     * year
+     *
+     * Years
+     *
+     * date_add(unit, value, timestamp) → [same as input]# Adds an interval value of type unit to timestamp. Subtraction
+     * can be performed by using a negative value.
+     *
+     * date_diff(unit, timestamp1, timestamp2) → bigint# Returns timestamp2 - timestamp1 expressed in terms of unit.
+     *
+     * Duration Function# The parse_duration function supports the following units:
+     *
+     * Unit
+     *
+     * Description
+     *
+     * ns
+     *
+     * Nanoseconds
+     *
+     * us
+     *
+     * Microseconds
+     *
+     * ms
+     *
+     * Milliseconds
+     *
+     * s
+     *
+     * Seconds
+     *
+     * m
+     *
+     * Minutes
+     *
+     * h
+     *
+     * Hours
+     *
+     * d
+     *
+     * Days
+     *
+     * parse_duration(string) → interval# Parses string of format value unit into an interval, where value is fractional
+     * number of unit values:
+     *
+     * SELECT parse_duration('42.8ms'); -- 0 00:00:00.043 SELECT parse_duration('3.81 d'); -- 3 19:26:24.000 SELECT
+     * parse_duration('5m'); -- 0 00:05:00.000 MySQL Date Functions# The functions in this section use a format string
+     * that is compatible with the MySQL date_parse and str_to_date functions. The following table, based on the MySQL
+     * manual, describes the format specifiers:
+     *
+     * Specifier
+     *
+     * Description
+     *
+     * %a
+     *
+     * Abbreviated weekday name (Sun .. Sat)
+     *
+     * %b
+     *
+     * Abbreviated month name (Jan .. Dec)
+     *
+     * %c
+     *
+     * Month, numeric (1 .. 12) 4
+     *
+     * %D
+     *
+     * Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
+     *
+     * %d
+     *
+     * Day of the month, numeric (01 .. 31) 4
+     *
+     * %e
+     *
+     * Day of the month, numeric (1 .. 31) 4
+     *
+     * %f
+     *
+     * Fraction of second (6 digits for printing: 000000 .. 999000; 1 - 9 digits for parsing: 0 .. 999999999) 1
+     *
+     * %H
+     *
+     * Hour (00 .. 23)
+     *
+     * %h
+     *
+     * Hour (01 .. 12)
+     *
+     * %I
+     *
+     * Hour (01 .. 12)
+     *
+     * %i
+     *
+     * Minutes, numeric (00 .. 59)
+     *
+     * %j
+     *
+     * Day of year (001 .. 366)
+     *
+     * %k
+     *
+     * Hour (0 .. 23)
+     *
+     * %l
+     *
+     * Hour (1 .. 12)
+     *
+     * %M
+     *
+     * Month name (January .. December)
+     *
+     * %m
+     *
+     * Month, numeric (01 .. 12) 4
+     *
+     * %p
+     *
+     * AM or PM
+     *
+     * %r
+     *
+     * Time, 12-hour (hh:mm:ss followed by AM or PM)
+     *
+     * %S
+     *
+     * Seconds (00 .. 59)
+     *
+     * %s
+     *
+     * Seconds (00 .. 59)
+     *
+     * %T
+     *
+     * Time, 24-hour (hh:mm:ss)
+     *
+     * %U
+     *
+     * Week (00 .. 53), where Sunday is the first day of the week
+     *
+     * %u
+     *
+     * Week (00 .. 53), where Monday is the first day of the week
+     *
+     * %V
+     *
+     * Week (01 .. 53), where Sunday is the first day of the week; used with %X
+     *
+     * %v
+     *
+     * Week (01 .. 53), where Monday is the first day of the week; used with %x
+     *
+     * %W
+     *
+     * Weekday name (Sunday .. Saturday)
+     *
+     * %w
+     *
+     * Day of the week (0 .. 6), where Sunday is the first day of the week 3
+     *
+     * %X
+     *
+     * Year for the week where Sunday is the first day of the week, numeric, four digits; used with %V
+     *
+     * %x
+     *
+     * Year for the week, where Monday is the first day of the week, numeric, four digits; used with %v
+     *
+     * %Y
+     *
+     * Year, numeric, four digits
+     *
+     * %y
+     *
+     * Year, numeric (two digits) 2
+     *
+     * %%
+     *
+     * A literal % character
+     *
+     * %x
+     *
+     * x, for any x not listed above
+     *
+     * 1 Timestamp is truncated to milliseconds.
+     *
+     * 2 When parsing, two-digit year format assumes range 1970 ... 2069, so “70” will result in year 1970 but “69” will
+     * produce 2069.
+     *
+     * 3 This specifier is not supported yet. Consider using day_of_week() (it uses 1-7 instead of 0-6).
+     *
+     * 4(1,2,3,4) This specifier does not support 0 as a month or day.
+     *
+     * Warning
+     *
+     * The following specifiers are not currently supported: %D %U %u %V %w %X
+     *
+     * date_format(timestamp, format) → varchar# Formats timestamp as a string using format.
+     *
+     * date_parse(string, format) → timestamp# Parses string into a timestamp using format.
+     *
+     * Java Date Functions# The functions in this section use a format string that is compatible with JodaTime’s
+     * DateTimeFormat pattern format.
+     *
+     * format_datetime(timestamp, format) → varchar# Formats timestamp as a string using format.
+     *
+     * parse_datetime(string, format) → timestamp with time zone# Parses string into a timestamp with time zone using
+     * format.
+     *
+     * Extraction Function# The extract function supports the following fields:
+     *
+     * Field
+     *
+     * Description
+     *
+     * YEAR
+     *
+     * year()
+     *
+     * QUARTER
+     *
+     * quarter()
+     *
+     * MONTH
+     *
+     * month()
+     *
+     * WEEK
+     *
+     * week()
+     *
+     * DAY
+     *
+     * day()
+     *
+     * DAY_OF_MONTH
+     *
+     * day()
+     *
+     * DAY_OF_WEEK
+     *
+     * day_of_week()
+     *
+     * DOW
+     *
+     * day_of_week()
+     *
+     * DAY_OF_YEAR
+     *
+     * day_of_year()
+     *
+     * DOY
+     *
+     * day_of_year()
+     *
+     * YEAR_OF_WEEK
+     *
+     * year_of_week()
+     *
+     * YOW
+     *
+     * year_of_week()
+     *
+     * HOUR
+     *
+     * hour()
+     *
+     * MINUTE
+     *
+     * minute()
+     *
+     * SECOND
+     *
+     * second()
+     *
+     * TIMEZONE_HOUR
+     *
+     * timezone_hour()
+     *
+     * TIMEZONE_MINUTE
+     *
+     * timezone_minute()
+     *
+     * The types supported by the extract function vary depending on the field to be extracted. Most fields support all
+     * date and time types.
+     *
+     * extract(field FROM x) → bigint# Returns field from x.
+     *
+     * Note
+     *
+     * This SQL-standard function uses special syntax for specifying the arguments.
+     *
+     * Convenience Extraction Functions# day(x) → bigint# Returns the day of the month from x.
+     *
+     * day_of_month(x) → bigint# This is an alias for day().
+     *
+     * day_of_week(x) → bigint# Returns the ISO day of the week from x. The value ranges from 1 (Monday) to 7 (Sunday).
+     *
+     * day_of_year(x) → bigint# Returns the day of the year from x. The value ranges from 1 to 366.
+     *
+     * dow(x) → bigint# This is an alias for day_of_week().
+     *
+     * doy(x) → bigint# This is an alias for day_of_year().
+     *
+     * hour(x) → bigint# Returns the hour of the day from x. The value ranges from 0 to 23.
+     *
+     * millisecond(x) → bigint# Returns the millisecond of the second from x.
+     *
+     * minute(x) → bigint# Returns the minute of the hour from x.
+     *
+     * month(x) → bigint# Returns the month of the year from x.
+     *
+     * quarter(x) → bigint# Returns the quarter of the year from x. The value ranges from 1 to 4.
+     *
+     * second(x) → bigint# Returns the second of the minute from x.
+     *
+     * timezone_hour(timestamp) → bigint# Returns the hour of the time zone offset from timestamp.
+     *
+     * timezone_minute(timestamp) → bigint# Returns the minute of the time zone offset from timestamp.
+     *
+     * week(x) → bigint# Returns the ISO week of the year from x. The value ranges from 1 to 53.
+     *
+     * week_of_year(x) → bigint# This is an alias for week().
+     *
+     * year(x) → bigint# Returns the year from x.
+     *
+     * year_of_week(x) → bigint# Returns the year of the ISO week from x.
+     *
+     * yow(x) → bigint# This is an alias for year_of_week().
+     *
+     *
+     *
+     */
+
+    private final PrestoDataType returnType;
+    private final PrestoDataType[] argumentTypes;
+    private final String functionName;
+
+    PrestoDateFunction(String functionName, PrestoDataType returnType, PrestoDataType... argumentTypes) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+        this.argumentTypes = argumentTypes.clone();
+    }
+
+    @Override
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    @Override
+    public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+        return this.returnType == returnType.getPrimitiveDataType();
+    }
+
+    @Override
+    public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+        return argumentTypes.clone();
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoDefaultFunction.java
+++ b/src/sqlancer/presto/ast/PrestoDefaultFunction.java
@@ -1,0 +1,233 @@
+package sqlancer.presto.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoDataType;
+import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
+
+public enum PrestoDefaultFunction implements PrestoFunction {
+
+    // Conditional functions
+    IF_TRUE("if", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoSchema.PrestoDataType[] getArgumentTypes(PrestoSchema.PrestoCompositeDataType returnType) {
+            return new PrestoSchema.PrestoDataType[] { PrestoSchema.PrestoDataType.BOOLEAN,
+                    returnType.getPrimitiveDataType() };
+        }
+    },
+
+    IF_TRUE_FALSE("if", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoSchema.PrestoDataType[] getArgumentTypes(PrestoSchema.PrestoCompositeDataType returnType) {
+            return new PrestoSchema.PrestoDataType[] { PrestoSchema.PrestoDataType.BOOLEAN,
+                    returnType.getPrimitiveDataType(), returnType.getPrimitiveDataType() };
+        }
+    },
+
+    NULLIF("nullif", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            return new PrestoDataType[] { returnType.getPrimitiveDataType(), returnType.getPrimitiveDataType() };
+        }
+    },
+
+    COALESCE("coalesce", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return true;
+        }
+
+        @Override
+        public int getNumberOfArguments() {
+            return UNLIMITED_NO_OF_ARGUMENTS;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            ArrayList<PrestoDataType> prestoDataTypes = new ArrayList<>();
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                prestoDataTypes.add(returnType.getPrimitiveDataType());
+            }
+            return prestoDataTypes.toArray(new PrestoDataType[0]);
+        }
+
+        @Override
+        public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+                PrestoDataType[] argumentTypes, PrestoCompositeDataType returnType) {
+            return super.getArgumentsForReturnType(gen, depth, argumentTypes, returnType);
+        }
+    },
+
+    // comparison
+
+    // Returns the largest of the provided values. → [same as input]
+    GREATEST("greatest", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return PrestoDataType.getOrderableTypes().contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public int getNumberOfArguments() {
+            return UNLIMITED_NO_OF_ARGUMENTS;
+        }
+
+        @Override
+        public PrestoSchema.PrestoDataType[] getArgumentTypes(PrestoSchema.PrestoCompositeDataType returnType) {
+            return new PrestoSchema.PrestoDataType[] { returnType.getPrimitiveDataType() };
+        }
+    },
+    // Returns the smallest of the provided values. → [same as input]
+    LEAST("least", null) {
+        @Override
+        public boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType) {
+            return PrestoDataType.getOrderableTypes().contains(returnType.getPrimitiveDataType());
+        }
+
+        @Override
+        public int getNumberOfArguments() {
+            return UNLIMITED_NO_OF_ARGUMENTS;
+        }
+
+        @Override
+        public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+            ArrayList<PrestoDataType> prestoDataTypes = new ArrayList<>();
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                prestoDataTypes.add(returnType.getPrimitiveDataType());
+            }
+            return prestoDataTypes.toArray(new PrestoDataType[0]);
+        }
+    };
+
+    private static final int UNLIMITED_NO_OF_ARGUMENTS = -1;
+    private final PrestoDataType returnType;
+    private final PrestoDataType[] argumentTypes;
+    private final String functionName;
+
+    PrestoDefaultFunction(String functionName, PrestoDataType returnType) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+        this.argumentTypes = new PrestoDataType[0];
+    }
+
+    PrestoDefaultFunction(PrestoDataType returnType) {
+        this.returnType = returnType;
+        this.argumentTypes = new PrestoDataType[0];
+        this.functionName = toString();
+    }
+
+    PrestoDefaultFunction(PrestoDataType returnType, PrestoDataType... argumentTypes) {
+        this.returnType = returnType;
+        this.argumentTypes = argumentTypes.clone();
+        this.functionName = toString();
+    }
+
+    PrestoDefaultFunction(String functionName, PrestoDataType returnType, PrestoDataType... argumentTypes) {
+        this.functionName = functionName;
+        this.returnType = returnType;
+        this.argumentTypes = argumentTypes.clone();
+    }
+
+    public static List<PrestoDefaultFunction> getFunctionsCompatibleWith(PrestoCompositeDataType returnType) {
+        return Stream.of(values()).filter(f -> f.isCompatibleWithReturnType(returnType)).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    @Override
+    public int getNumberOfArguments() {
+        return argumentTypes == null ? 0 : argumentTypes.length;
+    }
+
+    @Override
+    public boolean isCompatibleWithReturnType(PrestoCompositeDataType returnType) {
+        return this.returnType == returnType.getPrimitiveDataType();
+    }
+
+    @Override
+    public PrestoDataType[] getArgumentTypes(PrestoCompositeDataType returnType) {
+        return argumentTypes.clone();
+    }
+
+    @Override
+    public List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+            PrestoDataType[] argumentTypes, PrestoCompositeDataType returnType) {
+        List<Node<PrestoExpression>> arguments = new ArrayList<>();
+
+        // This is a workaround based on the assumption that array types should refer to the same element type.
+        PrestoCompositeDataType savedArrayType = null;
+        if (returnType.getPrimitiveDataType() == PrestoDataType.ARRAY) {
+            savedArrayType = returnType;
+        }
+
+        if (getNumberOfArguments() == UNLIMITED_NO_OF_ARGUMENTS) {
+            PrestoDataType dataType = getArgumentTypes(returnType)[0];
+            // TODO: consider upper
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                PrestoCompositeDataType type;
+
+                if (dataType == PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        savedArrayType = dataType.get();
+                    }
+                    type = savedArrayType;
+                } else {
+                    type = PrestoCompositeDataType.fromDataType(dataType);
+                }
+                arguments.add(gen.generateExpression(type, depth + 1));
+            }
+        } else {
+            for (PrestoDataType arg : argumentTypes) {
+                PrestoCompositeDataType type;
+                if (arg == PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        savedArrayType = arg.get();
+                    }
+                    type = savedArrayType;
+                } else {
+                    type = PrestoCompositeDataType.fromDataType(arg);
+                }
+                arguments.add(gen.generateExpression(type, depth + 1));
+
+            }
+        }
+        return arguments;
+    }
+
+    @Override
+    public String toString() {
+        if (functionName != null) {
+            return functionName;
+        }
+        return super.toString();
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoExpression.java
+++ b/src/sqlancer/presto/ast/PrestoExpression.java
@@ -1,0 +1,5 @@
+package sqlancer.presto.ast;
+
+public interface PrestoExpression {
+
+}

--- a/src/sqlancer/presto/ast/PrestoFunction.java
+++ b/src/sqlancer/presto/ast/PrestoFunction.java
@@ -1,0 +1,127 @@
+package sqlancer.presto.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
+
+public interface PrestoFunction {
+
+    String getFunctionName();
+
+    boolean isCompatibleWithReturnType(PrestoSchema.PrestoCompositeDataType returnType);
+
+    PrestoSchema.PrestoDataType[] getArgumentTypes(PrestoSchema.PrestoCompositeDataType returnType);
+
+    default List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+            PrestoSchema.PrestoDataType[] argumentTypes, PrestoSchema.PrestoCompositeDataType returnType) {
+
+        List<Node<PrestoExpression>> arguments = new ArrayList<>();
+
+        // This is a workaround based on the assumption that array types should refer to
+        // the same element type.
+        PrestoSchema.PrestoCompositeDataType savedArrayType = null;
+        if (returnType.getPrimitiveDataType() == PrestoSchema.PrestoDataType.ARRAY) {
+            savedArrayType = returnType;
+        }
+        // -1 - unlimited number of arguments
+        if (getNumberOfArguments() == -1) {
+            PrestoSchema.PrestoDataType dataType = argumentTypes[0];
+            // TODO: consider upper
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                PrestoSchema.PrestoCompositeDataType type;
+
+                if (dataType == PrestoSchema.PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        savedArrayType = dataType.get();
+                    }
+                    type = savedArrayType;
+                } else {
+                    type = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
+                }
+                arguments.add(gen.generateExpression(type, depth + 1));
+            }
+        } else {
+            for (PrestoSchema.PrestoDataType arg : argumentTypes) {
+                PrestoSchema.PrestoCompositeDataType dataType;
+                if (arg == PrestoSchema.PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        savedArrayType = arg.get();
+                    }
+                    dataType = savedArrayType;
+                } else {
+                    dataType = PrestoSchema.PrestoCompositeDataType.fromDataType(arg);
+                }
+                Node<PrestoExpression> expression = gen.generateExpression(dataType, depth + 1);
+                arguments.add(expression);
+            }
+        }
+        return arguments;
+    }
+
+    default List<Node<PrestoExpression>> getArgumentsForReturnType(PrestoTypedExpressionGenerator gen, int depth,
+            PrestoSchema.PrestoCompositeDataType returnType, boolean orderable) {
+
+        List<Node<PrestoExpression>> arguments = new ArrayList<>();
+
+        // This is a workaround based on the assumption that array types should refer to
+        // the same element type.
+        PrestoSchema.PrestoCompositeDataType savedArrayType = null;
+        if (returnType.getPrimitiveDataType() == PrestoSchema.PrestoDataType.ARRAY) {
+            savedArrayType = returnType;
+        }
+        if (getNumberOfArguments() == -1) {
+            PrestoSchema.PrestoDataType dataType = getArgumentTypes(returnType)[0];
+            // TODO: consider upper
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                PrestoSchema.PrestoCompositeDataType compositeDataType;
+                if (dataType == PrestoSchema.PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        savedArrayType = dataType.get();
+                    }
+                    compositeDataType = savedArrayType;
+                } else {
+                    compositeDataType = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
+                }
+                arguments.add(gen.generateExpression(compositeDataType, depth + 1));
+            }
+        } else {
+            for (PrestoSchema.PrestoDataType dataType : getArgumentTypes(returnType)) {
+                PrestoSchema.PrestoCompositeDataType compositeDataType;
+                if (dataType == PrestoSchema.PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        PrestoSchema.PrestoCompositeDataType arrayType;
+                        do {
+                            arrayType = dataType.get();
+                        } while (!arrayType.getElementType().isOrderable());
+                        savedArrayType = arrayType;
+                    }
+                    compositeDataType = savedArrayType;
+                } else {
+                    compositeDataType = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
+                }
+                Node<PrestoExpression> expression = gen.generateExpression(compositeDataType, depth + 1);
+                arguments.add(expression);
+            }
+        }
+        return arguments;
+    }
+
+    default int getNumberOfArguments() {
+        return getArgumentTypes(null).length;
+    }
+
+    default boolean shouldPreserveOrderOfArguments() {
+        return false;
+    }
+
+    default boolean isStandardFunction() {
+        return true;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoFunctionWithoutParenthesis.java
+++ b/src/sqlancer/presto/ast/PrestoFunctionWithoutParenthesis.java
@@ -1,0 +1,24 @@
+package sqlancer.presto.ast;
+
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoSchema;
+
+public class PrestoFunctionWithoutParenthesis implements Node<PrestoExpression> {
+
+    private final PrestoSchema.PrestoCompositeDataType type;
+    private final String expr;
+
+    public PrestoFunctionWithoutParenthesis(String expr, PrestoSchema.PrestoCompositeDataType type) {
+        this.expr = expr;
+        this.type = type;
+    }
+
+    public String getExpr() {
+        return expr;
+    }
+
+    public PrestoSchema.PrestoCompositeDataType getType() {
+        return type;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoJoin.java
+++ b/src/sqlancer/presto/ast/PrestoJoin.java
@@ -1,0 +1,118 @@
+package sqlancer.presto.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
+
+public class PrestoJoin implements Node<PrestoExpression> {
+
+    private final TableReferenceNode<PrestoExpression, PrestoTable> leftTable;
+    private final TableReferenceNode<PrestoExpression, PrestoTable> rightTable;
+    private final JoinType joinType;
+    private final Node<PrestoExpression> onCondition;
+    private OuterType outerType;
+
+    public PrestoJoin(TableReferenceNode<PrestoExpression, PrestoTable> leftTable,
+            TableReferenceNode<PrestoExpression, PrestoTable> rightTable, JoinType joinType,
+            Node<PrestoExpression> whereCondition) {
+        this.leftTable = leftTable;
+        this.rightTable = rightTable;
+        this.joinType = joinType;
+        this.onCondition = whereCondition;
+    }
+
+    public static List<Node<PrestoExpression>> getJoins(
+            List<TableReferenceNode<PrestoExpression, PrestoTable>> tableList, PrestoGlobalState globalState) {
+        List<Node<PrestoExpression>> joinExpressions = new ArrayList<>();
+        while (tableList.size() >= 2 && Randomly.getBooleanWithRatherLowProbability()) {
+            TableReferenceNode<PrestoExpression, PrestoTable> leftTable = tableList.remove(0);
+            TableReferenceNode<PrestoExpression, PrestoTable> rightTable = tableList.remove(0);
+            List<PrestoColumn> columns = new ArrayList<>(leftTable.getTable().getColumns());
+            columns.addAll(rightTable.getTable().getColumns());
+            PrestoTypedExpressionGenerator joinGen = new PrestoTypedExpressionGenerator(globalState)
+                    .setColumns(columns);
+            switch (JoinType.getRandom()) {
+            case INNER:
+                joinExpressions.add(PrestoJoin.createInnerJoin(leftTable, rightTable, joinGen.generateExpression(
+                        PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.BOOLEAN))));
+                break;
+            case LEFT:
+                joinExpressions.add(PrestoJoin.createLeftOuterJoin(leftTable, rightTable, joinGen.generateExpression(
+                        PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.BOOLEAN))));
+                break;
+            case RIGHT:
+                joinExpressions.add(PrestoJoin.createRightOuterJoin(leftTable, rightTable, joinGen.generateExpression(
+                        PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.BOOLEAN))));
+                break;
+            default:
+                throw new AssertionError();
+            }
+        }
+        return joinExpressions;
+    }
+
+    public static PrestoJoin createRightOuterJoin(TableReferenceNode<PrestoExpression, PrestoTable> left,
+            TableReferenceNode<PrestoExpression, PrestoTable> right, Node<PrestoExpression> predicate) {
+        return new PrestoJoin(left, right, JoinType.RIGHT, predicate);
+    }
+
+    public static PrestoJoin createLeftOuterJoin(TableReferenceNode<PrestoExpression, PrestoTable> left,
+            TableReferenceNode<PrestoExpression, PrestoTable> right, Node<PrestoExpression> predicate) {
+        return new PrestoJoin(left, right, JoinType.LEFT, predicate);
+    }
+
+    public static PrestoJoin createInnerJoin(TableReferenceNode<PrestoExpression, PrestoTable> left,
+            TableReferenceNode<PrestoExpression, PrestoTable> right, Node<PrestoExpression> predicate) {
+        return new PrestoJoin(left, right, JoinType.INNER, predicate);
+    }
+
+    public TableReferenceNode<PrestoExpression, PrestoTable> getLeftTable() {
+        return leftTable;
+    }
+
+    public TableReferenceNode<PrestoExpression, PrestoTable> getRightTable() {
+        return rightTable;
+    }
+
+    public JoinType getJoinType() {
+        return joinType;
+    }
+
+    public Node<PrestoExpression> getOnCondition() {
+        return onCondition;
+    }
+
+    public OuterType getOuterType() {
+        return outerType;
+    }
+
+    @SuppressWarnings("unused")
+    private void setOuterType(OuterType outerType) {
+        this.outerType = outerType;
+    }
+
+    public enum JoinType {
+        INNER, LEFT, RIGHT;
+
+        public static JoinType getRandom() {
+            return Randomly.fromOptions(values());
+        }
+    }
+
+    public enum OuterType {
+        FULL, LEFT, RIGHT;
+
+        public static OuterType getRandom() {
+            return Randomly.fromOptions(values());
+        }
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoMultiValuedComparison.java
+++ b/src/sqlancer/presto/ast/PrestoMultiValuedComparison.java
@@ -1,0 +1,39 @@
+package sqlancer.presto.ast;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.common.ast.newast.Node;
+
+public class PrestoMultiValuedComparison implements Node<PrestoExpression> {
+
+    private final Node<PrestoExpression> left;
+    private final List<Node<PrestoExpression>> right;
+    private final PrestoMultiValuedComparisonType type;
+    private final PrestoMultiValuedComparisonOperator op;
+
+    public PrestoMultiValuedComparison(Node<PrestoExpression> left, List<Node<PrestoExpression>> right,
+            PrestoMultiValuedComparisonType type, PrestoMultiValuedComparisonOperator op) {
+        this.left = left;
+        this.right = new ArrayList<>(right);
+        this.type = type;
+        this.op = op;
+    }
+
+    public Node<PrestoExpression> getLeft() {
+        return left;
+    }
+
+    public PrestoMultiValuedComparisonOperator getOp() {
+        return op;
+    }
+
+    public List<Node<PrestoExpression>> getRight() {
+        return new ArrayList<>(right);
+    }
+
+    public PrestoMultiValuedComparisonType getType() {
+        return type;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoMultiValuedComparisonOperator.java
+++ b/src/sqlancer/presto/ast/PrestoMultiValuedComparisonOperator.java
@@ -1,0 +1,43 @@
+package sqlancer.presto.ast;
+
+import sqlancer.Randomly;
+import sqlancer.presto.PrestoSchema;
+
+public enum PrestoMultiValuedComparisonOperator {
+    EQUALS("="), NOT_EQUALS("<>"), NOT_EQUALS_ALT("!="), GREATER(">"), GREATER_EQUALS(">="), SMALLER("<"),
+    SMALLER_EQUALS("<=");
+
+    private final String stringRepresentation;
+
+    PrestoMultiValuedComparisonOperator(String stringRepresentation) {
+        this.stringRepresentation = stringRepresentation;
+    }
+
+    public static PrestoMultiValuedComparisonOperator getRandom() {
+        return Randomly.fromOptions(values());
+    }
+
+    public static PrestoMultiValuedComparisonOperator getRandomForType(PrestoSchema.PrestoCompositeDataType type) {
+        PrestoSchema.PrestoDataType dataType = type.getPrimitiveDataType();
+
+        switch (dataType) {
+        case BOOLEAN:
+        case INT:
+        case FLOAT:
+        case DECIMAL:
+        case DATE:
+        case TIME:
+        case TIMESTAMP:
+        case TIME_WITH_TIME_ZONE:
+        case TIMESTAMP_WITH_TIME_ZONE:
+            return getRandom();
+        default:
+            return Randomly.fromOptions(EQUALS, NOT_EQUALS, NOT_EQUALS_ALT);
+        }
+    }
+
+    public String getStringRepresentation() {
+        return stringRepresentation;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoMultiValuedComparisonType.java
+++ b/src/sqlancer/presto/ast/PrestoMultiValuedComparisonType.java
@@ -1,0 +1,11 @@
+package sqlancer.presto.ast;
+
+import sqlancer.Randomly;
+
+public enum PrestoMultiValuedComparisonType {
+    ANY, SOME, ALL;
+
+    public static PrestoMultiValuedComparisonType getRandom() {
+        return Randomly.fromOptions(values());
+    }
+}

--- a/src/sqlancer/presto/ast/PrestoQuantifiedComparison.java
+++ b/src/sqlancer/presto/ast/PrestoQuantifiedComparison.java
@@ -1,0 +1,36 @@
+package sqlancer.presto.ast;
+
+import sqlancer.common.ast.newast.Node;
+
+public class PrestoQuantifiedComparison implements Node<PrestoExpression> {
+
+    private final Node<PrestoExpression> left;
+    private final PrestoSelect right;
+    private final PrestoMultiValuedComparisonType type;
+    private final PrestoMultiValuedComparisonOperator op;
+
+    public PrestoQuantifiedComparison(Node<PrestoExpression> left, PrestoSelect right,
+            PrestoMultiValuedComparisonType type, PrestoMultiValuedComparisonOperator op) {
+        this.left = left;
+        this.right = right;
+        this.type = type;
+        this.op = op;
+    }
+
+    public Node<PrestoExpression> getLeft() {
+        return left;
+    }
+
+    public PrestoMultiValuedComparisonOperator getOp() {
+        return op;
+    }
+
+    public Node<PrestoExpression> getRight() {
+        return right;
+    }
+
+    public PrestoMultiValuedComparisonType getType() {
+        return type;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoSelect.java
+++ b/src/sqlancer/presto/ast/PrestoSelect.java
@@ -1,0 +1,18 @@
+package sqlancer.presto.ast;
+
+import sqlancer.common.ast.SelectBase;
+import sqlancer.common.ast.newast.Node;
+
+public class PrestoSelect extends SelectBase<Node<PrestoExpression>> implements Node<PrestoExpression> {
+
+    private boolean isDistinct;
+
+    public boolean isDistinct() {
+        return isDistinct;
+    }
+
+    public void setDistinct(boolean isDistinct) {
+        this.isDistinct = isDistinct;
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoTableReference.java
+++ b/src/sqlancer/presto/ast/PrestoTableReference.java
@@ -1,0 +1,11 @@
+package sqlancer.presto.ast;
+
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.presto.PrestoSchema;
+
+public class PrestoTableReference extends TableReferenceNode<PrestoExpression, PrestoSchema.PrestoTable> {
+
+    public PrestoTableReference(PrestoSchema.PrestoTable table) {
+        super(table);
+    }
+}

--- a/src/sqlancer/presto/ast/PrestoUnaryPostfixOperation.java
+++ b/src/sqlancer/presto/ast/PrestoUnaryPostfixOperation.java
@@ -1,0 +1,52 @@
+package sqlancer.presto.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode;
+import sqlancer.common.ast.newast.NewUnaryPostfixOperatorNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoSchema;
+
+public class PrestoUnaryPostfixOperation extends NewUnaryPostfixOperatorNode<PrestoExpression> {
+
+    public PrestoUnaryPostfixOperation(Node<PrestoExpression> expr, PrestoUnaryPostfixOperator op) {
+        super(expr, op);
+    }
+
+    public Node<PrestoExpression> getExpression() {
+        return getExpr();
+    }
+
+    public enum PrestoUnaryPostfixOperator implements BinaryOperatorNode.Operator {
+        IS_NULL("IS NULL") {
+            @Override
+            public PrestoSchema.PrestoDataType[] getInputDataTypes() {
+                return PrestoSchema.PrestoDataType.values();
+            }
+        },
+        IS_NOT_NULL("IS NOT NULL") {
+            @Override
+            public PrestoSchema.PrestoDataType[] getInputDataTypes() {
+                return PrestoSchema.PrestoDataType.values();
+            }
+        };
+
+        private final String textRepresentations;
+
+        PrestoUnaryPostfixOperator(String text) {
+            this.textRepresentations = text;
+        }
+
+        public static PrestoUnaryPostfixOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentations;
+        }
+
+        public abstract PrestoSchema.PrestoDataType[] getInputDataTypes();
+
+    }
+
+}

--- a/src/sqlancer/presto/ast/PrestoUnaryPrefixOperation.java
+++ b/src/sqlancer/presto/ast/PrestoUnaryPrefixOperation.java
@@ -1,0 +1,62 @@
+package sqlancer.presto.ast;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode;
+import sqlancer.common.ast.newast.NewUnaryPrefixOperatorNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoSchema;
+
+public class PrestoUnaryPrefixOperation extends NewUnaryPrefixOperatorNode<PrestoExpression> {
+
+    public PrestoUnaryPrefixOperation(PrestoUnaryPrefixOperator operation, Node<PrestoExpression> expression) {
+        super(expression, operation);
+    }
+
+    public enum PrestoUnaryPrefixOperator implements BinaryOperatorNode.Operator {
+        NOT("NOT", PrestoSchema.PrestoDataType.BOOLEAN) {
+            @Override
+            public PrestoSchema.PrestoDataType getExpressionType() {
+                return PrestoSchema.PrestoDataType.BOOLEAN;
+            }
+        },
+
+        UNARY_PLUS("+", PrestoSchema.PrestoDataType.INT, PrestoSchema.PrestoDataType.FLOAT,
+                PrestoSchema.PrestoDataType.DECIMAL) {
+            @Override
+            public PrestoSchema.PrestoDataType getExpressionType() {
+                return PrestoSchema.PrestoDataType.INT;
+            }
+        },
+        UNARY_MINUS("-", PrestoSchema.PrestoDataType.INT, PrestoSchema.PrestoDataType.FLOAT,
+                PrestoSchema.PrestoDataType.DECIMAL) {
+            @Override
+            public PrestoSchema.PrestoDataType getExpressionType() {
+                return PrestoSchema.PrestoDataType.INT;
+            }
+        };
+
+        private final String textRepresentation;
+        private final PrestoSchema.PrestoDataType[] dataTypes;
+
+        PrestoUnaryPrefixOperator(String textRepresentation, PrestoSchema.PrestoDataType... dataTypes) {
+            this.textRepresentation = textRepresentation;
+            this.dataTypes = dataTypes.clone();
+        }
+
+        public PrestoSchema.PrestoDataType getRandomInputDataTypes() {
+            return Randomly.fromOptions(dataTypes);
+        }
+
+        public abstract PrestoSchema.PrestoDataType getExpressionType();
+
+        @Override
+        public String getTextRepresentation() {
+            return this.textRepresentation;
+        }
+
+        public PrestoSchema.PrestoDataType getExpressionType(PrestoSchema.PrestoDataType type) {
+            return type;
+        }
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoAlterTableGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoAlterTableGenerator.java
@@ -1,0 +1,67 @@
+package sqlancer.presto.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+
+public final class PrestoAlterTableGenerator {
+
+    private PrestoAlterTableGenerator() {
+    }
+
+    public static SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder("ALTER TABLE ");
+        PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        // PrestoTypedExpressionGenerator gen = new
+        // PrestoTypedExpressionGenerator(globalState).setColumns(table.getColumns());
+        sb.append(table.getName());
+        sb.append(" ");
+        Action action = Randomly.fromOptions(Action.values());
+        switch (action) {
+        case ADD_COLUMN:
+            sb.append("ADD COLUMN ");
+            String columnName = table.getFreeColumnName();
+            sb.append(columnName);
+            sb.append(" ");
+            sb.append(PrestoCompositeDataType.getRandomWithoutNull());
+            break;
+        case ALTER_COLUMN:
+            sb.append("ALTER COLUMN ");
+            sb.append(table.getRandomColumn().getName());
+            sb.append(" SET DATA TYPE ");
+            sb.append(PrestoCompositeDataType.getRandomWithoutNull());
+            // if (Randomly.getBoolean()) {
+            // sb.append(" USING ");
+            // PrestoErrors.addExpressionErrors(errors);
+            // sb.append(PrestoToStringVisitor.asString(gen.generateExpression()));
+            // }
+            errors.add("Cannot change the type of this column: an index depends on it!");
+            errors.add("Cannot change the type of a column that has a UNIQUE or PRIMARY KEY constraint specified");
+            errors.add("Unimplemented type for cast");
+            errors.add("Conversion:");
+            errors.add("Cannot change the type of a column that has a CHECK constraint specified");
+            break;
+        case DROP_COLUMN:
+            sb.append("DROP COLUMN ");
+            sb.append(table.getRandomColumn().getName());
+            errors.add("named in key does not exist"); // TODO
+            errors.add("Cannot drop this column:");
+            errors.add("Cannot drop column: table only has one column remaining!");
+            errors.add("because there is a CHECK constraint that depends on it");
+            errors.add("because there is a UNIQUE constraint that depends on it");
+            break;
+        default:
+            throw new AssertionError(action);
+        }
+        return new SQLQueryAdapter(sb.toString(), errors, true, false);
+    }
+
+    enum Action {
+        ADD_COLUMN, ALTER_COLUMN, DROP_COLUMN
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoDeleteGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoDeleteGenerator.java
@@ -1,0 +1,32 @@
+package sqlancer.presto.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.PrestoToStringVisitor;
+
+public final class PrestoDeleteGenerator {
+
+    private PrestoDeleteGenerator() {
+    }
+
+    public static SQLQueryAdapter generate(PrestoGlobalState globalState) {
+        StringBuilder sb = new StringBuilder("DELETE FROM ");
+        ExpectedErrors errors = new ExpectedErrors();
+        PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        sb.append(table.getName());
+        if (Randomly.getBoolean()) {
+            sb.append(" WHERE ");
+            sb.append(PrestoToStringVisitor
+                    .asString(new PrestoTypedExpressionGenerator(globalState).setColumns(table.getColumns())
+                            .generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull())));
+        }
+        PrestoErrors.addExpressionErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors, false, false);
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoIndexGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoIndexGenerator.java
@@ -1,0 +1,57 @@
+package sqlancer.presto.gen;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.ast.PrestoExpression;
+
+public final class PrestoIndexGenerator {
+
+    private PrestoIndexGenerator() {
+    }
+
+    public static SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE ");
+        if (Randomly.getBoolean()) {
+            errors.add("Cant create unique index, table contains duplicate data on indexed column(s)");
+            sb.append("UNIQUE ");
+        }
+        sb.append("INDEX ");
+        sb.append(Randomly.fromOptions("i0", "i1", "i2", "i3", "i4")); // cannot query this information
+        sb.append(" ON ");
+        PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        sb.append(table.getName());
+        sb.append("(");
+        List<PrestoColumn> columns = table.getRandomNonEmptyColumnSubset();
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(columns.get(i).getName());
+            sb.append(" ");
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                sb.append(Randomly.fromOptions("ASC", "DESC"));
+            }
+        }
+        sb.append(")");
+        if (Randomly.getBoolean()) {
+            sb.append(" WHERE ");
+            Node<PrestoExpression> expr = new PrestoTypedExpressionGenerator(globalState).setColumns(table.getColumns())
+                    .generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull());
+            sb.append(PrestoToStringVisitor.asString(expr));
+        }
+        errors.add("already exists!");
+        return new SQLQueryAdapter(sb.toString(), errors, true, false);
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoInsertGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoInsertGenerator.java
@@ -1,0 +1,52 @@
+package sqlancer.presto.gen;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.gen.AbstractInsertGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.ast.PrestoExpression;
+
+public class PrestoInsertGenerator extends AbstractInsertGenerator<PrestoColumn> {
+
+    private final PrestoGlobalState globalState;
+    private final ExpectedErrors errors = new ExpectedErrors();
+
+    public PrestoInsertGenerator(PrestoGlobalState globalState) {
+        this.globalState = globalState;
+    }
+
+    public static SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
+        return new PrestoInsertGenerator(globalState).generate();
+    }
+
+    private SQLQueryAdapter generate() {
+        sb.append("INSERT INTO ");
+        PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        List<PrestoColumn> columns = table.getRandomNonEmptyColumnSubset();
+        sb.append(table.getName());
+        sb.append("(");
+        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
+        sb.append(")");
+        sb.append(" VALUES ");
+        insertColumns(columns);
+        PrestoErrors.addInsertErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors, false, false);
+    }
+
+    @Override
+    protected void insertValue(PrestoColumn prestoColumn) {
+        Node<PrestoExpression> constant = new PrestoTypedExpressionGenerator(globalState)
+                .generateInsertConstant(prestoColumn.getType());
+        sb.append(PrestoToStringVisitor.asString(constant));
+
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoRandomQuerySynthesizer.java
+++ b/src/sqlancer/presto/gen/PrestoRandomQuerySynthesizer.java
@@ -1,0 +1,72 @@
+package sqlancer.presto.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.PrestoSchema.PrestoTables;
+import sqlancer.presto.ast.PrestoConstant;
+import sqlancer.presto.ast.PrestoExpression;
+import sqlancer.presto.ast.PrestoJoin;
+import sqlancer.presto.ast.PrestoSelect;
+
+public final class PrestoRandomQuerySynthesizer {
+
+    private PrestoRandomQuerySynthesizer() {
+    }
+
+    public static PrestoSelect generateSelect(PrestoGlobalState globalState, int nrColumns) {
+        PrestoTables targetTables = globalState.getSchema().getRandomTableNonEmptyTables();
+        PrestoTypedExpressionGenerator gen = new PrestoTypedExpressionGenerator(globalState)
+                .setColumns(targetTables.getColumns());
+        PrestoSelect select = new PrestoSelect();
+        // TODO: distinct
+        // select.setDistinct(Randomly.getBoolean());
+        // boolean allowAggregates = Randomly.getBooleanWithSmallProbability();
+        List<Node<PrestoExpression>> columns = new ArrayList<>();
+        for (int i = 0; i < nrColumns; i++) {
+            // if (allowAggregates && Randomly.getBoolean()) {
+            Node<PrestoExpression> expression = gen
+                    .generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull());
+            columns.add(expression);
+            // } else {
+            // columns.add(gen());
+            // }
+        }
+        select.setFetchColumns(columns);
+        List<PrestoTable> tables = targetTables.getTables();
+        List<TableReferenceNode<PrestoExpression, PrestoTable>> tableList = tables.stream()
+                .map(t -> new TableReferenceNode<PrestoExpression, PrestoTable>(t)).collect(Collectors.toList());
+        List<Node<PrestoExpression>> joins = PrestoJoin.getJoins(tableList, globalState);
+        select.setJoinList(new ArrayList<>(joins));
+        select.setFromList(new ArrayList<>(tableList));
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull()));
+        }
+        if (Randomly.getBoolean()) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+        if (Randomly.getBoolean()) {
+            select.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
+        }
+
+        if (Randomly.getBoolean()) {
+            select.setLimitClause(PrestoConstant.createIntConstant(Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)));
+        }
+        // if (Randomly.getBoolean()) {
+        // select.setOffsetClause(
+        // PrestoConstant.createIntConstant(Randomly.getNotCachedInteger(0, Integer.MAX_VALUE)));
+        // }
+        if (Randomly.getBoolean()) {
+            select.setHavingClause(gen.generateHavingClause());
+        }
+        return select;
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoTableGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoTableGenerator.java
@@ -1,0 +1,69 @@
+package sqlancer.presto.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+
+public class PrestoTableGenerator {
+
+    private static List<PrestoColumn> getNewColumns() {
+        List<PrestoColumn> columns = new ArrayList<>();
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            String columnName = String.format("c%d", i);
+            PrestoCompositeDataType columnType = PrestoCompositeDataType.getRandomWithoutNull();
+            columns.add(new PrestoColumn(columnName, columnType, false, false));
+        }
+        return columns;
+    }
+
+    public SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
+        ExpectedErrors errors = new ExpectedErrors();
+        StringBuilder sb = new StringBuilder();
+        String tableName = globalState.getSchema().getFreeTableName();
+        sb.append("CREATE TABLE ");
+        String catalog = globalState.getDbmsSpecificOptions().catalog;
+        String schema = globalState.getDatabaseName();
+
+        sb.append(catalog).append(".");
+        sb.append(schema).append(".");
+
+        sb.append(tableName);
+        sb.append("(");
+        List<PrestoColumn> columns = getNewColumns();
+        // TypedExpressionGenerator<Node<PrestoExpression>, PrestoColumn, PrestoCompositeDataType>
+        // typedExpressionGenerator = new PrestoTypedExpressionGenerator(globalState).setColumns(columns);
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            PrestoColumn column = columns.get(i);
+            sb.append(column.getName());
+            sb.append(" ");
+            sb.append(column.getType());
+            // if (globalState.getDbmsSpecificOptions().testIndexes && Randomly.getBooleanWithRatherLowProbability()) {
+            // sb.append(" UNIQUE");
+            // }
+            // if (globalState.getDbmsSpecificOptions().testNotNullConstraints
+            // && Randomly.getBooleanWithRatherLowProbability()) {
+            // sb.append(" NOT NULL");
+            // }
+        }
+        // if (globalState.getDbmsSpecificOptions().testIndexes && Randomly.getBoolean()) {
+        // errors.add("Invalid type for index");
+        // List<PrestoColumn> primaryKeyColumns = Randomly.nonEmptySubset(columns);
+        // sb.append(", PRIMARY KEY(");
+        // sb.append(primaryKeyColumns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
+        // sb.append(")");
+        // }
+        sb.append(")");
+
+        return new SQLQueryAdapter(sb.toString(), errors, true, false);
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoTypedExpressionGenerator.java
@@ -1,0 +1,798 @@
+package sqlancer.presto.gen;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.BinaryOperatorNode;
+import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.common.ast.newast.NewBetweenOperatorNode;
+import sqlancer.common.ast.newast.NewBinaryOperatorNode;
+import sqlancer.common.ast.newast.NewCaseOperatorNode;
+import sqlancer.common.ast.newast.NewFunctionNode;
+import sqlancer.common.ast.newast.NewInOperatorNode;
+import sqlancer.common.ast.newast.NewTernaryNode;
+import sqlancer.common.ast.newast.NewUnaryPrefixOperatorNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.common.gen.TypedExpressionGenerator;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.ast.PrestoAggregateFunction;
+import sqlancer.presto.ast.PrestoAtTimeZoneOperator;
+import sqlancer.presto.ast.PrestoCastFunction;
+import sqlancer.presto.ast.PrestoColumnReference;
+import sqlancer.presto.ast.PrestoConstant;
+import sqlancer.presto.ast.PrestoDefaultFunction;
+import sqlancer.presto.ast.PrestoExpression;
+import sqlancer.presto.ast.PrestoJoin;
+import sqlancer.presto.ast.PrestoMultiValuedComparison;
+import sqlancer.presto.ast.PrestoMultiValuedComparisonOperator;
+import sqlancer.presto.ast.PrestoMultiValuedComparisonType;
+import sqlancer.presto.ast.PrestoQuantifiedComparison;
+import sqlancer.presto.ast.PrestoSelect;
+import sqlancer.presto.ast.PrestoUnaryPostfixOperation;
+import sqlancer.presto.ast.PrestoUnaryPrefixOperation;
+
+public final class PrestoTypedExpressionGenerator extends
+        TypedExpressionGenerator<Node<PrestoExpression>, PrestoSchema.PrestoColumn, PrestoSchema.PrestoCompositeDataType> {
+
+    private final Randomly randomly;
+    private final PrestoGlobalState globalState;
+    private final int maxDepth;
+
+    public PrestoTypedExpressionGenerator(PrestoGlobalState globalState) {
+        this.globalState = globalState;
+        this.randomly = globalState.getRandomly();
+        this.maxDepth = globalState.getOptions().getMaxExpressionDepth();
+    }
+
+    @Override
+    public Node<PrestoExpression> generatePredicate() {
+        return generateExpression(
+                PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.BOOLEAN),
+                randomly.getInteger(0, maxDepth));
+    }
+
+    @Override
+    public Node<PrestoExpression> negatePredicate(Node<PrestoExpression> predicate) {
+        return new PrestoUnaryPrefixOperation(PrestoUnaryPrefixOperation.PrestoUnaryPrefixOperator.NOT, predicate);
+    }
+
+    @Override
+    public Node<PrestoExpression> isNull(Node<PrestoExpression> expr) {
+        return new PrestoUnaryPostfixOperation(expr, PrestoUnaryPostfixOperation.PrestoUnaryPostfixOperator.IS_NULL);
+    }
+
+    @Override
+    public Node<PrestoExpression> generateConstant(PrestoSchema.PrestoCompositeDataType type) {
+        if (Objects.requireNonNull(type.getPrimitiveDataType()) == PrestoSchema.PrestoDataType.ARRAY) {
+            return PrestoConstant.createArrayConstant(type);
+            // case MAP:
+            // return PrestoConstant.createMapConstant(type);
+        }
+        return PrestoConstant.generateConstant(type, false);
+    }
+
+    public Node<PrestoExpression> generateInsertConstant(PrestoSchema.PrestoCompositeDataType type) {
+        if (Objects.requireNonNull(type.getPrimitiveDataType()) == PrestoSchema.PrestoDataType.ARRAY) {
+            return PrestoConstant.createArrayConstant(type);
+            // case MAP:
+            // return PrestoConstant.createMapConstant(type);
+        }
+        return PrestoConstant.generateConstant(type, true);
+    }
+
+    @Override
+    public Node<PrestoExpression> generateExpression(PrestoSchema.PrestoCompositeDataType type, int depth) {
+        if (allowAggregates && Randomly.getBoolean()) {
+            return generateAggregate(type);
+        }
+        if (depth >= globalState.getOptions().getMaxExpressionDepth() || Randomly.getBoolean()) {
+            return generateLeafNode(type);
+        } else {
+            // TODO: functions
+            List<PrestoDefaultFunction> applicableFunctions = PrestoDefaultFunction.getFunctionsCompatibleWith(type);
+            if (Randomly.getBooleanWithRatherLowProbability() && !applicableFunctions.isEmpty()) {
+                PrestoDefaultFunction function = Randomly.fromList(applicableFunctions);
+                return generateFunction(type, depth, function);
+            }
+            // TODO: try
+            // if (Randomly.getBooleanWithRatherLowProbability()) {
+            // return generateTry(type, depth);
+            // }
+
+            // TODO: cast
+            //
+            // if (Randomly.getBooleanWithRatherLowProbability()) {
+            // Node<PrestoExpression> expressionNode = generateCast(type, depth);
+            // }
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                return getCase(type, depth);
+            }
+            switch (type.getPrimitiveDataType()) {
+            case BOOLEAN:
+                return generateBooleanExpression(depth);
+            case VARCHAR:
+            case CHAR:
+                return generateStringExpression(type, depth);
+            case INT:
+            case DECIMAL:
+            case FLOAT:
+                return generateNumericExpression(depth);
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case TIME_WITH_TIME_ZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
+                return generateTemporalExpression(type, depth);
+            case INTERVAL_YEAR_TO_MONTH:
+            case INTERVAL_DAY_TO_SECOND:
+                return generateIntervalExpression(type, depth);
+            case JSON:
+                return generateJsonExpression(type);
+            case VARBINARY:
+            case ARRAY:
+                // case MAP:
+                return generateLeafNode(type); // TODO
+            default:
+                throw new AssertionError(type);
+            }
+        }
+    }
+
+    private Node<PrestoExpression> generateJsonExpression(PrestoSchema.PrestoCompositeDataType type) {
+        return generateLeafNode(type);
+    }
+
+    private Node<PrestoExpression> generateCast(PrestoSchema.PrestoCompositeDataType type, int depth) {
+        // check can cast
+        Node<PrestoExpression> expressionNode = generateExpression(getRandomType(), depth + 1);
+        return new PrestoCastFunction(expressionNode, type);
+    }
+
+    @SuppressWarnings("unused")
+    private Node<PrestoExpression> generateTry(PrestoSchema.PrestoCompositeDataType type, int depth) {
+        if (type.getPrimitiveDataType().isNumeric() && Randomly.getBooleanWithRatherLowProbability()) {
+            Node<PrestoExpression> expression = generateExpression(type);
+            return new NewFunctionNode<>(List.of(expression), "try");
+        }
+
+        List<PrestoDefaultFunction> applicableFunctions = PrestoDefaultFunction.getFunctionsCompatibleWith(type);
+        if (Randomly.getBooleanWithRatherLowProbability() && !applicableFunctions.isEmpty()) {
+            PrestoDefaultFunction function = Randomly.fromList(applicableFunctions);
+            Node<PrestoExpression> expression = generateFunction(type, depth, function);
+            return new NewFunctionNode<>(List.of(expression), "try");
+        }
+        return new NewFunctionNode<>(List.of(generateCast(type, depth)), "try");
+    }
+
+    private NewCaseOperatorNode<PrestoExpression> getCase(PrestoSchema.PrestoCompositeDataType type, int depth) {
+        List<Node<PrestoExpression>> conditions = new ArrayList<>();
+        List<Node<PrestoExpression>> cases = new ArrayList<>();
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            conditions.add(generateExpression(type, depth + 1));
+            cases.add(generateExpression(type, depth + 1));
+        }
+        Node<PrestoExpression> elseExpr = null;
+        if (Randomly.getBoolean()) {
+            elseExpr = generateExpression(type, depth + 1);
+        }
+        Node<PrestoExpression> expression = generateExpression(type);
+        return new NewCaseOperatorNode<>(expression, conditions, cases, elseExpr);
+    }
+
+    private Node<PrestoExpression> generateFunction(PrestoSchema.PrestoCompositeDataType returnType, int depth,
+            PrestoDefaultFunction function) {
+
+        PrestoSchema.PrestoDataType[] argumentTypes = function.getArgumentTypes(returnType);
+        List<Node<PrestoExpression>> arguments = new ArrayList<>();
+
+        // This is a workaround based on the assumption that array types should refer to
+        // the same element type.
+        PrestoSchema.PrestoCompositeDataType savedArrayType = null;
+        if (returnType.getPrimitiveDataType() == PrestoSchema.PrestoDataType.ARRAY) {
+            savedArrayType = returnType;
+        }
+        if (function.getNumberOfArguments() == -1) {
+            PrestoSchema.PrestoDataType dataType = argumentTypes[0];
+            // TODO: consider upper
+            long no = Randomly.getNotCachedInteger(2, 10);
+            for (int i = 0; i < no; i++) {
+                PrestoSchema.PrestoCompositeDataType type;
+
+                if (dataType == PrestoSchema.PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        savedArrayType = dataType.get();
+                    }
+                    type = savedArrayType;
+                } else {
+                    type = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
+                }
+                arguments.add(generateExpression(type, depth + 1));
+            }
+        } else {
+            for (PrestoSchema.PrestoDataType arg : argumentTypes) {
+                PrestoSchema.PrestoCompositeDataType dataType;
+                if (arg == PrestoSchema.PrestoDataType.ARRAY) {
+                    if (savedArrayType == null) {
+                        savedArrayType = arg.get();
+                    }
+                    dataType = savedArrayType;
+                } else {
+                    dataType = PrestoSchema.PrestoCompositeDataType.fromDataType(arg);
+                }
+                Node<PrestoExpression> expression = generateExpression(dataType, depth + 1);
+                arguments.add(expression);
+            }
+        }
+        return new NewFunctionNode<>(arguments, function);
+    }
+
+    private Node<PrestoExpression> generateStringExpression(PrestoSchema.PrestoCompositeDataType type, int depth) {
+        if (depth >= globalState.getOptions().getMaxExpressionDepth() || Randomly.getBoolean()) {
+            return generateLeafNode(type);
+        }
+        return getStringOperation(depth);
+    }
+
+    private NewBinaryOperatorNode<PrestoExpression> getStringOperation(int depth) {
+        StringExpression exprType = Randomly.fromOptions(StringExpression.values());
+        if (Objects.requireNonNull(exprType) == StringExpression.CONCAT) {
+            Node<PrestoExpression> left = generateExpression(
+                    PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.VARCHAR), depth + 1);
+            Node<PrestoExpression> right = generateExpression(
+                    PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.VARCHAR), depth + 1);
+            PrestBinaryStringOperator operator = PrestBinaryStringOperator.CONCAT;
+            return new NewBinaryOperatorNode<>(left, right, operator);
+        }
+        throw new AssertionError(exprType);
+    }
+
+    private Node<PrestoExpression> generateBooleanExpression(int depth) {
+        List<BooleanExpression> booleanExpressions = Arrays.stream(BooleanExpression.values())
+                .collect(Collectors.toList());
+        if (!globalState.getDbmsSpecificOptions().testBetween) {
+            booleanExpressions.remove(BooleanExpression.BETWEEN);
+        }
+
+        booleanExpressions.remove(BooleanExpression.REGEX);
+
+        BooleanExpression exprType = Randomly.fromList(booleanExpressions);
+        switch (exprType) {
+        case NOT:
+            return generateNOT(depth + 1);
+        case BINARY_COMPARISON:
+            return getBinaryComparison(depth);
+        case BINARY_LOGICAL:
+            return getBinaryLogical(depth);
+        case AND_OR_CHAIN:
+            return getAndOrChain(depth);
+        case REGEX:
+            return getRegex(depth);
+        case IS_NULL:
+            return new PrestoUnaryPostfixOperation(generateExpression(getRandomType(), depth + 1),
+                    Randomly.fromOptions(PrestoUnaryPostfixOperation.PrestoUnaryPostfixOperator.IS_NULL,
+                            PrestoUnaryPostfixOperation.PrestoUnaryPostfixOperator.IS_NOT_NULL));
+        case IN:
+            return getInOperation(depth);
+        case BETWEEN:
+            return getBetween(depth);
+        case LIKE:
+            return getLike(depth);
+        case MULTI_VALUED_COMPARISON: // TODO other operators
+            return getMultiValuedComparison(depth);
+        default:
+            throw new AssertionError(exprType);
+        }
+    }
+
+    private Node<PrestoExpression> getMultiValuedComparison(int depth) {
+
+        PrestoSchema.PrestoCompositeDataType type;
+        do {
+            type = PrestoSchema.PrestoCompositeDataType
+                    .fromDataType(Randomly.fromList(PrestoSchema.PrestoDataType.getOrderableTypes()));
+        } while (type.getPrimitiveDataType() == PrestoSchema.PrestoDataType.ARRAY
+                && !type.getElementType().getPrimitiveDataType().isOrderable());
+
+        PrestoMultiValuedComparisonType comparisonType = PrestoMultiValuedComparisonType.getRandom();
+        PrestoMultiValuedComparisonOperator comparisonOperator = PrestoMultiValuedComparisonOperator
+                .getRandomForType(type);
+        Node<PrestoExpression> left = generateExpression(type, depth + 1);
+        // sub-query
+        PrestoSchema.PrestoCompositeDataType finalType = type;
+        List<PrestoSchema.PrestoColumn> columnsOfType = columns.stream().filter(c -> c.getType() == finalType)
+                .collect(Collectors.toList());
+        if (Randomly.getBooleanWithRatherLowProbability() && !columnsOfType.isEmpty()) {
+            PrestoSchema.PrestoColumn column = Randomly.fromList(columnsOfType);
+            PrestoSelect subquery = generateSubquery(List.of(column));
+            return new PrestoQuantifiedComparison(left, subquery, comparisonType, comparisonOperator);
+        }
+        int nr = Randomly.smallNumber() + 2;
+        List<Node<PrestoExpression>> rightList = new ArrayList<>();
+        for (int i = 0; i < nr; i++) {
+            rightList.add(generateConstant(type));
+        }
+        return new PrestoMultiValuedComparison(left, rightList, comparisonType, comparisonOperator);
+    }
+
+    private PrestoSelect generateSubquery(List<PrestoSchema.PrestoColumn> columns) {
+        PrestoSelect select = new PrestoSelect();
+        List<Node<PrestoExpression>> allColumns = columns.stream()
+                .map((c) -> new ColumnReferenceNode<PrestoExpression, PrestoSchema.PrestoColumn>(c))
+                .collect(Collectors.toList());
+        select.setFetchColumns(allColumns);
+        List<PrestoSchema.PrestoTable> tables = columns.stream().map(AbstractTableColumn::getTable)
+                .collect(Collectors.toList());
+        List<TableReferenceNode<PrestoExpression, PrestoSchema.PrestoTable>> tableList = tables.stream()
+                .map(t -> new TableReferenceNode<PrestoExpression, PrestoSchema.PrestoTable>(t)).distinct()
+                .collect(Collectors.toList());
+        List<Node<PrestoExpression>> tableNodeList = tables.stream()
+                .map(t -> new TableReferenceNode<PrestoExpression, PrestoSchema.PrestoTable>(t))
+                .collect(Collectors.toList());
+        select.setFromList(tableNodeList);
+        TypedExpressionGenerator<Node<PrestoExpression>, PrestoSchema.PrestoColumn, PrestoSchema.PrestoCompositeDataType> typedExpressionGenerator = new PrestoTypedExpressionGenerator(
+                globalState).setColumns(columns);
+        Node<PrestoExpression> predicate = typedExpressionGenerator.generatePredicate();
+        select.setWhereClause(predicate);
+        if (Randomly.getBooleanWithSmallProbability()) {
+            select.setOrderByExpressions(typedExpressionGenerator.generateOrderBys());
+        }
+        List<Node<PrestoExpression>> joins = PrestoJoin.getJoins(tableList, globalState);
+        select.setJoinList(joins);
+        return select;
+    }
+
+    private Node<PrestoExpression> generateNumericExpression(int depth) {
+        PrestoSchema.PrestoDataType dataType = Randomly.fromList(PrestoSchema.PrestoDataType.getNumberTypes());
+        PrestoSchema.PrestoCompositeDataType type = PrestoSchema.PrestoCompositeDataType.fromDataType(dataType);
+        if (Randomly.getBoolean()) {
+            BinaryOperatorNode.Operator operator = PrestoBinaryArithmeticOperator.getRandom();
+            Node<PrestoExpression> left = generateExpression(type, depth);
+            Node<PrestoExpression> right = generateExpression(type, depth);
+            return new NewBinaryOperatorNode<>(left, right, operator);
+        } else {
+            BinaryOperatorNode.Operator operator = PrestoUnaryArithmeticOperator.MINUS;
+            Node<PrestoExpression> left = generateExpression(type, depth);
+            return new NewUnaryPrefixOperatorNode<>(left, operator);
+        }
+    }
+
+    private Node<PrestoExpression> generateTemporalExpression(PrestoSchema.PrestoCompositeDataType type, int depth) {
+        if (Randomly.getBooleanWithSmallProbability()) {
+            Node<PrestoExpression> left = generateExpression(type, depth);
+            Node<PrestoExpression> right = generateExpression(PrestoSchema.PrestoCompositeDataType
+                    .fromDataType(Randomly.fromList(PrestoSchema.PrestoDataType.getIntervalTypes())), depth);
+            BinaryOperatorNode.Operator operator = PrestoBinaryTemporalOperator.getRandom();
+            return new NewBinaryOperatorNode<>(left, right, operator);
+        }
+
+        // timestamp at time zone
+        if (Randomly.getBooleanWithSmallProbability()
+                && (type.getPrimitiveDataType() == PrestoSchema.PrestoDataType.TIMESTAMP
+                        || type.getPrimitiveDataType() == PrestoSchema.PrestoDataType.TIMESTAMP_WITH_TIME_ZONE)) {
+            return new PrestoAtTimeZoneOperator(generateExpression(type, depth + 1),
+                    PrestoConstant.createTimezoneConstant());
+        }
+        return generateLeafNode(type);
+    }
+
+    private Node<PrestoExpression> generateIntervalExpression(PrestoSchema.PrestoCompositeDataType type, int depth) {
+        if (Randomly.getBooleanWithSmallProbability()) {
+            Node<PrestoExpression> left = generateExpression(type, depth);
+
+            Node<PrestoExpression> right;
+            if (Randomly.getBoolean()) {
+                right = generateExpression(PrestoSchema.PrestoCompositeDataType
+                        .fromDataType(Randomly.fromList(PrestoSchema.PrestoDataType.getTemporalTypes())), depth);
+            } else {
+                right = generateExpression(type, depth);
+            }
+            BinaryOperatorNode.Operator operator = PrestoBinaryTemporalOperator.getRandom();
+            if (Randomly.getBoolean()) {
+                return new NewBinaryOperatorNode<>(left, right, operator);
+            } else {
+                return new NewBinaryOperatorNode<>(right, left, operator);
+            }
+        }
+        return generateLeafNode(type);
+
+        // functions
+
+        // timestamp at time zone
+    }
+
+    private Node<PrestoExpression> getLike(int depth) {
+        PrestoSchema.PrestoCompositeDataType type = PrestoSchema.PrestoCompositeDataType
+                .fromDataType(PrestoSchema.PrestoDataType.VARCHAR);
+        Node<PrestoExpression> expression = generateExpression(type, depth + 1);
+        Node<PrestoExpression> pattern = generateExpression(type, depth + 1);
+        if (Randomly.getBoolean()) {
+            return new NewBinaryOperatorNode<>(expression, pattern, PrestoLikeOperator.getRandom());
+        } else {
+            String randomlyString = randomly.getString();
+            String randomlyChar = randomly.getChar();
+            Node<PrestoExpression> escape = new PrestoConstant.PrestoTextConstant(randomlyChar, 1);
+            int index = randomlyString.indexOf(randomlyChar);
+            while (index > -1) {
+                String wildcard = Randomly.fromOptions("%", "_");
+                randomlyString = randomlyString.substring(0, index + 1) + wildcard
+                        + randomlyString.substring(index + 1);
+                index = randomlyString.indexOf(randomlyChar, index + 1);
+            }
+            PrestoConstant.PrestoTextConstant patternString = new PrestoConstant.PrestoTextConstant(randomlyString);
+            return new NewTernaryNode<>(expression, patternString, escape, "LIKE", "ESCAPE");
+        }
+    }
+
+    private NewBinaryOperatorNode<PrestoExpression> getRegex(int depth) {
+        Node<PrestoExpression> left = generateExpression(
+                PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.VARCHAR), depth + 1);
+        Node<PrestoExpression> right = generateExpression(
+                PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.VARCHAR), depth + 1);
+        return new NewBinaryOperatorNode<>(left, right, PrestoBinaryLogicalOperator.getRandom());
+    }
+
+    private NewBinaryOperatorNode<PrestoExpression> getBinaryLogical(int depth) {
+        PrestoSchema.PrestoCompositeDataType type = PrestoSchema.PrestoCompositeDataType
+                .fromDataType(PrestoSchema.PrestoDataType.BOOLEAN);
+        Node<PrestoExpression> left = generateExpression(type, depth + 1);
+        Node<PrestoExpression> right = generateExpression(type, depth + 1);
+        BinaryOperatorNode.Operator operator = PrestoBinaryLogicalOperator.getRandom();
+        return new NewBinaryOperatorNode<>(left, right, operator);
+    }
+
+    private Node<PrestoExpression> getBetween(int depth) {
+        PrestoSchema.PrestoCompositeDataType type = PrestoSchema.PrestoCompositeDataType
+                .fromDataType(Randomly.fromList(PrestoSchema.PrestoDataType.getNumericTypes()));
+        Node<PrestoExpression> expression = generateExpression(type, depth + 1);
+        Node<PrestoExpression> left = generateExpression(type, depth + 1);
+        Node<PrestoExpression> right = generateExpression(type, depth + 1);
+        return new NewBetweenOperatorNode<>(expression, left, right, Randomly.getBoolean());
+    }
+
+    private Node<PrestoExpression> getInOperation(int depth) {
+        PrestoSchema.PrestoCompositeDataType type = PrestoSchema.PrestoCompositeDataType
+                .fromDataType(PrestoSchema.PrestoDataType.getRandomWithoutNull());
+        Node<PrestoExpression> left = generateExpression(type, depth + 1);
+        List<Node<PrestoExpression>> inList = generateExpressions(type, Randomly.smallNumber() + 1, depth + 1);
+        boolean isNegated = Randomly.getBoolean();
+        return new NewInOperatorNode<>(left, inList, isNegated);
+    }
+
+    private Node<PrestoExpression> getAndOrChain(int depth) {
+        Node<PrestoExpression> left = generateExpression(
+                PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.BOOLEAN), depth + 1);
+        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
+            Node<PrestoExpression> right = generateExpression(
+                    PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.BOOLEAN), depth + 1);
+            BinaryOperatorNode.Operator operator = PrestoBinaryLogicalOperator.getRandom();
+            left = new NewBinaryOperatorNode<>(left, right, operator);
+        }
+        return left;
+    }
+
+    private Node<PrestoExpression> getBinaryComparison(int depth) {
+        PrestoSchema.PrestoCompositeDataType type = getRandomType();
+        BinaryOperatorNode.Operator op = PrestoBinaryComparisonOperator.getRandomForType(type);
+        Node<PrestoExpression> left = generateExpression(type, depth + 1);
+        Node<PrestoExpression> right = generateExpression(type, depth + 1);
+        return new NewBinaryOperatorNode<>(left, right, op);
+    }
+
+    private Node<PrestoExpression> generateNOT(int depth) {
+        PrestoUnaryPrefixOperation.PrestoUnaryPrefixOperator operator = PrestoUnaryPrefixOperation.PrestoUnaryPrefixOperator.NOT;
+        return new PrestoUnaryPrefixOperation(operator, generateExpression(
+                PrestoSchema.PrestoCompositeDataType.fromDataType(PrestoSchema.PrestoDataType.BOOLEAN), depth));
+    }
+
+    @Override
+    protected Node<PrestoExpression> generateColumn(PrestoSchema.PrestoCompositeDataType type) {
+        List<PrestoSchema.PrestoColumn> columnList = columns.stream()
+                .filter(c -> c.getType().getPrimitiveDataType() == type.getPrimitiveDataType())
+                .collect(Collectors.toList());
+        PrestoSchema.PrestoColumn column = Randomly.fromList(columnList);
+        return new PrestoColumnReference(column);
+    }
+
+    @Override
+    public Node<PrestoExpression> generateLeafNode(PrestoSchema.PrestoCompositeDataType type) {
+        if (Randomly.getBoolean()) {
+            return generateConstant(type);
+        } else {
+            List<PrestoSchema.PrestoColumn> columnList = filterColumns(type.getPrimitiveDataType());
+            if (columnList.isEmpty()) {
+                return generateConstant(type);
+            } else {
+                return generateColumn(type);
+            }
+        }
+    }
+
+    private List<PrestoSchema.PrestoColumn> filterColumns(PrestoSchema.PrestoDataType dataType) {
+        if (columns == null) {
+            return Collections.emptyList();
+        } else {
+            return columns.stream().filter(c -> c.getType().getPrimitiveDataType() == dataType)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Override
+    protected PrestoSchema.PrestoCompositeDataType getRandomType() {
+        return PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull();
+    }
+
+    @Override
+    protected boolean canGenerateColumnOfType(PrestoSchema.PrestoCompositeDataType type) {
+        return columns.stream().anyMatch(c -> c.getType() == type);
+    }
+
+    public Node<PrestoExpression> generateAggregate() {
+        PrestoAggregateFunction aggregateFunction = PrestoAggregateFunction.getRandom();
+        List<Node<PrestoExpression>> argsForAggregate = generateArgsForAggregate(aggregateFunction);
+        return new NewFunctionNode<>(argsForAggregate, aggregateFunction);
+    }
+
+    public List<Node<PrestoExpression>> generateArgsForAggregate(PrestoAggregateFunction aggregateFunction) {
+        PrestoSchema.PrestoCompositeDataType returnType;
+        do {
+            returnType = aggregateFunction.getCompositeReturnType();
+        } while (!aggregateFunction.isCompatibleWithReturnType(returnType));
+        return aggregateFunction.getArgumentsForReturnType(this, this.maxDepth - 1, returnType, false);
+    }
+
+    private Node<PrestoExpression> generateAggregate(PrestoSchema.PrestoCompositeDataType type) {
+        PrestoAggregateFunction aggregateFunction = Randomly
+                .fromList(PrestoAggregateFunction.getFunctionsCompatibleWith(type));
+        List<Node<PrestoExpression>> argsForAggregate = generateArgsForAggregate(type, aggregateFunction);
+        return new NewFunctionNode<>(argsForAggregate, aggregateFunction);
+    }
+
+    public List<Node<PrestoExpression>> generateArgsForAggregate(PrestoSchema.PrestoCompositeDataType type,
+            PrestoAggregateFunction aggregateFunction) {
+        List<PrestoSchema.PrestoDataType> returnTypes = aggregateFunction.getReturnTypes(type.getPrimitiveDataType());
+        List<Node<PrestoExpression>> arguments = new ArrayList<>();
+        allowAggregates = false; //
+        for (PrestoSchema.PrestoDataType argumentType : returnTypes) {
+            arguments.add(generateExpression(PrestoSchema.PrestoCompositeDataType.fromDataType(argumentType)));
+        }
+        // return new NewFunctionNode<>(arguments, aggregateFunction);
+        return arguments;
+    }
+
+    @Override
+    public List<Node<PrestoExpression>> generateOrderBys() {
+        List<Node<PrestoExpression>> expressions = new ArrayList<>();
+        int nr = Randomly.smallNumber() + 1;
+        ArrayList<PrestoSchema.PrestoColumn> prestoColumns = new ArrayList<>(columns);
+        prestoColumns.removeIf(c -> !c.isOrderable());
+        for (int i = 0; i < nr && !prestoColumns.isEmpty(); i++) {
+            PrestoSchema.PrestoColumn randomColumn = Randomly.fromList(prestoColumns);
+            PrestoColumnReference columnReference = new PrestoColumnReference(randomColumn);
+            prestoColumns.remove(randomColumn);
+            expressions.add(columnReference);
+        }
+        return expressions;
+    }
+
+    public Node<PrestoExpression> generateHavingClause() {
+        allowAggregates = true;
+        Node<PrestoExpression> expr = generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull());
+        allowAggregates = false;
+        return expr;
+    }
+
+    public Node<PrestoExpression> generateExpressionWithColumns(List<PrestoSchema.PrestoColumn> columns,
+            int remainingDepth) {
+        if (columns.isEmpty() || remainingDepth <= 2 && Randomly.getBooleanWithRatherLowProbability()) {
+            return generateConstant(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull());
+        }
+        PrestoSchema.PrestoColumn column = Randomly.fromList(columns);
+        if (remainingDepth <= 2 || Randomly.getBooleanWithRatherLowProbability()) {
+            return new PrestoColumnReference(column);
+        }
+        List<Expression> possibleOptions = new ArrayList<>(
+                Arrays.asList(PrestoTypedExpressionGenerator.Expression.values()));
+        PrestoTypedExpressionGenerator.Expression expr = Randomly.fromList(possibleOptions);
+        BinaryOperatorNode.Operator op;
+        switch (expr) {
+        case BINARY_LOGICAL:
+        case BINARY_ARITHMETIC:
+            op = PrestoTypedExpressionGenerator.PrestoBinaryLogicalOperator.getRandom();
+            break;
+        case BINARY_COMPARISON:
+            op = PrestoBinaryComparisonOperator.getRandom();
+            break;
+        default:
+            throw new AssertionError();
+        }
+        return new NewBinaryOperatorNode<>(generateExpression(column.getType(), remainingDepth - 1),
+                generateExpression(column.getType(), remainingDepth - 1), op);
+    }
+
+    private enum StringExpression {
+        CONCAT
+    }
+
+    public enum PrestBinaryStringOperator implements BinaryOperatorNode.Operator {
+        CONCAT("||");
+
+        private final String textRepresentation;
+
+        PrestBinaryStringOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static BinaryOperatorNode.Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+    }
+
+    public enum PrestoBinaryTemporalOperator implements BinaryOperatorNode.Operator {
+        ADD("+"), SUB("-");
+
+        private final String textRepresentation;
+
+        PrestoBinaryTemporalOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static BinaryOperatorNode.Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+    }
+
+    private enum BooleanExpression {
+        NOT, BINARY_COMPARISON, BINARY_LOGICAL, AND_OR_CHAIN, REGEX, IS_NULL, IN, BETWEEN, LIKE, MULTI_VALUED_COMPARISON
+    }
+
+    public enum PrestoBinaryLogicalOperator implements BinaryOperatorNode.Operator {
+
+        AND, OR;
+
+        public static BinaryOperatorNode.Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return toString();
+        }
+
+    }
+
+    public enum PrestoLikeOperator implements BinaryOperatorNode.Operator {
+        LIKE("LIKE"), //
+        NOT_LIKE("NOT LIKE");
+
+        private final String textRepresentation;
+
+        PrestoLikeOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static PrestoLikeOperator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+    }
+
+    public enum PrestoBinaryComparisonOperator implements BinaryOperatorNode.Operator {
+        EQUALS("="), NOT_EQUALS("<>"), NOT_EQUALS_ALT("!="), IS_DISTINCT_FROM("IS DISTINCT FROM"),
+        IS_NOT_DISTINCT_FROM("IS NOT DISTINCT FROM"), GREATER(">"), GREATER_EQUALS(">="), SMALLER("<"),
+        SMALLER_EQUALS("<=");
+
+        private final String textRepresentation;
+
+        PrestoBinaryComparisonOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static BinaryOperatorNode.Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public static BinaryOperatorNode.Operator getRandomStringOperator() {
+            return Randomly.fromOptions(EQUALS, NOT_EQUALS, IS_DISTINCT_FROM, IS_NOT_DISTINCT_FROM);
+        }
+
+        public static BinaryOperatorNode.Operator getRandomForType(PrestoSchema.PrestoCompositeDataType type) {
+            PrestoSchema.PrestoDataType dataType = type.getPrimitiveDataType();
+
+            switch (dataType) {
+            case BOOLEAN:
+            case INT:
+            case FLOAT:
+            case DECIMAL:
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case TIME_WITH_TIME_ZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
+                return getRandom();
+            case VARCHAR:
+            case CHAR:
+            case VARBINARY:
+            case JSON:
+            case ARRAY:
+            case INTERVAL_YEAR_TO_MONTH:
+            case INTERVAL_DAY_TO_SECOND:
+                // return Randomly.fromOptions(EQUALS, NOT_EQUALS, NOT_EQUALS_ALT, IS_DISTINCT_FROM,
+                // IS_NOT_DISTINCT_FROM);
+            default:
+                return Randomly.fromOptions(EQUALS, NOT_EQUALS, NOT_EQUALS_ALT, IS_DISTINCT_FROM, IS_NOT_DISTINCT_FROM);
+            }
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+    }
+
+    public enum PrestoBinaryArithmeticOperator implements BinaryOperatorNode.Operator {
+        ADD("+"), SUB("-"), MULT("*"), DIV("/"), MOD("%");
+
+        private final String textRepresentation;
+
+        PrestoBinaryArithmeticOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        public static BinaryOperatorNode.Operator getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+    }
+
+    public enum PrestoUnaryArithmeticOperator implements BinaryOperatorNode.Operator {
+        MINUS("-");
+
+        private final String textRepresentation;
+
+        PrestoUnaryArithmeticOperator(String textRepresentation) {
+            this.textRepresentation = textRepresentation;
+        }
+
+        @Override
+        public String getTextRepresentation() {
+            return textRepresentation;
+        }
+
+    }
+
+    private enum Expression {
+        BINARY_LOGICAL, BINARY_COMPARISON, BINARY_ARITHMETIC
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoUpdateGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoUpdateGenerator.java
@@ -1,0 +1,53 @@
+package sqlancer.presto.gen;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.gen.AbstractUpdateGenerator;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.ast.PrestoExpression;
+
+public final class PrestoUpdateGenerator extends AbstractUpdateGenerator<PrestoColumn> {
+
+    private final PrestoGlobalState globalState;
+    private PrestoTypedExpressionGenerator gen;
+
+    private PrestoUpdateGenerator(PrestoGlobalState globalState) {
+        this.globalState = globalState;
+    }
+
+    public static SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
+        return new PrestoUpdateGenerator(globalState).generate();
+    }
+
+    private SQLQueryAdapter generate() {
+        PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        List<PrestoColumn> columns = table.getRandomNonEmptyColumnSubset();
+        gen = new PrestoTypedExpressionGenerator(globalState).setColumns(table.getColumns());
+        sb.append("UPDATE ");
+        sb.append(table.getName());
+        sb.append(" SET ");
+        updateColumns(columns);
+        PrestoErrors.addInsertErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors, false, false);
+    }
+
+    @Override
+    protected void updateValue(PrestoColumn column) {
+        Node<PrestoExpression> expr;
+        if (Randomly.getBooleanWithSmallProbability()) {
+            expr = gen.generateExpression(column.getType());
+            PrestoErrors.addExpressionErrors(errors);
+        } else {
+            expr = gen.generateConstant(column.getType());
+        }
+        sb.append(PrestoToStringVisitor.asString(expr));
+    }
+
+}

--- a/src/sqlancer/presto/gen/PrestoViewGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoViewGenerator.java
@@ -1,0 +1,36 @@
+package sqlancer.presto.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoToStringVisitor;
+
+public final class PrestoViewGenerator {
+
+    private PrestoViewGenerator() {
+    }
+
+    public static SQLQueryAdapter generate(PrestoGlobalState globalState) {
+        int nrColumns = Randomly.smallNumber() + 1;
+        StringBuilder sb = new StringBuilder("CREATE ");
+        sb.append("VIEW ");
+        sb.append(globalState.getSchema().getFreeViewName());
+        sb.append("(");
+        for (int i = 0; i < nrColumns; i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append("c");
+            sb.append(i);
+        }
+        sb.append(") AS ");
+        sb.append(PrestoToStringVisitor.asString(PrestoRandomQuerySynthesizer.generateSelect(globalState, nrColumns)));
+        ExpectedErrors errors = new ExpectedErrors();
+        PrestoErrors.addExpressionErrors(errors);
+        PrestoErrors.addGroupByErrors(errors);
+        return new SQLQueryAdapter(sb.toString(), errors, true, false);
+    }
+
+}

--- a/src/sqlancer/presto/test/PrestoNoRECOracle.java
+++ b/src/sqlancer/presto/test/PrestoNoRECOracle.java
@@ -1,0 +1,138 @@
+package sqlancer.presto.test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLConnection;
+import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.common.ast.newast.NewPostfixTextNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.common.oracle.NoRECBase;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoDataType;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.PrestoSchema.PrestoTables;
+import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.ast.PrestoCastFunction;
+import sqlancer.presto.ast.PrestoExpression;
+import sqlancer.presto.ast.PrestoJoin;
+import sqlancer.presto.ast.PrestoSelect;
+import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
+
+public class PrestoNoRECOracle extends NoRECBase<PrestoGlobalState> implements TestOracle<PrestoGlobalState> {
+
+    private final PrestoSchema s;
+
+    public PrestoNoRECOracle(PrestoGlobalState globalState) {
+        super(globalState);
+        this.s = globalState.getSchema();
+        PrestoErrors.addExpressionErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        PrestoTables randomTables = s.getRandomTableNonEmptyTables();
+        List<PrestoColumn> columns = randomTables.getColumns();
+
+        List<PrestoTable> tables = randomTables.getTables();
+
+        List<TableReferenceNode<PrestoExpression, PrestoTable>> tableList = tables.stream()
+                .map(t -> new TableReferenceNode<PrestoExpression, PrestoTable>(t)).collect(Collectors.toList());
+        List<Node<PrestoExpression>> joins = PrestoJoin.getJoins(tableList, state);
+
+        PrestoTypedExpressionGenerator gen = new PrestoTypedExpressionGenerator(state).setColumns(columns);
+        Node<PrestoExpression> randomWhereCondition = gen.generatePredicate();
+        int secondCount = getSecondQuery(new ArrayList<>(tableList), randomWhereCondition, joins);
+
+        int firstCount = getFirstQueryCount(con, new ArrayList<>(tableList), columns, randomWhereCondition, joins);
+        if (firstCount == -1 || secondCount == -1) {
+            throw new IgnoreMeException();
+        }
+        if (firstCount != secondCount) {
+            throw new AssertionError(
+                    optimizedQueryString + "; -- " + firstCount + "\n" + unoptimizedQueryString + " -- " + secondCount);
+        }
+    }
+
+    private int getSecondQuery(List<Node<PrestoExpression>> tableList, Node<PrestoExpression> randomWhereCondition,
+            List<Node<PrestoExpression>> joins) throws SQLException {
+        PrestoSelect select = new PrestoSelect();
+
+        Node<PrestoExpression> asText = new NewPostfixTextNode<>(
+
+                new PrestoCastFunction(
+                        new NewPostfixTextNode<>(randomWhereCondition,
+                                " IS NOT NULL AND " + PrestoToStringVisitor.asString(randomWhereCondition)),
+                        new PrestoCompositeDataType(PrestoDataType.INT, 8, 0)),
+                "as count");
+
+        select.setFetchColumns(List.of(asText));
+        select.setFromList(tableList);
+        select.setJoinList(joins);
+        int secondCount = 0;
+        unoptimizedQueryString = "SELECT SUM(count) FROM (" + PrestoToStringVisitor.asString(select) + ") as res";
+
+        errors.add("canceling statement due to statement timeout");
+        SQLQueryAdapter q = new SQLQueryAdapter(unoptimizedQueryString, errors, false, false);
+        SQLancerResultSet rs;
+        try {
+            rs = q.executeAndGetLogged(state);
+        } catch (Exception e) {
+            throw new AssertionError(unoptimizedQueryString, e);
+        }
+        if (rs == null) {
+            return -1;
+        }
+        if (rs.next()) {
+            secondCount += rs.getLong(1);
+        }
+        rs.close();
+        return secondCount;
+    }
+
+    private int getFirstQueryCount(SQLConnection con, List<Node<PrestoExpression>> tableList,
+            List<PrestoColumn> columns, Node<PrestoExpression> randomWhereCondition,
+            List<Node<PrestoExpression>> joins) {
+        PrestoSelect select = new PrestoSelect();
+        List<Node<PrestoExpression>> allColumns = columns.stream()
+                .map((c) -> new ColumnReferenceNode<PrestoExpression, PrestoColumn>(c)).collect(Collectors.toList());
+        select.setFetchColumns(allColumns);
+        select.setFromList(tableList);
+        select.setWhereClause(randomWhereCondition);
+        if (Randomly.getBooleanWithSmallProbability()) {
+            select.setOrderByExpressions(
+                    new PrestoTypedExpressionGenerator(state).setColumns(columns).generateOrderBys());
+        }
+        select.setJoinList(joins);
+        int firstCount = 0;
+        try (Statement stat = con.createStatement()) {
+            optimizedQueryString = PrestoToStringVisitor.asString(select);
+            if (options.logEachSelect()) {
+                logger.writeCurrent(optimizedQueryString);
+            }
+            try (ResultSet rs = stat.executeQuery(optimizedQueryString)) {
+                while (rs.next()) {
+                    firstCount++;
+                }
+            }
+        } catch (SQLException e) {
+            throw new IgnoreMeException();
+        }
+        return firstCount;
+    }
+
+}

--- a/src/sqlancer/presto/test/PrestoQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/presto/test/PrestoQueryPartitioningAggregateTester.java
@@ -1,0 +1,206 @@
+package sqlancer.presto.test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.NewAliasNode;
+import sqlancer.common.ast.newast.NewFunctionNode;
+import sqlancer.common.ast.newast.NewUnaryPostfixOperatorNode;
+import sqlancer.common.ast.newast.NewUnaryPrefixOperatorNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
+import sqlancer.presto.PrestoSchema.PrestoDataType;
+import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.ast.PrestoAggregateFunction;
+import sqlancer.presto.ast.PrestoCastFunction;
+import sqlancer.presto.ast.PrestoExpression;
+import sqlancer.presto.ast.PrestoSelect;
+import sqlancer.presto.ast.PrestoUnaryPostfixOperation;
+import sqlancer.presto.ast.PrestoUnaryPrefixOperation;
+
+public class PrestoQueryPartitioningAggregateTester extends PrestoQueryPartitioningBase
+        implements TestOracle<PrestoGlobalState> {
+
+    private String firstResult;
+    private String firstResultType;
+    private String secondResult;
+    private String originalQuery;
+    private String metamorphicQuery;
+
+    public PrestoQueryPartitioningAggregateTester(PrestoGlobalState state) {
+        super(state);
+        PrestoErrors.addGroupByErrors(errors);
+        PrestoErrors.addExpressionErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        PrestoAggregateFunction aggregateFunction = Randomly.fromOptions(PrestoAggregateFunction.MAX,
+                PrestoAggregateFunction.MIN, PrestoAggregateFunction.SUM, PrestoAggregateFunction.COUNT,
+                PrestoAggregateFunction.AVG/* , PrestoAggregateFunction.STDDEV_POP */);
+        List<Node<PrestoExpression>> aggregateArgs = gen.generateArgsForAggregate(aggregateFunction);
+        NewFunctionNode<PrestoExpression, PrestoAggregateFunction> aggregate = new NewFunctionNode<>(aggregateArgs,
+                aggregateFunction);
+        select.setFetchColumns(List.of(aggregate));
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+        originalQuery = PrestoToStringVisitor.asString(select);
+        firstResult = getAggregateResult(originalQuery);
+        firstResultType = getAggregateResultType(originalQuery);
+        metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
+        secondResult = getAggregateResult(metamorphicQuery);
+
+        state.getState().getLocalState().log(
+                "--" + originalQuery + ";\n--" + metamorphicQuery + "\n-- " + firstResult + "\n-- " + secondResult);
+        if (firstResultType.equals("VARBINARY") || firstResultType.equals("ARRAY(VARBINARY)")
+                || firstResultType.equals("ARRAY(ARRAY(VARBINARY))")) {
+            throw new IgnoreMeException();
+        }
+        if (firstResult == null && secondResult != null) {
+            if (secondResult.contains("Inf")) {
+                throw new IgnoreMeException(); // FIXME: average computation
+            }
+            throw new AssertionError();
+        } else if (firstResult != null && !firstResult.contentEquals(secondResult)
+                && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
+            if (secondResult.contains("Inf")) {
+                throw new IgnoreMeException(); // FIXME: average computation
+            }
+            throw new AssertionError();
+        }
+
+    }
+
+    private String createMetamorphicUnionQuery(PrestoSelect select,
+            NewFunctionNode<PrestoExpression, PrestoAggregateFunction> aggregate, List<Node<PrestoExpression>> from) {
+        String metamorphicQuery;
+        Node<PrestoExpression> whereClause = gen.generatePredicate();
+        Node<PrestoExpression> negatedClause = new NewUnaryPrefixOperatorNode<>(whereClause,
+                PrestoUnaryPrefixOperation.PrestoUnaryPrefixOperator.NOT);
+        Node<PrestoExpression> notNullClause = new NewUnaryPostfixOperatorNode<>(whereClause,
+                PrestoUnaryPostfixOperation.PrestoUnaryPostfixOperator.IS_NULL);
+        List<Node<PrestoExpression>> mappedAggregate = mapped(aggregate);
+        PrestoSelect leftSelect = getSelect(mappedAggregate, from, whereClause, select.getJoinList());
+        PrestoSelect middleSelect = getSelect(mappedAggregate, from, negatedClause, select.getJoinList());
+        PrestoSelect rightSelect = getSelect(mappedAggregate, from, notNullClause, select.getJoinList());
+        metamorphicQuery = "SELECT " + getOuterAggregateFunction(aggregate) + " FROM (";
+        metamorphicQuery += PrestoToStringVisitor.asString(leftSelect) + " UNION ALL "
+                + PrestoToStringVisitor.asString(middleSelect) + " UNION ALL "
+                + PrestoToStringVisitor.asString(rightSelect);
+        metamorphicQuery += ") as asdf";
+        return metamorphicQuery;
+    }
+
+    private String getAggregateResult(String queryString) {
+        String resultString;
+        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors, false, false);
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
+            if (result == null) {
+                throw new IgnoreMeException();
+            }
+            if (!result.next()) {
+                resultString = null;
+            } else {
+                resultString = result.getString(1);
+            }
+            return resultString;
+        } catch (SQLException e) {
+            if (errors.errorIsExpected(e.getMessage())) {
+                throw new IgnoreMeException();
+            }
+
+            if (!e.getMessage().contains("Not implemented type")) {
+                throw new AssertionError(queryString, e);
+            } else {
+                throw new IgnoreMeException();
+            }
+        }
+    }
+
+    private String getAggregateResultType(String queryString) {
+        String resultString;
+        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors, false, false);
+        try (SQLancerResultSet result = q.executeAndGet(state)) {
+            if (result == null) {
+                throw new IgnoreMeException();
+            }
+            if (!result.next()) {
+                resultString = null;
+            } else {
+                resultString = result.getType(1);
+            }
+            return resultString;
+        } catch (SQLException e) {
+            if (!e.getMessage().contains("Not implemented type")) {
+                throw new AssertionError(queryString, e);
+            } else {
+                throw new IgnoreMeException();
+            }
+        }
+    }
+
+    private List<Node<PrestoExpression>> mapped(NewFunctionNode<PrestoExpression, PrestoAggregateFunction> aggregate) {
+        PrestoCastFunction count;
+        switch (aggregate.getFunc()) {
+        case COUNT:
+        case MAX:
+        case MIN:
+        case SUM:
+            return aliasArgs(List.of(aggregate));
+        case AVG:
+            NewFunctionNode<PrestoExpression, PrestoAggregateFunction> sum = new NewFunctionNode<>(aggregate.getArgs(),
+                    PrestoAggregateFunction.SUM);
+            count = new PrestoCastFunction(new NewFunctionNode<>(aggregate.getArgs(), PrestoAggregateFunction.COUNT),
+                    new PrestoCompositeDataType(PrestoDataType.FLOAT, 8, 0));
+            return aliasArgs(Arrays.asList(sum, count));
+        default:
+            throw new AssertionError(aggregate.getFunc());
+        }
+    }
+
+    private List<Node<PrestoExpression>> aliasArgs(List<Node<PrestoExpression>> originalAggregateArgs) {
+        List<Node<PrestoExpression>> args = new ArrayList<>();
+        int i = 0;
+        for (Node<PrestoExpression> expr : originalAggregateArgs) {
+            args.add(new NewAliasNode<>(expr, "agg" + i++));
+        }
+        return args;
+    }
+
+    private String getOuterAggregateFunction(NewFunctionNode<PrestoExpression, PrestoAggregateFunction> aggregate) {
+        switch (aggregate.getFunc()) {
+        case AVG:
+            return "SUM(CAST(agg0 AS DOUBLE))/CAST(SUM(agg1) AS DOUBLE)";
+        case COUNT:
+            return PrestoAggregateFunction.SUM + "(agg0)";
+        default:
+            return aggregate.getFunc().toString() + "(agg0)";
+        }
+    }
+
+    private PrestoSelect getSelect(List<Node<PrestoExpression>> aggregates, List<Node<PrestoExpression>> from,
+            Node<PrestoExpression> whereClause, List<Node<PrestoExpression>> joinList) {
+        PrestoSelect leftSelect = new PrestoSelect();
+        leftSelect.setFetchColumns(aggregates);
+        leftSelect.setFromList(from);
+        leftSelect.setWhereClause(whereClause);
+        leftSelect.setJoinList(joinList);
+        if (Randomly.getBooleanWithSmallProbability()) {
+            leftSelect.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
+        }
+        return leftSelect;
+    }
+
+}

--- a/src/sqlancer/presto/test/PrestoQueryPartitioningBase.java
+++ b/src/sqlancer/presto/test/PrestoQueryPartitioningBase.java
@@ -1,0 +1,90 @@
+package sqlancer.presto.test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.ast.newast.TableReferenceNode;
+import sqlancer.common.gen.ExpressionGenerator;
+import sqlancer.common.oracle.TernaryLogicPartitioningOracleBase;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoSchema.PrestoTable;
+import sqlancer.presto.PrestoSchema.PrestoTables;
+import sqlancer.presto.ast.PrestoExpression;
+import sqlancer.presto.ast.PrestoJoin;
+import sqlancer.presto.ast.PrestoSelect;
+import sqlancer.presto.gen.PrestoTypedExpressionGenerator;
+
+public class PrestoQueryPartitioningBase
+        extends TernaryLogicPartitioningOracleBase<Node<PrestoExpression>, PrestoGlobalState>
+        implements TestOracle<PrestoGlobalState> {
+
+    PrestoSchema s;
+    PrestoTables targetTables;
+    PrestoTypedExpressionGenerator gen;
+    PrestoSelect select;
+
+    public PrestoQueryPartitioningBase(PrestoGlobalState state) {
+        super(state);
+        PrestoErrors.addExpressionErrors(errors);
+    }
+
+    public static String canonicalizeResultValue(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        // TODO: check this
+        switch (value) {
+        case "-0.0":
+            return "0.0";
+        case "-0":
+            return "0";
+        default:
+        }
+
+        return value;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        s = state.getSchema();
+        targetTables = s.getRandomTableNonEmptyTables();
+        gen = new PrestoTypedExpressionGenerator(state).setColumns(targetTables.getColumns());
+        initializeTernaryPredicateVariants();
+        select = new PrestoSelect();
+        select.setFetchColumns(generateFetchColumns());
+        List<PrestoTable> tables = targetTables.getTables();
+        List<TableReferenceNode<PrestoExpression, PrestoTable>> tableList = tables.stream()
+                .map(t -> new TableReferenceNode<PrestoExpression, PrestoTable>(t)).collect(Collectors.toList());
+        List<Node<PrestoExpression>> joins = PrestoJoin.getJoins(tableList, state);
+        select.setJoinList(new ArrayList<>(joins));
+        select.setFromList(new ArrayList<>(tableList));
+        select.setWhereClause(null);
+    }
+
+    List<Node<PrestoExpression>> generateFetchColumns() {
+        List<Node<PrestoExpression>> columns = new ArrayList<>();
+        if (Randomly.getBoolean()) {
+            columns.add(new ColumnReferenceNode<>(new PrestoColumn("*", null, false, false)));
+        } else {
+            columns = Randomly.nonEmptySubset(targetTables.getColumns()).stream()
+                    .map(c -> new ColumnReferenceNode<PrestoExpression, PrestoColumn>(c)).collect(Collectors.toList());
+        }
+        return columns;
+    }
+
+    @Override
+    protected ExpressionGenerator<Node<PrestoExpression>> getGen() {
+        return gen;
+    }
+
+}

--- a/src/sqlancer/presto/test/PrestoQueryPartitioningDistinctTester.java
+++ b/src/sqlancer/presto/test/PrestoQueryPartitioningDistinctTester.java
@@ -1,0 +1,44 @@
+package sqlancer.presto.test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoToStringVisitor;
+
+public class PrestoQueryPartitioningDistinctTester extends PrestoQueryPartitioningBase {
+
+    public PrestoQueryPartitioningDistinctTester(PrestoGlobalState state) {
+        super(state);
+        PrestoErrors.addGroupByErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        select.setDistinct(true);
+        select.setWhereClause(null);
+        String originalQueryString = PrestoToStringVisitor.asString(select);
+
+        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+        if (Randomly.getBoolean()) {
+            select.setDistinct(false);
+        }
+        select.setWhereClause(predicate);
+        String firstQueryString = PrestoToStringVisitor.asString(select);
+        select.setWhereClause(negatedPredicate);
+        String secondQueryString = PrestoToStringVisitor.asString(select);
+        select.setWhereClause(isNullPredicate);
+        String thirdQueryString = PrestoToStringVisitor.asString(select);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
+                secondQueryString, thirdQueryString, combinedString, true, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
+                state, PrestoQueryPartitioningBase::canonicalizeResultValue);
+    }
+
+}

--- a/src/sqlancer/presto/test/PrestoQueryPartitioningGroupByTester.java
+++ b/src/sqlancer/presto/test/PrestoQueryPartitioningGroupByTester.java
@@ -1,0 +1,53 @@
+package sqlancer.presto.test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.ColumnReferenceNode;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema.PrestoColumn;
+import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.ast.PrestoExpression;
+
+public class PrestoQueryPartitioningGroupByTester extends PrestoQueryPartitioningBase {
+
+    public PrestoQueryPartitioningGroupByTester(PrestoGlobalState state) {
+        super(state);
+        PrestoErrors.addGroupByErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        select.setGroupByExpressions(select.getFetchColumns());
+        select.setWhereClause(null);
+        String originalQueryString = PrestoToStringVisitor.asString(select);
+
+        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        select.setWhereClause(predicate);
+        String firstQueryString = PrestoToStringVisitor.asString(select);
+        select.setWhereClause(negatedPredicate);
+        String secondQueryString = PrestoToStringVisitor.asString(select);
+        select.setWhereClause(isNullPredicate);
+        String thirdQueryString = PrestoToStringVisitor.asString(select);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
+                secondQueryString, thirdQueryString, combinedString, true, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
+                state, PrestoQueryPartitioningBase::canonicalizeResultValue);
+    }
+
+    @Override
+    List<Node<PrestoExpression>> generateFetchColumns() {
+        return Randomly.nonEmptySubset(targetTables.getColumns()).stream()
+                .map(c -> new ColumnReferenceNode<PrestoExpression, PrestoColumn>(c)).collect(Collectors.toList());
+    }
+
+}

--- a/src/sqlancer/presto/test/PrestoQueryPartitioningHavingTester.java
+++ b/src/sqlancer/presto/test/PrestoQueryPartitioningHavingTester.java
@@ -1,0 +1,64 @@
+package sqlancer.presto.test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Node;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoSchema;
+import sqlancer.presto.PrestoToStringVisitor;
+import sqlancer.presto.ast.PrestoExpression;
+
+public class PrestoQueryPartitioningHavingTester extends PrestoQueryPartitioningBase
+        implements TestOracle<PrestoGlobalState> {
+
+    public PrestoQueryPartitioningHavingTester(PrestoGlobalState state) {
+        super(state);
+        PrestoErrors.addGroupByErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull()));
+        }
+        boolean orderBy = Randomly.getBoolean();
+        if (orderBy) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+        select.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
+        select.setHavingClause(null);
+        String originalQueryString = PrestoToStringVisitor.asString(select);
+        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        select.setHavingClause(predicate);
+        String firstQueryString = PrestoToStringVisitor.asString(select);
+        select.setHavingClause(negatedPredicate);
+        String secondQueryString = PrestoToStringVisitor.asString(select);
+        select.setHavingClause(isNullPredicate);
+        String thirdQueryString = PrestoToStringVisitor.asString(select);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                thirdQueryString, combinedString, !orderBy, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
+                state, PrestoQueryPartitioningBase::canonicalizeResultValue);
+    }
+
+    @Override
+    protected Node<PrestoExpression> generatePredicate() {
+        return gen.generateHavingClause();
+    }
+
+    @Override
+    List<Node<PrestoExpression>> generateFetchColumns() {
+        return Collections.singletonList(gen.generateHavingClause());
+    }
+
+}

--- a/src/sqlancer/presto/test/PrestoQueryPartitioningWhereTester.java
+++ b/src/sqlancer/presto/test/PrestoQueryPartitioningWhereTester.java
@@ -1,0 +1,46 @@
+package sqlancer.presto.test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.presto.PrestoErrors;
+import sqlancer.presto.PrestoGlobalState;
+import sqlancer.presto.PrestoToStringVisitor;
+
+public class PrestoQueryPartitioningWhereTester extends PrestoQueryPartitioningBase {
+
+    public PrestoQueryPartitioningWhereTester(PrestoGlobalState state) {
+        super(state);
+        PrestoErrors.addGroupByErrors(errors);
+        PrestoErrors.addExpressionErrors(errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        super.check();
+        select.setWhereClause(null);
+        String originalQueryString = PrestoToStringVisitor.asString(select);
+
+        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+
+        boolean orderBy = Randomly.getBooleanWithRatherLowProbability();
+        if (orderBy) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+        select.setWhereClause(predicate);
+        String firstQueryString = PrestoToStringVisitor.asString(select);
+        select.setWhereClause(negatedPredicate);
+        String secondQueryString = PrestoToStringVisitor.asString(select);
+        select.setWhereClause(isNullPredicate);
+        String thirdQueryString = PrestoToStringVisitor.asString(select);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                thirdQueryString, combinedString, !orderBy, state, errors);
+        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
+                state, PrestoQueryPartitioningBase::canonicalizeResultValue);
+    }
+
+}


### PR DESCRIPTION
This is the first Pull Request for [Presto](https://prestodb.io/) implementation. 
The following oracles are currently completed:
-  NoRec oracle
-  TLP Where
-  TLP Aggregate (basic aggregate function)

## Data types
The following data types are currently supported:
BOOLEAN, INT, FLOAT, DECIMAL, VARCHAR, CHAR, VARBINARY, JSON, 
DATE, TIME, TIMESTAMP, TIME_WITH_TIME_ZONE, 
TIMESTAMP_WITH_TIME_ZONE, INTERVAL_YEAR_TO_MONTH, 
INTERVAL_DAY_TO_SECOND, ARRAY. 
Others such as MAP, ROW, IPADDRESS, UID, IPPREFIX, HyperLogLog, 
P4HyperLogLog, KHyperLogLog, QDigest and TDigest 
will be supported in the future.

## Functions

Large number of Presto supported are implemented, 
but only small number are actually used in test. 
Most of the functions will be supported in the future.

