### PR TITLE
Add Fuzzer oracle for PostgreSQL and MySQL

### DIFF
--- a/src/sqlancer/mysql/MySQLOptions.java
+++ b/src/sqlancer/mysql/MySQLOptions.java
@@ -12,6 +12,7 @@ import sqlancer.OracleFactory;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.mysql.MySQLOptions.MySQLOracleFactory;
 import sqlancer.mysql.oracle.MySQLCERTOracle;
+import sqlancer.mysql.oracle.MySQLFuzzer;
 import sqlancer.mysql.oracle.MySQLPivotedQuerySynthesisOracle;
 import sqlancer.mysql.oracle.MySQLTLPWhereOracle;
 
@@ -57,6 +58,13 @@ public class MySQLOptions implements DBMSSpecificOptions<MySQLOracleFactory> {
             public boolean requiresAllTablesToContainRows() {
                 return true;
             }
+        },
+        FUZZER {
+            @Override
+            public TestOracle<MySQLGlobalState> create(MySQLGlobalState globalState) throws Exception {
+                return new MySQLFuzzer(globalState);
+            }
+
         };
     }
 

--- a/src/sqlancer/mysql/gen/MySQLRandomQuerySynthesizer.java
+++ b/src/sqlancer/mysql/gen/MySQLRandomQuerySynthesizer.java
@@ -1,0 +1,52 @@
+package sqlancer.mysql.gen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import sqlancer.Randomly;
+import sqlancer.mysql.MySQLGlobalState;
+import sqlancer.mysql.MySQLSchema.MySQLTables;
+import sqlancer.mysql.ast.MySQLExpression;
+import sqlancer.mysql.ast.MySQLSelect;
+import sqlancer.mysql.ast.MySQLTableReference;
+
+public class MySQLRandomQuerySynthesizer {
+
+    private MySQLRandomQuerySynthesizer() {
+    }
+
+    public static MySQLSelect generate(MySQLGlobalState globalState, int nrColumns) {
+        MySQLTables tables = globalState.getSchema().getRandomTableNonEmptyTables();
+        MySQLExpressionGenerator gen = new MySQLExpressionGenerator(globalState).setColumns(tables.getColumns());
+        MySQLSelect select = new MySQLSelect();
+        List<MySQLExpression> columns = new ArrayList<>();
+
+        select.setSelectType(Randomly.fromOptions(MySQLSelect.SelectType.values()));
+        columns.addAll(gen.generateExpressions(nrColumns));
+        select.setFetchColumns(columns);
+        List<MySQLExpression> tableList = tables.getTables().stream().map(t -> new MySQLTableReference(t))
+                .collect(Collectors.toList());
+        select.setFromList(tableList);
+        if (Randomly.getBoolean()) {
+            select.setWhereClause(gen.generateExpression());
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+        if (Randomly.getBoolean()) {
+            select.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
+            if (Randomly.getBoolean()) {
+                select.setHavingClause(gen.generateHavingClause());
+            }
+        }
+        if (Randomly.getBoolean()) {
+            select.setLimitClause(gen.generateExpression());
+        }
+        if (Randomly.getBoolean()) {
+            select.setOffsetClause(gen.generateExpression());
+        }
+        return select;
+    }
+
+}

--- a/src/sqlancer/mysql/gen/MySQLRandomQuerySynthesizer.java
+++ b/src/sqlancer/mysql/gen/MySQLRandomQuerySynthesizer.java
@@ -11,7 +11,7 @@ import sqlancer.mysql.ast.MySQLExpression;
 import sqlancer.mysql.ast.MySQLSelect;
 import sqlancer.mysql.ast.MySQLTableReference;
 
-public class MySQLRandomQuerySynthesizer {
+public final class MySQLRandomQuerySynthesizer {
 
     private MySQLRandomQuerySynthesizer() {
     }

--- a/src/sqlancer/mysql/oracle/MySQLFuzzer.java
+++ b/src/sqlancer/mysql/oracle/MySQLFuzzer.java
@@ -1,0 +1,30 @@
+package sqlancer.mysql.oracle;
+
+import sqlancer.Randomly;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.mysql.MySQLGlobalState;
+import sqlancer.mysql.MySQLVisitor;
+import sqlancer.mysql.gen.MySQLRandomQuerySynthesizer;
+
+public class MySQLFuzzer implements TestOracle<MySQLGlobalState> {
+
+    private final MySQLGlobalState globalState;
+
+    public MySQLFuzzer(MySQLGlobalState globalState) {
+        this.globalState = globalState;
+    }
+
+    @Override
+    public void check() throws Exception {
+        String s = MySQLVisitor.asString(MySQLRandomQuerySynthesizer.generate(globalState, Randomly.smallNumber() + 1))
+                + ';';
+        try {
+            globalState.executeStatement(new SQLQueryAdapter(s));
+            globalState.getManager().incrementSelectQueryCount();
+        } catch (Error e) {
+
+        }
+    }
+
+}

--- a/src/sqlancer/postgres/PostgresOptions.java
+++ b/src/sqlancer/postgres/PostgresOptions.java
@@ -13,6 +13,7 @@ import sqlancer.OracleFactory;
 import sqlancer.common.oracle.CompositeTestOracle;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.postgres.PostgresOptions.PostgresOracleFactory;
+import sqlancer.postgres.oracle.PostgresFuzzer;
 import sqlancer.postgres.oracle.PostgresNoRECOracle;
 import sqlancer.postgres.oracle.PostgresPivotedQuerySynthesisOracle;
 import sqlancer.postgres.oracle.tlp.PostgresTLPAggregateOracle;
@@ -76,6 +77,13 @@ public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactor
                 oracles.add(new PostgresTLPAggregateOracle(globalState));
                 return new CompositeTestOracle<PostgresGlobalState>(oracles, globalState);
             }
+        },
+        FUZZER {
+            @Override
+            public TestOracle<PostgresGlobalState> create(PostgresGlobalState globalState) throws Exception {
+                return new PostgresFuzzer(globalState);
+            }
+
         };
 
     }

--- a/src/sqlancer/postgres/oracle/PostgresFuzzer.java
+++ b/src/sqlancer/postgres/oracle/PostgresFuzzer.java
@@ -1,0 +1,30 @@
+package sqlancer.postgres.oracle;
+
+import sqlancer.Randomly;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.postgres.PostgresGlobalState;
+import sqlancer.postgres.PostgresVisitor;
+import sqlancer.postgres.gen.PostgresRandomQueryGenerator;
+
+public class PostgresFuzzer implements TestOracle<PostgresGlobalState> {
+
+    private final PostgresGlobalState globalState;
+
+    public PostgresFuzzer(PostgresGlobalState globalState) {
+        this.globalState = globalState;
+    }
+
+    @Override
+    public void check() throws Exception {
+        String s = PostgresVisitor.asString(
+                PostgresRandomQueryGenerator.createRandomQuery(Randomly.smallNumber() + 1, globalState)) + ';';
+        try {
+            globalState.executeStatement(new SQLQueryAdapter(s));
+            globalState.getManager().incrementSelectQueryCount();
+        } catch (Error e) {
+
+        }
+    }
+
+}

--- a/src/sqlancer/sqlite3/SQLite3Options.java
+++ b/src/sqlancer/sqlite3/SQLite3Options.java
@@ -87,10 +87,6 @@ public class SQLite3Options implements DBMSSpecificOptions<SQLite3OracleFactory>
     public boolean generateDatabase = true;
 
     @Parameter(names = {
-            "--execute-queries" }, description = "Specifies whether the query in the fuzzer should be executed", arity = 1)
-    public boolean executeQuery = true;
-
-    @Parameter(names = {
             "--max-num-tables" }, description = "The maximum number of tables/virtual tables/ rtree tables/ views that can be created")
     public int maxNumTables = 10;
 

--- a/src/sqlancer/sqlite3/oracle/SQLite3Fuzzer.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3Fuzzer.java
@@ -20,10 +20,8 @@ public class SQLite3Fuzzer implements TestOracle<SQLite3GlobalState> {
         String s = SQLite3Visitor
                 .asString(SQLite3RandomQuerySynthesizer.generate(globalState, Randomly.smallNumber() + 1)) + ";";
         try {
-            if (globalState.getDbmsSpecificOptions().executeQuery) {
-                globalState.executeStatement(new SQLQueryAdapter(s));
-                globalState.getManager().incrementSelectQueryCount();
-            }
+            globalState.executeStatement(new SQLQueryAdapter(s));
+            globalState.getManager().incrementSelectQueryCount();
         } catch (Error e) {
 
         }


### PR DESCRIPTION
Changes:
- Add RandomQuerySynthesizer for MySQL
- Add Fuzzer class for MySQL
- Add Fuzzer option in MySQL oracle 
- Add Fuzzer class for PostgreSQL
- Add Fuzzer option in PostgreSQL oracle
- Remove `--execute-queries` option from SQLite options