### PR TITLE
Add support for Presto - common classes

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -48,7 +48,8 @@ public final class ComparatorHelper {
                 e.printStackTrace();
             }
         }
-        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
+        boolean canonicalizeString = state.getOptions().canonicalizeSqlString();
+        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors, true, canonicalizeString);
         List<String> resultSet = new ArrayList<>();
         SQLancerResultSet result = null;
         try {
@@ -106,7 +107,8 @@ public final class ComparatorHelper {
         Set<String> firstHashSet = new HashSet<>(resultSet);
         Set<String> secondHashSet = new HashSet<>(secondResultSet);
 
-        if (!firstHashSet.equals(secondHashSet)) {
+        boolean validateResultSizeOnly = state.getOptions().validateResultSizeOnly();
+        if (!validateResultSizeOnly && !firstHashSet.equals(secondHashSet)) {
             Set<String> firstResultSetMisses = new HashSet<>(firstHashSet);
             firstResultSetMisses.removeAll(secondHashSet);
             Set<String> secondResultSetMisses = new HashSet<>(secondHashSet);

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -141,6 +141,12 @@ public class MainOptions {
     @Parameter(names = "--ast-reducer-max-time", description = "EXPERIMENTAL Maximum time duration (secs) the statement reducer will do")
     private long maxStatementReduceTime = NO_REDUCE_LIMIT; // NOPMD
 
+    @Parameter(names = "--validate-result-size-only", description = "Should validate result size only and skip comparing content of the result set ", arity = 1)
+    private boolean validateResultSizeOnly = false; // NOPMD
+
+    @Parameter(names = "--canonicalize-sql-strings", description = "Should canonicalize query string (add ';' at the end", arity = 1)
+    private boolean canonicalizeSqlString = true; // NOPMD
+
     public int getMaxExpressionDepth() {
         return maxExpressionDepth;
     }
@@ -320,6 +326,14 @@ public class MainOptions {
 
     public long getMaxASTReduceTime() {
         return maxASTReduceTime;
+    }
+
+    public boolean validateResultSizeOnly() {
+        return validateResultSizeOnly;
+    }
+
+    public boolean canonicalizeSqlString() {
+        return canonicalizeSqlString;
     }
 
 }

--- a/src/sqlancer/common/query/SQLQueryAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryAdapter.java
@@ -32,7 +32,16 @@ public class SQLQueryAdapter extends Query<SQLConnection> {
     }
 
     public SQLQueryAdapter(String query, ExpectedErrors expectedErrors, boolean couldAffectSchema) {
-        this.query = canonicalizeString(query);
+        this(query, expectedErrors, couldAffectSchema, true);
+    }
+
+    public SQLQueryAdapter(String query, ExpectedErrors expectedErrors, boolean couldAffectSchema,
+            boolean canonicalizeString) {
+        if (canonicalizeString) {
+            this.query = canonicalizeString(query);
+        } else {
+            this.query = query;
+        }
         this.expectedErrors = expectedErrors;
         this.couldAffectSchema = couldAffectSchema;
         checkQueryString();

--- a/src/sqlancer/common/query/SQLancerResultSet.java
+++ b/src/sqlancer/common/query/SQLancerResultSet.java
@@ -46,6 +46,10 @@ public class SQLancerResultSet implements Closeable {
         return rs.getLong(i);
     }
 
+    public String getType(int i) throws SQLException {
+        return rs.getMetaData().getColumnTypeName(i);
+    }
+
     public void registerEpilogue(Runnable runnableEpilogue) {
         this.runnableEpilogue = runnableEpilogue;
     }

--- a/test/sqlancer/TestComparatorHelper.java
+++ b/test/sqlancer/TestComparatorHelper.java
@@ -2,19 +2,37 @@ package sqlancer;
 
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import sqlancer.h2.H2Options;
+import sqlancer.h2.H2Schema;
+
 public class TestComparatorHelper {
     // TODO: Implement tests for the other ComparatorHelper methods
+
+    // TODO: create test state that not depends on specific database
+    final SQLGlobalState<H2Options, H2Schema> state = new SQLGlobalState<H2Options, H2Schema>() {
+
+        @Override
+        protected H2Schema readSchema() throws SQLException {
+            return H2Schema.fromConnection(getConnection(), getDatabaseName());
+        }
+
+        @Override
+        public MainOptions getOptions() {
+            return new MainOptions();
+        }
+    };
 
     @Test
     public void testAssumeResultSetsAreEqualWithEqualSets() {
         List<String> r1 = Arrays.asList("a", "b", "c");
         List<String> r2 = Arrays.asList("a", "b", "c");
-        ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null);
+        ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), state);
 
     }
 
@@ -26,7 +44,7 @@ public class TestComparatorHelper {
         // line occurs before AssertionError is thrown, but it's good enough as an indicator that one of the Exceptions
         // is raised
         assertThrowsExactly(NullPointerException.class, () -> {
-            ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null);
+            ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), state);
         });
     }
 
@@ -38,7 +56,7 @@ public class TestComparatorHelper {
         // line occurs before AssertionError is thrown, but it's good enough as an indicator that one of the Exceptions
         // is raised
         assertThrowsExactly(NullPointerException.class, () -> {
-            ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null);
+            ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), state);
         });
     }
 
@@ -46,7 +64,7 @@ public class TestComparatorHelper {
     public void testAssumeResultSetsAreEqualWithCanonicalizationRule() {
         List<String> r1 = Arrays.asList("a", "b", "c");
         List<String> r2 = Arrays.asList("a", "b", "d");
-        ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), null, (String s) -> {
+        ComparatorHelper.assumeResultSetsAreEqual(r1, r2, "", Arrays.asList(""), state, (String s) -> {
             return s.equals("d") ? "c" : s;
         });
     }


### PR DESCRIPTION
To implement support for Presto some changes in common classes are required.

## Changes in common classes:
1. class sqlancer.MainOptions - added global parameters :
 * canonicalizeString (boolean) - presto doesn't support JDBC queries with ";" at the end of the statement
 * compareResultsContent (boolean) - comparing the content of VARBINARY columns fails

2. class sqlancer.ComparatorHelper - compare results based on parameter

```
    boolean compare = state.getOptions().compareResultsContent();
    if (compare && !firstHashSet.equals(secondHashSet)) {
```

3. sqlancer.common.query.SQLancerResultSet - added method:

```
    public String getType(int i) throws SQLException {
    return rs.getMetaData().getColumnTypeName(i);
    }
```

4. sqlancer.common.query.SQLQueryAdapter : added constructor

```
    public SQLQueryAdapter(String query, ExpectedErrors expectedErrors,
        boolean couldAffectSchema, boolean canonicalizeString) {

```