### PR TITLE
feat: add support of advanced functions

### DIFF
--- a/src/sqlancer/common/query/SQLQueryAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryAdapter.java
@@ -50,10 +50,8 @@ public class SQLQueryAdapter extends Query<SQLConnection> {
     }
 
     private void checkQueryString() {
-        if (!couldAffectSchema) {
-            if (guessAffectSchemaFromQuery(query)) {
-                throw new AssertionError("CREATE TABLE statements should set couldAffectSchema to true");
-            }
+        if (!couldAffectSchema && guessAffectSchemaFromQuery(query)) {
+            throw new AssertionError("CREATE TABLE statements should set couldAffectSchema to true");
         }
     }
 

--- a/src/sqlancer/stonedb/ast/StoneDBAdvancedFunction.java
+++ b/src/sqlancer/stonedb/ast/StoneDBAdvancedFunction.java
@@ -1,0 +1,34 @@
+package sqlancer.stonedb.ast;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.ast.FunctionNode;
+import sqlancer.stonedb.ast.StoneDBAdvancedFunction.StoneDBAdvancedFunc;
+
+public class StoneDBAdvancedFunction extends FunctionNode<StoneDBAdvancedFunc, StoneDBExpression>
+        implements StoneDBExpression {
+
+    // https://stonedb.io/docs/SQL-reference/functions/advanced-functions
+    public enum StoneDBAdvancedFunc {
+        IFNULL(2), IF(3), NULLIF(2), BIN(1), BINARY(1), CONV(3);
+
+        private int nrArgs;
+
+        StoneDBAdvancedFunc(int nrArgs) {
+            this.nrArgs = nrArgs;
+        }
+
+        public static StoneDBAdvancedFunc getRandom() {
+            return Randomly.fromOptions(values());
+        }
+
+        public int getNrArgs() {
+            return nrArgs;
+        }
+    }
+
+    protected StoneDBAdvancedFunction(StoneDBAdvancedFunc function, List<StoneDBExpression> args) {
+        super(function, args);
+    }
+}

--- a/src/sqlancer/stonedb/gen/StoneDBExpressionGenerator.java
+++ b/src/sqlancer/stonedb/gen/StoneDBExpressionGenerator.java
@@ -28,6 +28,7 @@ import sqlancer.common.gen.UntypedExpressionGenerator;
 import sqlancer.stonedb.StoneDBProvider.StoneDBGlobalState;
 import sqlancer.stonedb.StoneDBSchema.StoneDBColumn;
 import sqlancer.stonedb.StoneDBSchema.StoneDBDataType;
+import sqlancer.stonedb.ast.StoneDBAdvancedFunction.StoneDBAdvancedFunc;
 import sqlancer.stonedb.ast.StoneDBAggregate.StoneDBAggregateFunction;
 import sqlancer.stonedb.ast.StoneDBConstant;
 import sqlancer.stonedb.ast.StoneDBExpression;
@@ -117,6 +118,11 @@ public class StoneDBExpressionGenerator extends UntypedExpressionGenerator<Node<
             allowAggregates = false;
             return new NewFunctionNode<>(generateExpressions(aggregateFunction.getNrArgs(), depth + 1),
                     aggregateFunction);
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            StoneDBAdvancedFunc advancedFunction = StoneDBAdvancedFunc.getRandom();
+            return new NewFunctionNode<>(generateExpressions(advancedFunction.getNrArgs(), depth + 1),
+                    advancedFunction);
         }
         List<Expression> possibleOptions = new ArrayList<>(Arrays.asList(Expression.values()));
         Expression expr = Randomly.fromList(possibleOptions);


### PR DESCRIPTION
feat: add support of stonedb advaned functions

see: https://stonedb.io/docs/SQL-reference/functions/advanced-functions

Note: The diff below is changed because it's an violation of the PMD rules, but it is not directly related to the feature of thie PR.
<img width="1678" alt="image" src="https://github.com/sqlancer/sqlancer/assets/63448884/587df1e3-3ce2-4c9a-9c2b-3485625af6e4">
