### PR TITLE
Make --test-collations=false more robust.

### DIFF
--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -325,17 +325,24 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
     private String getCreateDatabaseCommand(PostgresGlobalState state) {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE DATABASE " + databaseName + " ");
-        if (Randomly.getBoolean() && ((PostgresOptions) state.getDbmsSpecificOptions()).testCollations) {
+        if (((PostgresOptions) state.getDbmsSpecificOptions()).testCollations) {
             if (Randomly.getBoolean()) {
-                sb.append("WITH ENCODING '");
-                sb.append(Randomly.fromOptions("utf8"));
-                sb.append("' ");
-            }
-            for (String lc : Arrays.asList("LC_COLLATE", "LC_CTYPE")) {
-                if (!state.getCollates().isEmpty() && Randomly.getBoolean()) {
-                    sb.append(String.format(" %s = '%s'", lc, Randomly.fromList(state.getCollates())));
+                if (Randomly.getBoolean()) {
+                    sb.append("WITH ENCODING '");
+                    sb.append(Randomly.fromOptions("utf8"));
+                    sb.append("' ");
                 }
+                for (String lc : Arrays.asList("LC_COLLATE", "LC_CTYPE")) {
+                    if (!state.getCollates().isEmpty() && Randomly.getBoolean()) {
+                        sb.append(String.format(" %s = '%s'", lc, Randomly.fromList(state.getCollates())));
+                    }
+                }
+                sb.append(" TEMPLATE template0");
             }
+        } else {
+            sb.append("WITH ENCODING '");
+            sb.append(Randomly.fromOptions("utf8"));
+            sb.append("' ");
             sb.append(" TEMPLATE template0");
         }
         return sb.toString();

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -340,10 +340,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
                 sb.append(" TEMPLATE template0");
             }
         } else {
-            sb.append("WITH ENCODING '");
-            sb.append(Randomly.fromOptions("utf8"));
-            sb.append("' ");
-            sb.append(" TEMPLATE template0");
+            sb.append("WITH ENCODING 'UTF8' TEMPLATE template0");
         }
         return sb.toString();
     }


### PR DESCRIPTION
With `--test-collations=false`, database creation would now enforce using `UTF8` and `template0` database. 

Fixes #907 .

This ensures that when run with `--test-collations=false` on postgres clusters created in other locales, SQLancer still tries to create UTF8 encoded databases and test other aspects of the database engine.

No change made to scenarios where --test-collations=true (default).

`mvn verify` passes. 

With patch, stops throwing collation errors:
```
$ cd $lancerpth && java -jar sqlancer-*.jar --username ubuntu postgres --test-collations=false
[2024/01/16 01:23:49] Executed 13705 queries (2740 queries/s; 3.20/s dbs, successful statements: 42%). Threads shut down: 0.
[2024/01/16 01:23:54] Executed 37912 queries (4843 queries/s; 0.00/s dbs, successful statements: 41%). Threads shut down: 0.
[2024/01/16 01:23:59] Executed 60715 queries (4561 queries/s; 0.00/s dbs, successful statements: 41%). Threads shut down: 0.
[2024/01/16 01:24:05] Executed 82813 queries (4385 queries/s; 0.00/s dbs, successful statements: 40%). Threads shut down: 0.
[2024/01/16 01:24:09] Executed 108197 queries (5116 queries/s; 0.00/s dbs, successful statements: 40%). Threads shut down: 0.
^C
```