### PR TITLE
feat: add support of insert on duplicate key update

### DIFF
--- a/src/sqlancer/common/query/SQLQueryAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryAdapter.java
@@ -50,10 +50,8 @@ public class SQLQueryAdapter extends Query<SQLConnection> {
     }
 
     private void checkQueryString() {
-        if (!couldAffectSchema) {
-            if (guessAffectSchemaFromQuery(query)) {
-                throw new AssertionError("CREATE TABLE statements should set couldAffectSchema to true");
-            }
+        if (!couldAffectSchema && guessAffectSchemaFromQuery(query)) {
+            throw new AssertionError("CREATE TABLE statements should set couldAffectSchema to true");
         }
     }
 

--- a/src/sqlancer/stonedb/gen/StoneDBTableInsertGenerator.java
+++ b/src/sqlancer/stonedb/gen/StoneDBTableInsertGenerator.java
@@ -48,6 +48,7 @@ public class StoneDBTableInsertGenerator extends AbstractInsertGenerator<StoneDB
         sb.append(table.getName());
         appendPartition();
         appendColumnsAndValues(columns);
+        appendOnDuplicateUpdate();
         addExpectedErrors();
         return new SQLQueryAdapter(sb.toString(), errors);
     }
@@ -81,6 +82,14 @@ public class StoneDBTableInsertGenerator extends AbstractInsertGenerator<StoneDB
         sb.append(")");
         sb.append(Randomly.fromOptions(" VALUES ", " VALUE "));
         appendValues();
+    }
+
+    private void appendOnDuplicateUpdate() {
+        sb.append("on duplicate key update ");
+        StoneDBColumn randomColumn = table.getRandomColumn();
+        sb.append(randomColumn.getName());
+        sb.append("=");
+        insertValue(randomColumn);
     }
 
     // append nrRows rows


### PR DESCRIPTION
feat: add support of insert on duplicate key update


<img width="1014" alt="image" src="https://github.com/sqlancer/sqlancer/assets/63448884/af7d61f7-5e80-4982-b094-3ff318b22d04">

see: https://stonedb.io/docs/developer-guide/DML-statements/#insert-into--on-duplicate-key-update




Note: The diff below is changed because it's an violation of the PMD rules, but it is not directly related to the feature of thie PR.
<img width="1678" alt="image" src="https://github.com/sqlancer/sqlancer/assets/63448884/587df1e3-3ce2-4c9a-9c2b-3485625af6e4">
