### PR TITLE
Update options to be of the same type

### DIFF
--- a/src/sqlancer/mariadb/gen/MariaDBSetGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBSetGenerator.java
@@ -35,11 +35,11 @@ public class MariaDBSetGenerator {
 
         AUTOCOMMIT("autocommit", (r) -> 1, Scope.GLOBAL, Scope.SESSION), //
         BIG_TABLES("big_tables", (r) -> Randomly.fromOptions("OFF", "ON"), Scope.GLOBAL, Scope.SESSION), //
-        COMPLETION_TYPE("completion_type", (r) -> Randomly.fromOptions("'NO_CHAIN'", "'CHAIN'", "'RELEASE'", 0, 1, 2),
-                Scope.GLOBAL), //
+        COMPLETION_TYPE("completion_type",
+                (r) -> Randomly.fromOptions("'NO_CHAIN'", "'CHAIN'", "'RELEASE'", "0", "1", "2"), Scope.GLOBAL), //
         // BULK_INSERT_CACHE_SIZE("bulk_insert_buffer_size", (r) -> r.getLong(0, Long.MAX_VALUE), Scope.GLOBAL,
         // Scope.SESSION),
-        CONCURRENT_INSERT("concurrent_insert", (r) -> Randomly.fromOptions("NEVER", "AUTO", "ALWAYS", 0, 1, 2),
+        CONCURRENT_INSERT("concurrent_insert", (r) -> Randomly.fromOptions("NEVER", "AUTO", "ALWAYS", "0", "1", "2"),
                 Scope.GLOBAL),
         CTE_MAX_RECURSION_DEPTH("cte_max_recursion_depth", (r) -> r.getLong(0, 4294967295L), Scope.GLOBAL),
         DELAY_KEY_WRITE("delay_key_write", (r) -> Randomly.fromOptions("ON", "OFF", "ALL"), Scope.GLOBAL),

--- a/src/sqlancer/mysql/gen/MySQLAlterTable.java
+++ b/src/sqlancer/mysql/gen/MySQLAlterTable.java
@@ -130,15 +130,15 @@ public class MySQLAlterTable {
                 break;
             case STATS_AUTO_RECALC:
                 sb.append("STATS_AUTO_RECALC ");
-                sb.append(Randomly.fromOptions(0, 1, "DEFAULT"));
+                sb.append(Randomly.fromOptions("0", "1", "DEFAULT"));
                 break;
             case STATS_PERSISTENT:
                 sb.append("STATS_PERSISTENT ");
-                sb.append(Randomly.fromOptions(0, 1, "DEFAULT"));
+                sb.append(Randomly.fromOptions("0", "1", "DEFAULT"));
                 break;
             case PACK_KEYS:
                 sb.append("PACK_KEYS ");
-                sb.append(Randomly.fromOptions(0, 1, "DEFAULT"));
+                sb.append(Randomly.fromOptions("0", "1", "DEFAULT"));
                 break;
             // not relevant:
             // case WITH_WITHOUT_VALIDATION:

--- a/src/sqlancer/mysql/gen/MySQLSetGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLSetGenerator.java
@@ -34,11 +34,11 @@ public class MySQLSetGenerator {
 
         AUTOCOMMIT("autocommit", (r) -> 1, Scope.GLOBAL, Scope.SESSION), //
         BIG_TABLES("big_tables", (r) -> Randomly.fromOptions("OFF", "ON"), Scope.GLOBAL, Scope.SESSION), //
-        COMPLETION_TYPE("completion_type", (r) -> Randomly.fromOptions("'NO_CHAIN'", "'CHAIN'", "'RELEASE'", 0, 1, 2),
-                Scope.GLOBAL), //
+        COMPLETION_TYPE("completion_type",
+                (r) -> Randomly.fromOptions("'NO_CHAIN'", "'CHAIN'", "'RELEASE'", "0", "1", "2"), Scope.GLOBAL), //
         BULK_INSERT_CACHE_SIZE("bulk_insert_buffer_size", (r) -> r.getLong(0, Long.MAX_VALUE), Scope.GLOBAL, //
                 Scope.SESSION), //
-        CONCURRENT_INSERT("concurrent_insert", (r) -> Randomly.fromOptions("NEVER", "AUTO", "ALWAYS", 0, 1, 2), //
+        CONCURRENT_INSERT("concurrent_insert", (r) -> Randomly.fromOptions("NEVER", "AUTO", "ALWAYS", "0", "1", "2"), //
                 Scope.GLOBAL), //
         CTE_MAX_RECURSION_DEPTH("cte_max_recursion_depth", //
                 (r) -> r.getLong(0, 4294967295L), Scope.GLOBAL), //


### PR DESCRIPTION
Update calls of  `Randomly.fromOptions` to be of the same type.

Fixes the build error:
- java: The method fromOptions(T...) of type sqlancer.Randomly is not applicable as the formal varargs element type T is not accessible here