### PR TITLE
Fix query plan format for QPG of TiDB

### DIFF
--- a/src/sqlancer/tidb/TiDBProvider.java
+++ b/src/sqlancer/tidb/TiDBProvider.java
@@ -208,7 +208,7 @@ public class TiDBProvider extends SQLProviderAdapter<TiDBGlobalState, TiDBOption
             }
         }
 
-        SQLQueryAdapter q = new SQLQueryAdapter("EXPLAIN " + selectStr);
+        SQLQueryAdapter q = new SQLQueryAdapter("EXPLAIN FORMAT=brief " + selectStr);
         try (SQLancerResultSet rs = q.executeAndGet(globalState)) {
             if (rs != null) {
                 while (rs.next()) {


### PR DESCRIPTION
For TiDB, `EXPLAIN` outputs random id for each operator. 

```EXPLAIN DELETE FROM t1 WHERE c1=3;```
| id                        | estRows | task      | access object | operator info                  |
| -----------------|:--------:|:------:|:-------------:|:----------------:|
| Delete_4                  | N/A     | root      |               | N/A                            |
| └─TableReader_8           | 0.00    | root      |               | data:Selection_7               |
|   └─Selection_7           | 0.00    | cop[tikv] |               | eq(test.t1.c1, 3)              |
|     └─TableFullScan_6     | 3.00    | cop[tikv] | table:t1      | keep order:false, stats:pseudo |

According to the [QPG paper](https://bajinsheng.github.io/assets/pdf/qpg_icse23.pdf), the random id should be removed, but not in fact.
We fix this issue by using `EXPLAIN FORMAT=simplified`.

```EXPLAIN DELETE FROM t1 WHERE c1=3;```
| id                        | estRows | task      | access object | operator info                  |
| -----------------|:--------:|:------:|:-------------:|:----------------:|
| Delete                  | N/A     | root      |               | N/A                            |
| └─TableReader           | 0.00    | root      |               | data:Selection_7               |
|   └─Selection           | 0.00    | cop[tikv] |               | eq(test.t1.c1, 3)              |
|     └─TableFullScan     | 3.00    | cop[tikv] | table:t1      | keep order:false, stats:pseudo |

Reference: https://docs.pingcap.com/tidb/dev/sql-statement-explain