### PR TITLE
[WIP] Generic TLP oracle

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -195,14 +195,27 @@ public final class ComparatorHelper {
     }
 
     public static String runQuery(String queryString, ExpectedErrors errors, GlobalState<?, ?, SQLConnection> state) {
+        if (state.getOptions().logEachSelect()) {
+            // TODO: refactor me
+            state.getLogger().writeCurrent(queryString);
+            try {
+                state.getLogger().getCurrentFileWriter().flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
         SQLQueryAdapter query = new SQLQueryAdapter(queryString, errors);
         try (SQLancerResultSet result = query.executeAndGet(state)) {
             if (result == null) {
                 throw new IgnoreMeException();
             }
+            if (!result.next()) {
+                return null;
+            }
             return result.getString(1);
-        } catch (Exception e) {
-            throw new IgnoreMeException();
+        } catch (SQLException e) {
+            throw new AssertionError(queryString, e);
         }
     }
 

--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -131,7 +131,8 @@ public final class ComparatorHelper {
     public static void assumeResultSetsAreEqual(List<String> resultSet, List<String> secondResultSet,
             String originalQueryString, List<String> combinedString, SQLGlobalState<?, ?> state,
             UnaryOperator<String> canonicalizationRule) {
-        // Overloaded version of assumeResultSetsAreEqual that takes a canonicalization function which is applied to
+        // Overloaded version of assumeResultSetsAreEqual that takes a canonicalization
+        // function which is applied to
         // both result sets before their comparison.
         List<String> canonicalizedResultSet = resultSet.stream().map(canonicalizationRule).collect(Collectors.toList());
         List<String> canonicalizedSecondResultSet = secondResultSet.stream().map(canonicalizationRule)
@@ -191,6 +192,18 @@ public final class ComparatorHelper {
         }
 
         return value;
+    }
+
+    public static String runQuery(String queryString, ExpectedErrors errors, GlobalState<?, ?, SQLConnection> state) {
+        SQLQueryAdapter query = new SQLQueryAdapter(queryString, errors);
+        try (SQLancerResultSet result = query.executeAndGet(state)) {
+            if (result == null) {
+                throw new IgnoreMeException();
+            }
+            return result.getString(1);
+        } catch (Exception e) {
+            throw new IgnoreMeException();
+        }
     }
 
 }

--- a/src/sqlancer/common/ast/SelectBase.java
+++ b/src/sqlancer/common/ast/SelectBase.java
@@ -36,6 +36,10 @@ public class SelectBase<T> {
         this.fromList = fromList;
     }
 
+    public void setFromTables(List<T> tables) {
+        setFromList(tables);
+    }
+
     public List<T> getFromList() {
         if (fromList == null) {
             throw new IllegalStateException();
@@ -115,4 +119,11 @@ public class SelectBase<T> {
         this.joinList = joinList;
     }
 
+    public List<T> getGroupByClause() {
+        return getGroupByExpressions();
+    }
+
+    public void setGroupByClause(List<T> groupByExpressions) {
+        setGroupByExpressions(groupByExpressions);
+    }
 }

--- a/src/sqlancer/common/ast/newast/Aggregate.java
+++ b/src/sqlancer/common/ast/newast/Aggregate.java
@@ -1,0 +1,12 @@
+package sqlancer.common.ast.newast;
+
+import sqlancer.common.schema.AbstractTableColumn;
+
+public interface Aggregate<E extends Expression<C>, C extends AbstractTableColumn<?, ?>> extends Expression<C> {
+
+    E asExpression();
+
+    String asString();
+
+    String asAggregatedString(String... from);
+}

--- a/src/sqlancer/common/ast/newast/Join.java
+++ b/src/sqlancer/common/ast/newast/Join.java
@@ -6,8 +6,6 @@ import sqlancer.common.schema.AbstractTableColumn;
 public interface Join<E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>>
         extends Expression<C> {
 
-    T getTable();
-
     Expression<C> getOnClause();
 
     void setOnClause(E onClause);

--- a/src/sqlancer/common/ast/newast/Select.java
+++ b/src/sqlancer/common/ast/newast/Select.java
@@ -44,5 +44,7 @@ public interface Select<J extends Join<E, T, C>, E extends Expression<C>, T exte
 
     Expression<C> getHavingClause();
 
+    void setDistinct();
+
     String asString();
 }

--- a/src/sqlancer/common/gen/AggregateGenerator.java
+++ b/src/sqlancer/common/gen/AggregateGenerator.java
@@ -1,0 +1,15 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+
+import sqlancer.common.ast.newast.Aggregate;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+
+public interface AggregateGenerator<A extends Aggregate<E, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
+
+    A generateAggregate();
+
+    List<E> aliasAggregates(List<A> aggregates);
+}

--- a/src/sqlancer/common/gen/HavingClauseGenerator.java
+++ b/src/sqlancer/common/gen/HavingClauseGenerator.java
@@ -1,0 +1,13 @@
+package sqlancer.common.gen;
+
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.schema.AbstractTableColumn;
+
+public interface HavingClauseGenerator<E extends Expression<C>, C extends AbstractTableColumn<?, ?>> {
+
+    E getHavingClause();
+
+    E negatePredicate(E predicate);
+
+    E isNull(E expr);
+}

--- a/src/sqlancer/common/gen/PredicateGenerator.java
+++ b/src/sqlancer/common/gen/PredicateGenerator.java
@@ -1,7 +1,7 @@
 package sqlancer.common.gen;
 
-import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.schema.AbstractTableColumn;
 
 public interface PredicateGenerator<E extends Expression<C>, C extends AbstractTableColumn<?, ?>> {
     /**

--- a/src/sqlancer/common/gen/PredicateGenerator.java
+++ b/src/sqlancer/common/gen/PredicateGenerator.java
@@ -1,0 +1,33 @@
+package sqlancer.common.gen;
+
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.ast.newast.Expression;
+
+public interface PredicateGenerator<E extends Expression<C>, C extends AbstractTableColumn<?, ?>> {
+    /**
+     * Generates a boolean predicate.
+     *
+     * @return an expression that can be used in a boolean context.
+     */
+    E generatePredicate();
+
+    /**
+     * Negates a predicate (i.e., uses a NOT operator).
+     *
+     * @param predicate
+     *            the boolean predicate.
+     *
+     * @return the negated predicate.
+     */
+    E negatePredicate(E predicate);
+
+    /**
+     * Checks if an expression evaluates to NULL (i.e., implements the IS NULL operator).
+     *
+     * @param expr
+     *            the expression
+     *
+     * @return an expression that checks whether the expression evaluates to NULL.
+     */
+    E isNull(E expr);
+}

--- a/src/sqlancer/common/gen/SelectGenerator.java
+++ b/src/sqlancer/common/gen/SelectGenerator.java
@@ -14,6 +14,8 @@ public interface SelectGenerator<J extends Join<E, T, C>, E extends Expression<C
 
     List<E> generateFetchColumns(boolean shouldCreateDummy);
 
+    List<E> generateGroupBys();
+
     List<E> generateOrderBys();
 
     List<J> getRandomJoinClauses();

--- a/src/sqlancer/common/gen/SelectGenerator.java
+++ b/src/sqlancer/common/gen/SelectGenerator.java
@@ -1,12 +1,12 @@
 package sqlancer.common.gen;
 
+import java.util.List;
+
 import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.ast.newast.Join;
 import sqlancer.common.ast.newast.Select;
 import sqlancer.common.schema.AbstractTable;
 import sqlancer.common.schema.AbstractTableColumn;
-
-import java.util.List;
 
 public interface SelectGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
 

--- a/src/sqlancer/common/gen/SelectGenerator.java
+++ b/src/sqlancer/common/gen/SelectGenerator.java
@@ -12,7 +12,7 @@ public interface SelectGenerator<J extends Join<E, T, C>, E extends Expression<C
 
     Select<J, E, T, C> generateSelect();
 
-    List<E> generateFetchColumns();
+    List<E> generateFetchColumns(boolean shouldCreateDummy);
 
     List<E> generateOrderBys();
 

--- a/src/sqlancer/common/gen/SelectGenerator.java
+++ b/src/sqlancer/common/gen/SelectGenerator.java
@@ -1,0 +1,22 @@
+package sqlancer.common.gen;
+
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+
+import java.util.List;
+
+public interface SelectGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
+
+    Select<J, E, T, C> generateSelect();
+
+    List<E> generateFetchColumns();
+
+    List<E> generateOrderBys();
+
+    List<J> getRandomJoinClauses();
+
+    List<E> getTableRefs();
+}

--- a/src/sqlancer/common/gen/TLPAggregateGenerator.java
+++ b/src/sqlancer/common/gen/TLPAggregateGenerator.java
@@ -10,13 +10,10 @@ import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.common.schema.AbstractTables;
 
 public interface TLPAggregateGenerator<A extends Aggregate<E, C>, J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>>
-        extends SelectGenerator<J, E, T, C>, PredicateGenerator<E, C>, AggregateGenerator<A, E, T, C> {
+        extends SelectGenerator<J, E, T, C>, PredicateGenerator<E, C>, AggregateGenerator<A, E, T, C>,
+        TypeExpressionGenerator<E, T, C> {
 
     TLPAggregateGenerator<A, J, E, T, C> setColumns(List<C> columns);
 
     TLPAggregateGenerator<A, J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
-
-    E generateExpression();
-
-    List<E> getRandomExpressions(int size);
 }

--- a/src/sqlancer/common/gen/TLPAggregateGenerator.java
+++ b/src/sqlancer/common/gen/TLPAggregateGenerator.java
@@ -1,0 +1,22 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+
+import sqlancer.common.ast.newast.Aggregate;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public interface TLPAggregateGenerator<A extends Aggregate<E, C>, J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>>
+        extends SelectGenerator<J, E, T, C>, PredicateGenerator<E, C>, AggregateGenerator<A, E, T, C> {
+
+    TLPAggregateGenerator<A, J, E, T, C> setColumns(List<C> columns);
+
+    TLPAggregateGenerator<A, J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
+
+    E generateExpression();
+
+    List<E> getRandomExpressions(int size);
+}

--- a/src/sqlancer/common/gen/TLPGenerator.java
+++ b/src/sqlancer/common/gen/TLPGenerator.java
@@ -1,0 +1,13 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+
+public interface TLPGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>>
+        extends SelectGenerator<J, E, T, C>, PredicateGenerator<E, C> {
+
+    TLPGenerator<J, E, T, C> setColumns(List<C> columns);
+}

--- a/src/sqlancer/common/gen/TLPGenerator.java
+++ b/src/sqlancer/common/gen/TLPGenerator.java
@@ -1,13 +1,17 @@
 package sqlancer.common.gen;
 
 import java.util.List;
+
 import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.ast.newast.Join;
 import sqlancer.common.schema.AbstractTable;
 import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
 
 public interface TLPGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>>
         extends SelectGenerator<J, E, T, C>, PredicateGenerator<E, C> {
 
     TLPGenerator<J, E, T, C> setColumns(List<C> columns);
+
+    TLPGenerator<J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
 }

--- a/src/sqlancer/common/gen/TLPHavingGenerator.java
+++ b/src/sqlancer/common/gen/TLPHavingGenerator.java
@@ -14,4 +14,6 @@ public interface TLPHavingGenerator<J extends Join<E, T, C>, E extends Expressio
     TLPHavingGenerator<J, E, T, C> setColumns(List<C> columns);
 
     TLPHavingGenerator<J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
+
+    String combineQueryStrings(String... queryStrings);
 }

--- a/src/sqlancer/common/gen/TLPHavingGenerator.java
+++ b/src/sqlancer/common/gen/TLPHavingGenerator.java
@@ -1,0 +1,17 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public interface TLPHavingGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>>
+        extends SelectGenerator<J, E, T, C>, HavingClauseGenerator<E, C> {
+
+    TLPHavingGenerator<J, E, T, C> setColumns(List<C> columns);
+
+    TLPHavingGenerator<J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
+}

--- a/src/sqlancer/common/gen/TLPHavingGenerator.java
+++ b/src/sqlancer/common/gen/TLPHavingGenerator.java
@@ -9,7 +9,7 @@ import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.common.schema.AbstractTables;
 
 public interface TLPHavingGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>>
-        extends SelectGenerator<J, E, T, C>, HavingClauseGenerator<E, C> {
+        extends SelectGenerator<J, E, T, C>, HavingClauseGenerator<E, C>, TypeExpressionGenerator<E, T, C> {
 
     TLPHavingGenerator<J, E, T, C> setColumns(List<C> columns);
 

--- a/src/sqlancer/common/gen/TypeExpressionGenerator.java
+++ b/src/sqlancer/common/gen/TypeExpressionGenerator.java
@@ -1,0 +1,14 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+
+public interface TypeExpressionGenerator<E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
+
+    List<E> generateExpressions(int number);
+
+    E generateBooleanExpression();
+}

--- a/src/sqlancer/common/oracle/TLPAggregateOracle.java
+++ b/src/sqlancer/common/oracle/TLPAggregateOracle.java
@@ -48,7 +48,7 @@ public class TLPAggregateOracle<A extends Aggregate<E, C>, E extends Expression<
         select.setFromList(from);
 
         if (Randomly.getBoolean()) {
-            select.setOrderByExpressions(gen.generateOrderBys());
+            select.setOrderByClauses(gen.generateOrderBys());
         }
 
         String originalQuery = select.asString();

--- a/src/sqlancer/common/oracle/TLPAggregateOracle.java
+++ b/src/sqlancer/common/oracle/TLPAggregateOracle.java
@@ -1,0 +1,100 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.SQLGlobalState;
+import sqlancer.common.ast.newast.Aggregate;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.gen.TLPAggregateGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public class TLPAggregateOracle<A extends Aggregate<E, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+        implements TestOracle<G> {
+
+    private final G state;
+
+    private TLPAggregateGenerator<A, ?, E, T, C> gen;
+    private final ExpectedErrors errors;
+
+    private String generatedQueryString;
+
+    public TLPAggregateOracle(G state, TLPAggregateGenerator<A, ?, E, T, C> gen, ExpectedErrors expectedErrors) {
+        this.state = state;
+        this.gen = gen;
+        this.errors = expectedErrors;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        S s = state.getSchema();
+        AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(s);
+        gen = gen.setTablesAndColumns(targetTables);
+
+        Select<?, E, T, C> select = gen.generateSelect();
+
+        A aggregate = gen.generateAggregate();
+        select.setFetchColumns(Arrays.asList(aggregate.asExpression()));
+
+        List<E> from = gen.getTableRefs();
+        select.setFromList(from);
+
+        if (Randomly.getBoolean()) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+
+        String originalQuery = select.asString();
+        generatedQueryString = originalQuery;
+        String firstResult = ComparatorHelper.runQuery(originalQuery, errors, state);
+
+        E whereClause = gen.generateExpression();
+        E negatedClause = gen.negatePredicate(whereClause);
+        E notNullClause = gen.isNull(whereClause);
+
+        Select<?, E, T, C> leftSelect = getSelect(aggregate, from, whereClause);
+        Select<?, E, T, C> middleSelect = getSelect(aggregate, from, negatedClause);
+        Select<?, E, T, C> rightSelect = getSelect(aggregate, from, notNullClause);
+
+        String metamorphicText = aggregate.asAggregatedString(leftSelect.asString(), middleSelect.asString(),
+                rightSelect.asString());
+
+        String secondResult = ComparatorHelper.runQuery(metamorphicText, errors, state);
+
+        state.getState().getLocalState()
+                .log("--" + originalQuery + "\n--" + metamorphicText + "\n-- " + firstResult + "\n-- " + secondResult);
+
+        if ((firstResult == null && secondResult != null
+                || firstResult != null && !firstResult.contentEquals(secondResult))
+                && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
+
+            throw new AssertionError();
+        }
+    }
+
+    private Select<?, E, T, C> getSelect(A aggregate, List<E> from, E whereClause) {
+        Select<?, E, T, C> leftSelect = gen.generateSelect();
+        leftSelect.setFetchColumns(gen.aliasAggregates(List.of(aggregate)));
+        leftSelect.setFromList(from);
+        leftSelect.setWhereClause(whereClause);
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            leftSelect.setGroupByClause(gen.getRandomExpressions(Randomly.smallNumber() + 1));
+        }
+        if (Randomly.getBoolean()) {
+            leftSelect.setOrderByClauses(gen.generateOrderBys());
+        }
+        return leftSelect;
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return generatedQueryString;
+    }
+}

--- a/src/sqlancer/common/oracle/TLPAggregateOracle.java
+++ b/src/sqlancer/common/oracle/TLPAggregateOracle.java
@@ -55,7 +55,7 @@ public class TLPAggregateOracle<A extends Aggregate<E, C>, E extends Expression<
         generatedQueryString = originalQuery;
         String firstResult = ComparatorHelper.runQuery(originalQuery, errors, state);
 
-        E whereClause = gen.generateExpression();
+        E whereClause = gen.generateBooleanExpression();
         E negatedClause = gen.negatePredicate(whereClause);
         E notNullClause = gen.isNull(whereClause);
 

--- a/src/sqlancer/common/oracle/TLPDistinctOracle.java
+++ b/src/sqlancer/common/oracle/TLPDistinctOracle.java
@@ -1,0 +1,75 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.SQLGlobalState;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.gen.TLPGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public class TLPDistinctOracle<J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+        implements TestOracle<G> {
+
+    private final G state;
+
+    private TLPGenerator<J, E, T, C> gen;
+    private final ExpectedErrors errors;
+
+    private String generatedQueryString;
+
+    public TLPDistinctOracle(G state, TLPGenerator<J, E, T, C> gen, ExpectedErrors expectedErrors) {
+        this.state = state;
+        this.gen = gen;
+        this.errors = expectedErrors;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        S s = state.getSchema();
+        AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(s);
+        gen = gen.setTablesAndColumns(targetTables);
+
+        Select<J, E, T, C> select = gen.generateSelect();
+        select.setDistinct();
+
+        boolean shouldCreateDummy = true;
+        select.setFetchColumns(gen.generateFetchColumns(shouldCreateDummy));
+        select.setJoinClauses(gen.getRandomJoinClauses());
+        select.setFromList(gen.getTableRefs());
+        select.setWhereClause(null);
+
+        String originalQueryString = select.asString();
+        generatedQueryString = originalQueryString;
+        List<String> firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
+                state);
+
+        TestOracleUtils.PredicateVariants<E, C> predicates = TestOracleUtils.initializeTernaryPredicateVariants(gen);
+        select.setWhereClause(predicates.predicate);
+        String firstQueryString = select.asString();
+        select.setWhereClause(predicates.negatedPredicate);
+        String secondQueryString = select.asString();
+        select.setWhereClause(predicates.isNullPredicate);
+        String thirdQueryString = select.asString();
+
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
+                secondQueryString, thirdQueryString, combinedString, true, state, errors);
+
+        ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString, combinedString,
+                state);
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return generatedQueryString;
+    }
+}

--- a/src/sqlancer/common/oracle/TLPGroupByOracle.java
+++ b/src/sqlancer/common/oracle/TLPGroupByOracle.java
@@ -1,0 +1,77 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.SQLGlobalState;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.gen.TLPGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public class TLPGroupByOracle<J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+        implements TestOracle<G> {
+    private final G state;
+
+    private TLPGenerator<J, E, T, C> gen;
+    private final ExpectedErrors errors;
+
+    private String generatedQueryString;
+
+    public TLPGroupByOracle(G state, TLPGenerator<J, E, T, C> gen, ExpectedErrors expectedErrors) {
+        this.state = state;
+        this.gen = gen;
+        this.errors = expectedErrors;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        S s = state.getSchema();
+        AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(s);
+        gen = gen.setTablesAndColumns(targetTables);
+
+        Select<J, E, T, C> select = gen.generateSelect();
+
+        boolean shouldCreateDummy = true;
+        List<E> fetchColumns = gen.generateFetchColumns(shouldCreateDummy);
+        select.setFetchColumns(fetchColumns);
+        select.setJoinClauses(gen.getRandomJoinClauses());
+        select.setFromList(gen.getTableRefs());
+        select.setGroupByClause(fetchColumns);
+        select.setWhereClause(null);
+
+        String originalQueryString = select.asString();
+        generatedQueryString = originalQueryString;
+        List<String> firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
+                state);
+
+        TestOracleUtils.PredicateVariants<E, C> predicates = TestOracleUtils.initializeTernaryPredicateVariants(gen);
+        select.setWhereClause(predicates.predicate);
+        String firstQueryString = select.asString();
+        select.setWhereClause(predicates.negatedPredicate);
+        String secondQueryString = select.asString();
+        select.setWhereClause(predicates.isNullPredicate);
+        String thirdQueryString = select.asString();
+
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
+                secondQueryString, thirdQueryString, combinedString, true, state, errors);
+
+        ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString, combinedString,
+                state);
+
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return generatedQueryString;
+    }
+
+}

--- a/src/sqlancer/common/oracle/TLPHavingOracle.java
+++ b/src/sqlancer/common/oracle/TLPHavingOracle.java
@@ -1,0 +1,93 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLGlobalState;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.gen.TLPHavingGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public class TLPHavingOracle<J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+        implements TestOracle<G> {
+
+    private final G state;
+
+    private TLPHavingGenerator<J, E, T, C> gen;
+    private final ExpectedErrors errors;
+
+    private String generatedQueryString;
+
+    public TLPHavingOracle(G state, TLPHavingGenerator<J, E, T, C> gen, ExpectedErrors expectedErrors) {
+        this.state = state;
+        this.gen = gen;
+        this.errors = expectedErrors;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        S s = state.getSchema();
+        AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(s);
+        gen = gen.setTablesAndColumns(targetTables);
+
+        Select<J, E, T, C> select = gen.generateSelect();
+
+        boolean shouldCreateDummy = false;
+        List<E> fetchColumns = gen.generateFetchColumns(shouldCreateDummy);
+
+        select.setFetchColumns(fetchColumns);
+        select.setJoinClauses(gen.getRandomJoinClauses());
+        select.setFromList(gen.getTableRefs());
+        select.setGroupByClause(fetchColumns);
+        select.setHavingClause(null);
+
+        String originalQueryString = select.asString();
+        generatedQueryString = originalQueryString;
+        List<String> firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
+                state);
+
+        boolean orderBy = Randomly.getBooleanWithSmallProbability();
+        if (orderBy) {
+            select.setOrderByClauses(gen.generateOrderBys());
+        }
+
+        E predicate = gen.getHavingClause();
+        select.setHavingClause(predicate);
+        String firstQueryString = select.asString();
+        select.setHavingClause(gen.negatePredicate(predicate));
+        String secondQueryString = select.asString();
+        select.setHavingClause(gen.isNull(predicate));
+        String thirdQueryString = select.asString();
+        String combinedString = TestOracleUtils.combineQueryStrings(" UNION ALL ", firstQueryString, secondQueryString,
+                thirdQueryString);
+
+        if (combinedString.contains("EXIST")) {
+            throw new IgnoreMeException();
+        }
+
+        List<String> secondResultSet = ComparatorHelper.getResultSetFirstColumnAsString(combinedString, errors, state);
+        if (state.getOptions().logEachSelect()) {
+            state.getLogger().writeCurrent(originalQueryString);
+            state.getLogger().writeCurrent(combinedString);
+        }
+
+        if (new HashSet<>(firstResultSet).size() != new HashSet<>(secondResultSet).size()) {
+            throw new AssertionError(originalQueryString + ";\n" + combinedString + ";");
+        }
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return generatedQueryString;
+    }
+}

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -3,7 +3,6 @@ package sqlancer.common.oracle;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.Randomly;
@@ -32,12 +31,6 @@ public class TLPWhereOracle<J extends Join<E, T, C>, E extends Expression<C>, S 
         this.state = state;
         this.gen = gen;
         this.errors = expectedErrors;
-    }
-
-    public TLPWhereOracle(G state, TLPGenerator<J, E, T, C> gen, List<String> expectedErrors,
-            List<Pattern> expectedErrorsRegex) {
-        this(state, gen, expectedErrors);
-        this.errors.addAllRegexes(expectedErrorsRegex);
     }
 
     @Override

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -3,6 +3,7 @@ package sqlancer.common.oracle;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.Randomly;
@@ -31,6 +32,12 @@ public class TLPWhereOracle<J extends Join<E, T, C>, E extends Expression<C>, S 
         this.state = state;
         this.gen = gen;
         this.errors = expectedErrors;
+    }
+
+    public TLPWhereOracle(G state, TLPGenerator<J, E, T, C> gen, List<String> expectedErrors,
+            List<Pattern> expectedErrorsRegex) {
+        this(state, gen, expectedErrors);
+        this.errors.addAllRegexes(expectedErrorsRegex);
     }
 
     @Override

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -1,0 +1,76 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
+import sqlancer.SQLGlobalState;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.gen.TLPGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+
+public class TLPWhereOracle<J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+        implements TestOracle<G> {
+
+    private final G state;
+
+    private TLPGenerator<J, E, T, C> gen;
+    private final ExpectedErrors errors;
+
+    private String generatedQueryString;
+
+    public TLPWhereOracle(G state, TLPGenerator<J, E, T, C> gen) {
+        this.state = state;
+        this.gen = gen;
+        this.errors = new ExpectedErrors();
+    }
+
+    @Override
+    public void check() throws SQLException {
+        gen = TestOracleUtils.initializeGenerator(state, gen);
+
+        Select<J, E, T, C> select = gen.generateSelect();
+
+        select.setFetchColumns(gen.generateFetchColumns());
+        select.setJoinClauses(gen.getRandomJoinClauses());
+        select.setFromTables(gen.getTableRefs());
+        select.setWhereClause(null);
+
+        String originalQueryString = select.asString();
+        generatedQueryString = originalQueryString;
+
+        boolean orderBy = Randomly.getBooleanWithSmallProbability();
+        if (orderBy) {
+            select.setOrderByExpressions(gen.generateOrderBys());
+        }
+
+        TestOracleUtils.PredicateVariants<E, C> predicates = TestOracleUtils.initializeTernaryPredicateVariants(gen);
+        select.setWhereClause(predicates.predicate);
+        String firstQueryString = select.asString();
+        select.setWhereClause(predicates.negatedPredicate);
+        String secondQueryString = select.asString();
+        select.setWhereClause(predicates.isNullPredicate);
+        String thirdQueryString = select.asString();
+
+        List<String> firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
+                state);
+        List<String> combinedString = new ArrayList<>();
+        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                thirdQueryString, combinedString, !orderBy, state, errors);
+
+        ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString, combinedString,
+                state);
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return generatedQueryString;
+    }
+}

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -64,8 +64,4 @@ public final class TestOracleUtils {
         AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(s);
         return gen.setTablesAndColumns(targetTables);
     }
-
-    public static String combineQueryStrings(String combineOperation, String... queryStrings) {
-        return String.join(combineOperation, queryStrings);
-    }
 }

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -1,0 +1,67 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+
+import sqlancer.GlobalState;
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.gen.TLPGenerator;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public final class TestOracleUtils {
+
+    public static class PredicateVariants<E extends Expression<C>, C extends AbstractTableColumn<?, ?>> {
+        public E predicate;
+        public E negatedPredicate;
+        public E isNullPredicate;
+
+        PredicateVariants(E predicate, E negatedPredicate, E isNullPredicate) {
+            this.predicate = predicate;
+            this.negatedPredicate = negatedPredicate;
+            this.isNullPredicate = isNullPredicate;
+        }
+    }
+
+    private TestOracleUtils() {
+    }
+
+    public static <J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> PredicateVariants<E, C> initializeTernaryPredicateVariants(
+            TLPGenerator<J, E, T, C> gen) {
+        if (gen == null) {
+            throw new IllegalStateException();
+        }
+        E predicate = gen.generatePredicate();
+        if (predicate == null) {
+            throw new IllegalStateException();
+        }
+        E negatedPredicate = gen.negatePredicate(predicate);
+        if (negatedPredicate == null) {
+            throw new IllegalStateException();
+        }
+        E isNullPredicate = gen.isNull(predicate);
+        if (isNullPredicate == null) {
+            throw new IllegalStateException();
+        }
+        return new PredicateVariants<>(predicate, negatedPredicate, isNullPredicate);
+    }
+
+    public static <T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> AbstractTables<T, C> getRandomTableNonEmptyTables(
+            AbstractSchema<?, T> schema) {
+        if (schema.getDatabaseTables().isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        return new AbstractTables<>(Randomly.nonEmptySubset(schema.getDatabaseTables()));
+    }
+
+    public static <J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> TLPGenerator<J, E, T, C> initializeGenerator(
+            GlobalState<?, S, ?> state, TLPGenerator<J, E, T, C> gen) throws SQLException {
+        S s = state.getSchema();
+        AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(s);
+        return gen.setTablesAndColumns(targetTables);
+    }
+}

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -64,4 +64,8 @@ public final class TestOracleUtils {
         AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(s);
         return gen.setTablesAndColumns(targetTables);
     }
+
+    public static String combineQueryStrings(String combineOperation, String... queryStrings) {
+        return String.join(combineOperation, queryStrings);
+    }
 }

--- a/src/sqlancer/mariadb/ast/MariaDBSelectStatement.java
+++ b/src/sqlancer/mariadb/ast/MariaDBSelectStatement.java
@@ -16,6 +16,7 @@ public class MariaDBSelectStatement extends SelectBase<MariaDBExpression> implem
     private MariaDBSelectType selectType = MariaDBSelectType.ALL;
     private MariaDBExpression whereCondition;
 
+    @Override
     public void setGroupByClause(List<MariaDBExpression> groupBys) {
         this.groupBys = groupBys;
     }

--- a/src/sqlancer/oceanbase/ast/OceanBaseSelect.java
+++ b/src/sqlancer/oceanbase/ast/OceanBaseSelect.java
@@ -29,10 +29,12 @@ public class OceanBaseSelect extends SelectBase<OceanBaseExpression> implements 
         this.fromOptions = fromOptions;
     }
 
+    @Override
     public void setGroupByClause(List<OceanBaseExpression> groupBys) {
         this.groupBys = groupBys;
     }
 
+    @Override
     public List<OceanBaseExpression> getGroupByClause() {
         return this.groupBys;
     }

--- a/src/sqlancer/postgres/ast/PostgresExpression.java
+++ b/src/sqlancer/postgres/ast/PostgresExpression.java
@@ -1,8 +1,10 @@
 package sqlancer.postgres.ast;
 
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 
-public interface PostgresExpression {
+public interface PostgresExpression extends Expression<PostgresColumn> {
 
     default PostgresDataType getExpressionType() {
         return null;

--- a/src/sqlancer/postgres/ast/PostgresJoin.java
+++ b/src/sqlancer/postgres/ast/PostgresJoin.java
@@ -5,12 +5,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Join;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
+import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
 
-public class PostgresJoin implements PostgresExpression {
+public class PostgresJoin implements PostgresExpression, Join<PostgresExpression, PostgresTable, PostgresColumn> {
 
     public enum PostgresJoinType {
         INNER, LEFT, RIGHT, FULL, CROSS;
@@ -77,6 +79,7 @@ public class PostgresJoin implements PostgresExpression {
         return joinExpressions;
     }
 
+    @Override
     public void setOnClause(PostgresExpression clause) {
         this.onClause = clause;
     }
@@ -97,6 +100,7 @@ public class PostgresJoin implements PostgresExpression {
         return rightTable;
     }
 
+    @Override
     public PostgresExpression getOnClause() {
         return onClause;
     }

--- a/src/sqlancer/postgres/ast/PostgresSelect.java
+++ b/src/sqlancer/postgres/ast/PostgresSelect.java
@@ -5,33 +5,18 @@ import java.util.List;
 
 import sqlancer.Randomly;
 import sqlancer.common.ast.SelectBase;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
+import sqlancer.postgres.PostgresVisitor;
 
-public class PostgresSelect extends SelectBase<PostgresExpression> implements PostgresExpression {
+public class PostgresSelect extends SelectBase<PostgresExpression>
+        implements PostgresExpression, Select<PostgresJoin, PostgresExpression, PostgresTable, PostgresColumn> {
 
     private SelectType selectOption = SelectType.ALL;
     private List<PostgresJoin> joinClauses = Collections.emptyList();
     private PostgresExpression distinctOnClause;
-    private ForClause forClause;
-
-    public enum ForClause {
-        UPDATE("UPDATE"), NO_KEY_UPDATE("NO KEY UPDATE"), SHARE("SHARE"), KEY_SHARE("KEY SHARE");
-
-        private final String textRepresentation;
-
-        ForClause(String textRepresentation) {
-            this.textRepresentation = textRepresentation;
-        }
-
-        public String getTextRepresentation() {
-            return textRepresentation;
-        }
-
-        public static ForClause getRandom() {
-            return Randomly.fromOptions(values());
-        }
-    }
 
     public static class PostgresFromTable implements PostgresExpression {
         private final PostgresTable t;
@@ -98,6 +83,11 @@ public class PostgresSelect extends SelectBase<PostgresExpression> implements Po
         this.distinctOnClause = distinctOnClause;
     }
 
+    @Override
+    public void setDistinct() {
+        this.selectOption = SelectType.DISTINCT;
+    }
+
     public SelectType getSelectOption() {
         return selectOption;
     }
@@ -111,11 +101,13 @@ public class PostgresSelect extends SelectBase<PostgresExpression> implements Po
         return null;
     }
 
+    @Override
     public void setJoinClauses(List<PostgresJoin> joinStatements) {
         this.joinClauses = joinStatements;
 
     }
 
+    @Override
     public List<PostgresJoin> getJoinClauses() {
         return joinClauses;
     }
@@ -124,12 +116,8 @@ public class PostgresSelect extends SelectBase<PostgresExpression> implements Po
         return distinctOnClause;
     }
 
-    public void setForClause(ForClause forClause) {
-        this.forClause = forClause;
+    @Override
+    public String asString() {
+        return PostgresVisitor.asString(this);
     }
-
-    public ForClause getForClause() {
-        return forClause;
-    }
-
 }

--- a/src/sqlancer/postgres/gen/PostgresCommon.java
+++ b/src/sqlancer/postgres/gen/PostgresCommon.java
@@ -188,7 +188,7 @@ public final class PostgresCommon {
         errors.add("result of range union would not be contiguous");
 
         return errors;
-    }
+   }
 
     public static void addCommonRangeExpressionErrors(ExpectedErrors errors) {
         errors.addAll(getCommonRangeExpressionErrors());

--- a/src/sqlancer/postgres/gen/PostgresCommon.java
+++ b/src/sqlancer/postgres/gen/PostgresCommon.java
@@ -188,7 +188,7 @@ public final class PostgresCommon {
         errors.add("result of range union would not be contiguous");
 
         return errors;
-   }
+    }
 
     public static void addCommonRangeExpressionErrors(ExpectedErrors errors) {
         errors.addAll(getCommonRangeExpressionErrors());

--- a/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
@@ -21,6 +21,8 @@ import sqlancer.postgres.PostgresProvider;
 import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresSchema.PostgresRowValue;
+import sqlancer.postgres.PostgresSchema.PostgresTable;
+import sqlancer.postgres.PostgresSchema.PostgresTables;
 import sqlancer.postgres.ast.PostgresAggregate;
 import sqlancer.postgres.ast.PostgresAggregate.PostgresAggregateFunction;
 import sqlancer.postgres.ast.PostgresBetweenOperation;
@@ -44,6 +46,8 @@ import sqlancer.postgres.ast.PostgresFunction;
 import sqlancer.postgres.ast.PostgresFunction.PostgresFunctionWithResult;
 import sqlancer.postgres.ast.PostgresFunctionWithUnknownResult;
 import sqlancer.postgres.ast.PostgresInOperation;
+import sqlancer.postgres.ast.PostgresJoin;
+import sqlancer.postgres.ast.PostgresJoin.PostgresJoinType;
 import sqlancer.postgres.ast.PostgresLikeOperation;
 import sqlancer.postgres.ast.PostgresOrderByTerm;
 import sqlancer.postgres.ast.PostgresOrderByTerm.PostgresOrder;
@@ -53,6 +57,9 @@ import sqlancer.postgres.ast.PostgresPostfixOperation;
 import sqlancer.postgres.ast.PostgresPostfixOperation.PostfixOperator;
 import sqlancer.postgres.ast.PostgresPrefixOperation;
 import sqlancer.postgres.ast.PostgresPrefixOperation.PrefixOperator;
+import sqlancer.postgres.ast.PostgresSelect;
+import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
+import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
 import sqlancer.postgres.ast.PostgresSimilarTo;
 
 public class PostgresExpressionGenerator implements ExpressionGenerator<PostgresExpression>,
@@ -65,6 +72,8 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
     private final Randomly r;
 
     private List<PostgresColumn> columns;
+
+    private List<PostgresTable> targetTables;
 
     private PostgresRowValue rw;
 
@@ -86,6 +95,7 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         this.allowedFunctionTypes = globalState.getAllowedFunctionTypes();
     }
 
+    @Override
     public PostgresExpressionGenerator setColumns(List<PostgresColumn> columns) {
         this.columns = columns;
         return this;
@@ -161,56 +171,55 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         }
         BooleanExpression option = Randomly.fromList(validOptions);
         switch (option) {
-            case POSTFIX_OPERATOR:
-                PostfixOperator random = PostfixOperator.getRandom();
-                return PostgresPostfixOperation
-                        .create(generateExpression(depth + 1, Randomly.fromOptions(random.getInputDataTypes())),
-                                random);
-            case IN_OPERATION:
-                return inOperation(depth + 1);
-            case NOT:
-                return new PostgresPrefixOperation(generateExpression(depth + 1, PostgresDataType.BOOLEAN),
-                        PrefixOperator.NOT);
-            case BINARY_LOGICAL_OPERATOR:
-                PostgresExpression first = generateExpression(depth + 1, PostgresDataType.BOOLEAN);
-                int nr = Randomly.smallNumber() + 1;
-                for (int i = 0; i < nr; i++) {
-                    first = new PostgresBinaryLogicalOperation(first,
-                            generateExpression(depth + 1, PostgresDataType.BOOLEAN), BinaryLogicalOperator.getRandom());
-                }
-                return first;
-            case BINARY_COMPARISON:
-                PostgresDataType dataType = getMeaningfulType();
-                return generateComparison(depth, dataType);
-            case CAST:
-                return new PostgresCastOperation(generateExpression(depth + 1),
-                        getCompoundDataType(PostgresDataType.BOOLEAN));
-            case FUNCTION:
-                return generateFunction(depth + 1, PostgresDataType.BOOLEAN);
-            case LIKE:
-                return new PostgresLikeOperation(generateExpression(depth + 1, PostgresDataType.TEXT),
-                        generateExpression(depth + 1, PostgresDataType.TEXT));
-            case BETWEEN:
-                PostgresDataType type = getMeaningfulType();
-                return new PostgresBetweenOperation(generateExpression(depth + 1, type),
-                        generateExpression(depth + 1, type), generateExpression(depth + 1, type),
-                        Randomly.getBoolean());
-            case SIMILAR_TO:
-                assert !expectedResult;
-                // TODO also generate the escape character
-                return new PostgresSimilarTo(generateExpression(depth + 1, PostgresDataType.TEXT),
-                        generateExpression(depth + 1, PostgresDataType.TEXT), null);
-            case POSIX_REGEX:
-                assert !expectedResult;
-                return new PostgresPOSIXRegularExpression(generateExpression(depth + 1, PostgresDataType.TEXT),
-                        generateExpression(depth + 1, PostgresDataType.TEXT), POSIXRegex.getRandom());
-            case BINARY_RANGE_COMPARISON:
-                // TODO element check
-                return new PostgresBinaryRangeOperation(PostgresBinaryRangeComparisonOperator.getRandom(),
-                        generateExpression(depth + 1, PostgresDataType.RANGE),
-                        generateExpression(depth + 1, PostgresDataType.RANGE));
-            default:
-                throw new AssertionError();
+        case POSTFIX_OPERATOR:
+            PostfixOperator random = PostfixOperator.getRandom();
+            return PostgresPostfixOperation
+                    .create(generateExpression(depth + 1, Randomly.fromOptions(random.getInputDataTypes())),
+                            random);
+        case IN_OPERATION:
+            return inOperation(depth + 1);
+        case NOT:
+            return new PostgresPrefixOperation(generateExpression(depth + 1, PostgresDataType.BOOLEAN),
+                    PrefixOperator.NOT);
+        case BINARY_LOGICAL_OPERATOR:
+            PostgresExpression first = generateExpression(depth + 1, PostgresDataType.BOOLEAN);
+            int nr = Randomly.smallNumber() + 1;
+            for (int i = 0; i < nr; i++) {
+                first = new PostgresBinaryLogicalOperation(first,
+                        generateExpression(depth + 1, PostgresDataType.BOOLEAN), BinaryLogicalOperator.getRandom());
+            }
+            return first;
+        case BINARY_COMPARISON:
+            PostgresDataType dataType = getMeaningfulType();
+            return generateComparison(depth, dataType);
+        case CAST:
+            return new PostgresCastOperation(generateExpression(depth + 1),
+                    getCompoundDataType(PostgresDataType.BOOLEAN));
+        case FUNCTION:
+            return generateFunction(depth + 1, PostgresDataType.BOOLEAN);
+        case LIKE:
+            return new PostgresLikeOperation(generateExpression(depth + 1, PostgresDataType.TEXT),
+                    generateExpression(depth + 1, PostgresDataType.TEXT));
+        case BETWEEN:
+            PostgresDataType type = getMeaningfulType();
+            return new PostgresBetweenOperation(generateExpression(depth + 1, type),
+                    generateExpression(depth + 1, type), generateExpression(depth + 1, type), Randomly.getBoolean());
+        case SIMILAR_TO:
+            assert !expectedResult;
+            // TODO also generate the escape character
+            return new PostgresSimilarTo(generateExpression(depth + 1, PostgresDataType.TEXT),
+                    generateExpression(depth + 1, PostgresDataType.TEXT), null);
+        case POSIX_REGEX:
+            assert !expectedResult;
+            return new PostgresPOSIXRegularExpression(generateExpression(depth + 1, PostgresDataType.TEXT),
+                    generateExpression(depth + 1, PostgresDataType.TEXT), POSIXRegex.getRandom());
+        case BINARY_RANGE_COMPARISON:
+            // TODO element check
+            return new PostgresBinaryRangeOperation(PostgresBinaryRangeComparisonOperator.getRandom(),
+                    generateExpression(depth + 1, PostgresDataType.RANGE),
+                    generateExpression(depth + 1, PostgresDataType.RANGE));
+        default:
+            throw new AssertionError();
         }
     }
 
@@ -311,52 +320,48 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
             }
         } else {
             switch (dataType) {
-                case BOOLEAN:
-                    return generateBooleanExpression(depth);
-                case INT:
-                    return generateIntExpression(depth);
-                case TEXT:
-                    return generateTextExpression(depth);
-                case DECIMAL:
-                case REAL:
-                case FLOAT:
-                case MONEY:
-                case INET:
-                    return generateConstant(r, dataType);
-                case BIT:
-                    return generateBitExpression(depth);
-                case RANGE:
-                    return generateRangeExpression(depth);
-                default:
-                    throw new AssertionError(dataType);
+            case BOOLEAN:
+                return generateBooleanExpression(depth);
+            case INT:
+                return generateIntExpression(depth);
+            case TEXT:
+                return generateTextExpression(depth);
+            case DECIMAL:
+            case REAL:
+            case FLOAT:
+            case MONEY:
+            case INET:
+                return generateConstant(r, dataType);
+            case BIT:
+                return generateBitExpression(depth);
+            case RANGE:
+                return generateRangeExpression(depth);
+            default:
+                throw new AssertionError(dataType);
             }
         }
     }
 
     private static PostgresCompoundDataType getCompoundDataType(PostgresDataType type) {
         switch (type) {
-            case BOOLEAN:
-            case DECIMAL: // TODO
-            case FLOAT:
-            case INT:
-            case MONEY:
-            case RANGE:
-            case REAL:
-            case INET:
+        case BOOLEAN:
+        case DECIMAL: // TODO
+        case FLOAT:
+        case INT:
+        case MONEY:
+        case RANGE:
+        case REAL:
+        case INET:
+            return PostgresCompoundDataType.create(type);
+        case TEXT: // TODO
+        case BIT:
+            if (Randomly.getBoolean() || PostgresProvider.generateOnlyKnown /* The PQS implementation does not check for size specifications */) {
                 return PostgresCompoundDataType.create(type);
-            case TEXT: // TODO
-            case BIT:
-                if (Randomly.getBoolean() || PostgresProvider.generateOnlyKnown /*
-                                                                                 * The PQS implementation does not check
-                                                                                 * for
-                                                                                 * size specifications
-                                                                                 */) {
-                    return PostgresCompoundDataType.create(type);
-                } else {
-                    return PostgresCompoundDataType.create(type, (int) Randomly.getNotCachedInteger(1, 1000));
-                }
-            default:
-                throw new AssertionError(type);
+            } else {
+                return PostgresCompoundDataType.create(type, (int) Randomly.getNotCachedInteger(1, 1000));
+            }
+        default:
+            throw new AssertionError(type);
         }
 
     }
@@ -370,12 +375,12 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         List<RangeExpression> validOptions = new ArrayList<>(Arrays.asList(RangeExpression.values()));
         option = Randomly.fromList(validOptions);
         switch (option) {
-            case BINARY_OP:
-                return new PostgresBinaryRangeOperation(PostgresBinaryRangeOperator.getRandom(),
-                        generateExpression(depth + 1, PostgresDataType.RANGE),
-                        generateExpression(depth + 1, PostgresDataType.RANGE));
-            default:
-                throw new AssertionError(option);
+        case BINARY_OP:
+            return new PostgresBinaryRangeOperation(PostgresBinaryRangeOperator.getRandom(),
+                    generateExpression(depth + 1, PostgresDataType.RANGE),
+                    generateExpression(depth + 1, PostgresDataType.RANGE));
+        default:
+            throw new AssertionError(option);
         }
     }
 
@@ -395,20 +400,18 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         option = Randomly.fromList(validOptions);
 
         switch (option) {
-            case CAST:
-                return new PostgresCastOperation(generateExpression(depth + 1),
-                        getCompoundDataType(PostgresDataType.TEXT));
-            case FUNCTION:
-                return generateFunction(depth + 1, PostgresDataType.TEXT);
-            case CONCAT:
-                return generateConcat(depth);
-            case COLLATE:
-                assert !expectedResult;
-                return new PostgresCollate(generateExpression(depth + 1, PostgresDataType.TEXT), globalState == null
-                        ? Randomly.fromOptions("C", "POSIX", "de_CH.utf8", "es_CR.utf8")
-                        : globalState.getRandomCollate());
-            default:
-                throw new AssertionError();
+        case CAST:
+            return new PostgresCastOperation(generateExpression(depth + 1), getCompoundDataType(PostgresDataType.TEXT));
+        case FUNCTION:
+            return generateFunction(depth + 1, PostgresDataType.TEXT);
+        case CONCAT:
+            return generateConcat(depth);
+        case COLLATE:
+            assert !expectedResult;
+            return new PostgresCollate(generateExpression(depth + 1, PostgresDataType.TEXT), globalState == null
+                    ? Randomly.fromOptions("C", "POSIX", "de_CH.utf8", "es_CR.utf8") : globalState.getRandomCollate());
+        default:
+            throw new AssertionError();
         }
     }
 
@@ -426,12 +429,12 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         BitExpression option;
         option = Randomly.fromOptions(BitExpression.values());
         switch (option) {
-            case BINARY_OPERATION:
-                return new PostgresBinaryBitOperation(PostgresBinaryBitOperator.getRandom(),
-                        generateExpression(depth + 1, PostgresDataType.BIT),
-                        generateExpression(depth + 1, PostgresDataType.BIT));
-            default:
-                throw new AssertionError();
+        case BINARY_OPERATION:
+            return new PostgresBinaryBitOperation(PostgresBinaryBitOperator.getRandom(),
+                    generateExpression(depth + 1, PostgresDataType.BIT),
+                    generateExpression(depth + 1, PostgresDataType.BIT));
+        default:
+            throw new AssertionError();
         }
     }
 
@@ -443,20 +446,19 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         IntExpression option;
         option = Randomly.fromOptions(IntExpression.values());
         switch (option) {
-            case CAST:
-                return new PostgresCastOperation(generateExpression(depth + 1),
-                        getCompoundDataType(PostgresDataType.INT));
-            case UNARY_OPERATION:
-                PostgresExpression intExpression = generateExpression(depth + 1, PostgresDataType.INT);
-                return new PostgresPrefixOperation(intExpression,
-                        Randomly.getBoolean() ? PrefixOperator.UNARY_PLUS : PrefixOperator.UNARY_MINUS);
-            case FUNCTION:
-                return generateFunction(depth + 1, PostgresDataType.INT);
-            case BINARY_ARITHMETIC_EXPRESSION:
-                return new PostgresBinaryArithmeticOperation(generateExpression(depth + 1, PostgresDataType.INT),
-                        generateExpression(depth + 1, PostgresDataType.INT), PostgresBinaryOperator.getRandom());
-            default:
-                throw new AssertionError();
+        case CAST:
+            return new PostgresCastOperation(generateExpression(depth + 1), getCompoundDataType(PostgresDataType.INT));
+        case UNARY_OPERATION:
+            PostgresExpression intExpression = generateExpression(depth + 1, PostgresDataType.INT);
+            return new PostgresPrefixOperation(intExpression,
+                    Randomly.getBoolean() ? PrefixOperator.UNARY_PLUS : PrefixOperator.UNARY_MINUS);
+        case FUNCTION:
+            return generateFunction(depth + 1, PostgresDataType.INT);
+        case BINARY_ARITHMETIC_EXPRESSION:
+            return new PostgresBinaryArithmeticOperation(generateExpression(depth + 1, PostgresDataType.INT),
+                    generateExpression(depth + 1, PostgresDataType.INT), PostgresBinaryOperator.getRandom());
+        default:
+            throw new AssertionError();
         }
     }
 
@@ -614,8 +616,6 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         return new PostgresPostfixOperation(expr, PostfixOperator.IS_NULL);
     }
 
-<<<<<<< HEAD
-=======
     @Override
     public List<PostgresExpression> generateFetchColumns(boolean shouldCreateDummy) {
         if (shouldCreateDummy && Randomly.getBooleanWithRatherLowProbability()) {
@@ -740,5 +740,4 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         }
         return args;
     }
->>>>>>> 1046ad81 (postgres exp select)
 }

--- a/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
@@ -636,11 +636,13 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         if (shouldCreateDummy && Randomly.getBooleanWithRatherLowProbability()) {
             return Arrays.asList(new PostgresColumnValue(PostgresColumn.createDummy("*"), null));
         }
+        allowAggregateFunctions = true;
         List<PostgresExpression> fetchColumns = new ArrayList<>();
         List<PostgresColumn> targetColumns = Randomly.nonEmptySubset(columns);
         for (PostgresColumn c : targetColumns) {
             fetchColumns.add(new PostgresColumnValue(c, null));
         }
+        allowAggregateFunctions = false;
         return fetchColumns;
     }
 
@@ -755,5 +757,15 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
             }
         }
         return args;
+    }
+
+    @Override
+    public List<PostgresExpression> generateGroupBys() {
+        return generateExpressions(Randomly.smallNumber() + 1);
+    }
+
+    @Override
+    public String combineQueryStrings(String... queryStrings) {
+        return String.join(" UNION ALL ", queryStrings);
     }
 }

--- a/src/sqlancer/postgres/gen/PostgresRandomQueryGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresRandomQueryGenerator.java
@@ -11,7 +11,6 @@ import sqlancer.postgres.PostgresSchema.PostgresTables;
 import sqlancer.postgres.ast.PostgresConstant;
 import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresSelect;
-import sqlancer.postgres.ast.PostgresSelect.ForClause;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.ast.PostgresSelect.SelectType;
 
@@ -53,9 +52,6 @@ public final class PostgresRandomQueryGenerator {
                 select.setOffsetClause(
                         PostgresConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
             }
-        }
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            select.setForClause(ForClause.getRandom());
         }
         return select;
     }

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPAggregateOracle.java
@@ -1,33 +1,28 @@
 package sqlancer.postgres.oracle.tlp;
 
-import java.io.IOException;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import org.postgresql.util.PSQLException;
+import java.util.regex.Pattern;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
+import sqlancer.common.oracle.TLPAggregateOracle;
 import sqlancer.common.oracle.TestOracle;
-import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.postgres.PostgresGlobalState;
+import sqlancer.postgres.PostgresSchema;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
+import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.PostgresVisitor;
 import sqlancer.postgres.ast.PostgresAggregate;
-import sqlancer.postgres.ast.PostgresAggregate.PostgresAggregateFunction;
-import sqlancer.postgres.ast.PostgresAlias;
 import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresJoin;
-import sqlancer.postgres.ast.PostgresPostfixOperation;
-import sqlancer.postgres.ast.PostgresPostfixOperation.PostfixOperator;
-import sqlancer.postgres.ast.PostgresPrefixOperation;
-import sqlancer.postgres.ast.PostgresPrefixOperation.PrefixOperator;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.gen.PostgresCommon;
+import sqlancer.postgres.gen.PostgresExpressionGenerator;
 
 public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestOracle<PostgresGlobalState> {
 
@@ -36,37 +31,43 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
     private String originalQuery;
     private String metamorphicQuery;
 
+    private final TLPAggregateOracle<PostgresAggregate, PostgresExpression, PostgresSchema, PostgresTable, PostgresColumn, PostgresGlobalState> oracle;
+
     public PostgresTLPAggregateOracle(PostgresGlobalState state) {
         super(state);
         PostgresCommon.addGroupingErrors(errors);
+
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(PostgresCommon.getCommonExpressionErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonFetchErrors().toArray(new String[0]))
+                .with(PostgresCommon.getGroupingErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonExpressionRegexErrors().toArray(new Pattern[0])).build();
+
+        PostgresExpressionGenerator gen = new PostgresExpressionGenerator(state);
+        this.oracle = new TLPAggregateOracle<>(state, gen, expectedErrors, false);
     }
 
     @Override
     public void check() throws SQLException {
-        super.check();
-        aggregateCheck();
+        oracle.check();
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return oracle.getLastQueryString();
     }
 
     protected void aggregateCheck() throws SQLException {
-        PostgresAggregateFunction aggregateFunction = Randomly.fromOptions(PostgresAggregateFunction.MAX,
-                PostgresAggregateFunction.MIN, PostgresAggregateFunction.SUM, PostgresAggregateFunction.BIT_AND,
-                PostgresAggregateFunction.BIT_OR, PostgresAggregateFunction.BOOL_AND, PostgresAggregateFunction.BOOL_OR,
-                PostgresAggregateFunction.COUNT);
-        PostgresAggregate aggregate = gen.generateArgsForAggregate(aggregateFunction.getRandomReturnType(),
-                aggregateFunction);
-        List<PostgresExpression> fetchColumns = new ArrayList<>();
-        fetchColumns.add(aggregate);
-        while (Randomly.getBooleanWithRatherLowProbability()) {
-            fetchColumns.add(gen.generateAggregate());
-        }
+        PostgresAggregate aggregate = gen.generateAggregate();
         select.setFetchColumns(Arrays.asList(aggregate));
         if (Randomly.getBooleanWithRatherLowProbability()) {
             select.setOrderByClauses(gen.generateOrderBy());
         }
         originalQuery = PostgresVisitor.asString(select);
-        firstResult = getAggregateResult(originalQuery);
+        firstResult = ComparatorHelper.runQuery(originalQuery, errors, state);
+
         metamorphicQuery = createMetamorphicUnionQuery(select, aggregate, select.getFromList());
-        secondResult = getAggregateResult(metamorphicQuery);
+        secondResult = ComparatorHelper.runQuery(metamorphicQuery, errors, state);
 
         String queryFormatString = "-- %s;\n-- result: %s";
         String firstQueryString = String.format(queryFormatString, originalQuery, firstResult);
@@ -86,103 +87,19 @@ public class PostgresTLPAggregateOracle extends PostgresTLPBase implements TestO
 
     private String createMetamorphicUnionQuery(PostgresSelect select, PostgresAggregate aggregate,
             List<PostgresExpression> from) {
-        String metamorphicQuery;
         PostgresExpression whereClause = gen.generateExpression(PostgresDataType.BOOLEAN);
-        PostgresExpression negatedClause = new PostgresPrefixOperation(whereClause, PrefixOperator.NOT);
-        PostgresExpression notNullClause = new PostgresPostfixOperation(whereClause, PostfixOperator.IS_NULL);
-        List<PostgresExpression> mappedAggregate = mapped(aggregate);
-        PostgresSelect leftSelect = getSelect(mappedAggregate, from, whereClause, select.getJoinClauses());
-        PostgresSelect middleSelect = getSelect(mappedAggregate, from, negatedClause, select.getJoinClauses());
-        PostgresSelect rightSelect = getSelect(mappedAggregate, from, notNullClause, select.getJoinClauses());
-        metamorphicQuery = "SELECT " + getOuterAggregateFunction(aggregate) + " FROM (";
-        metamorphicQuery += PostgresVisitor.asString(leftSelect) + " UNION ALL "
-                + PostgresVisitor.asString(middleSelect) + " UNION ALL " + PostgresVisitor.asString(rightSelect);
-        metamorphicQuery += ") as asdf";
-        return metamorphicQuery;
+        PostgresExpression negatedClause = gen.negatePredicate(whereClause);
+        PostgresExpression notNullClause = gen.isNull(whereClause);
+        PostgresSelect leftSelect = getSelect(aggregate, from, whereClause, select.getJoinClauses());
+        PostgresSelect middleSelect = getSelect(aggregate, from, negatedClause, select.getJoinClauses());
+        PostgresSelect rightSelect = getSelect(aggregate, from, notNullClause, select.getJoinClauses());
+        return aggregate.asAggregatedString(leftSelect.asString(), middleSelect.asString(), rightSelect.asString());
     }
 
-    private String getAggregateResult(String queryString) throws SQLException {
-        // log TLP Aggregate SELECT queries on the current log file
-        if (state.getOptions().logEachSelect()) {
-            // TODO: refactor me
-            state.getLogger().writeCurrent(queryString);
-            try {
-                state.getLogger().getCurrentFileWriter().flush();
-            } catch (IOException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
-        }
-        String resultString;
-        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
-        try (SQLancerResultSet result = q.executeAndGet(state)) {
-            if (result == null) {
-                throw new IgnoreMeException();
-            }
-            if (!result.next()) {
-                resultString = null;
-            } else {
-                resultString = result.getString(1);
-            }
-        } catch (PSQLException e) {
-            throw new AssertionError(queryString, e);
-        }
-        return resultString;
-    }
-
-    private List<PostgresExpression> mapped(PostgresAggregate aggregate) {
-        switch (aggregate.getFunction()) {
-        case SUM:
-        case COUNT:
-        case BIT_AND:
-        case BIT_OR:
-        case BOOL_AND:
-        case BOOL_OR:
-        case MAX:
-        case MIN:
-            return aliasArgs(Arrays.asList(aggregate));
-        // case AVG:
-        //// List<PostgresExpression> arg = Arrays.asList(new
-        // PostgresCast(aggregate.getExpr().get(0),
-        // PostgresDataType.DECIMAL.get()));
-        // PostgresAggregate sum = new PostgresAggregate(PostgresAggregateFunction.SUM,
-        // aggregate.getExpr());
-        // PostgresCast count = new PostgresCast(
-        // new PostgresAggregate(PostgresAggregateFunction.COUNT, aggregate.getExpr()),
-        // PostgresDataType.DECIMAL.get());
-        //// PostgresBinaryArithmeticOperation avg = new
-        // PostgresBinaryArithmeticOperation(sum, count,
-        // PostgresBinaryArithmeticOperator.DIV);
-        // return aliasArgs(Arrays.asList(sum, count));
-        default:
-            throw new AssertionError(aggregate.getFunction());
-        }
-    }
-
-    private List<PostgresExpression> aliasArgs(List<PostgresExpression> originalAggregateArgs) {
-        List<PostgresExpression> args = new ArrayList<>();
-        int i = 0;
-        for (PostgresExpression expr : originalAggregateArgs) {
-            args.add(new PostgresAlias(expr, "agg" + i++));
-        }
-        return args;
-    }
-
-    private String getOuterAggregateFunction(PostgresAggregate aggregate) {
-        switch (aggregate.getFunction()) {
-        // case AVG:
-        // return "SUM(agg0::DECIMAL)/SUM(agg1)::DECIMAL";
-        case COUNT:
-            return PostgresAggregateFunction.SUM.toString() + "(agg0)";
-        default:
-            return aggregate.getFunction().toString() + "(agg0)";
-        }
-    }
-
-    private PostgresSelect getSelect(List<PostgresExpression> aggregates, List<PostgresExpression> from,
+    private PostgresSelect getSelect(PostgresAggregate aggregate, List<PostgresExpression> from,
             PostgresExpression whereClause, List<PostgresJoin> joinList) {
         PostgresSelect leftSelect = new PostgresSelect();
-        leftSelect.setFetchColumns(aggregates);
+        leftSelect.setFetchColumns(gen.aliasAggregates(List.of(aggregate)));
         leftSelect.setFromList(from);
         leftSelect.setWhereClause(whereClause);
         leftSelect.setJoinClauses(joinList);

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPBase.java
@@ -21,7 +21,6 @@ import sqlancer.postgres.ast.PostgresConstant;
 import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresJoin;
 import sqlancer.postgres.ast.PostgresSelect;
-import sqlancer.postgres.ast.PostgresSelect.ForClause;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
 import sqlancer.postgres.gen.PostgresCommon;
@@ -67,9 +66,6 @@ public class PostgresTLPBase extends TernaryLogicPartitioningOracleBase<Postgres
         select.setFromList(tableList);
         select.setWhereClause(null);
         select.setJoinClauses(joins);
-        if (Randomly.getBoolean()) {
-            select.setForClause(ForClause.getRandom());
-        }
     }
 
     List<PostgresExpression> generateFetchColumns() {
@@ -111,9 +107,6 @@ public class PostgresTLPBase extends TernaryLogicPartitioningOracleBase<Postgres
                 select.setOffsetClause(
                         PostgresConstant.createIntConstant(Randomly.getPositiveOrZeroNonCachedInteger()));
             }
-        }
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            select.setForClause(ForClause.getRandom());
         }
         return new PostgresSubquery(select, name);
     }

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPHavingOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPHavingOracle.java
@@ -3,31 +3,48 @@ package sqlancer.postgres.oracle.tlp;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.Randomly;
+import sqlancer.common.oracle.TLPHavingOracle;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.postgres.PostgresGlobalState;
-import sqlancer.postgres.PostgresSchema.PostgresDataType;
+import sqlancer.postgres.PostgresSchema;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
+import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.PostgresVisitor;
 import sqlancer.postgres.ast.PostgresExpression;
+import sqlancer.postgres.ast.PostgresJoin;
 import sqlancer.postgres.gen.PostgresCommon;
+import sqlancer.postgres.gen.PostgresExpressionGenerator;
 
 public class PostgresTLPHavingOracle extends PostgresTLPBase {
+
+    private final TLPHavingOracle<PostgresJoin, PostgresExpression, PostgresSchema, PostgresTable, PostgresColumn, PostgresGlobalState> oracle;
 
     public PostgresTLPHavingOracle(PostgresGlobalState state) {
         super(state);
         PostgresCommon.addGroupingErrors(errors);
+
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(PostgresCommon.getCommonExpressionErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonFetchErrors().toArray(new String[0]))
+                .with(PostgresCommon.getGroupingErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonExpressionRegexErrors().toArray(new Pattern[0])).build();
+
+        PostgresExpressionGenerator gen = new PostgresExpressionGenerator(state);
+        this.oracle = new TLPHavingOracle<>(state, gen, expectedErrors, true, false);
     }
 
     @Override
     public void check() throws SQLException {
-        super.check();
-        havingCheck();
+        oracle.check();
     }
 
     protected void havingCheck() throws SQLException {
         if (Randomly.getBoolean()) {
-            select.setWhereClause(gen.generateExpression(PostgresDataType.BOOLEAN));
+            select.setWhereClause(gen.generateBooleanExpression());
         }
         select.setGroupByExpressions(gen.generateExpressions(Randomly.smallNumber() + 1));
         select.setHavingClause(null);
@@ -64,4 +81,8 @@ public class PostgresTLPHavingOracle extends PostgresTLPBase {
         return expressions;
     }
 
+    @Override
+    public String getLastQueryString() {
+        return oracle.getLastQueryString();
+    }
 }

--- a/src/sqlancer/postgres/oracle/tlp/PostgresTLPWhereOracle.java
+++ b/src/sqlancer/postgres/oracle/tlp/PostgresTLPWhereOracle.java
@@ -4,24 +4,44 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import sqlancer.ComparatorHelper;
 import sqlancer.Randomly;
+import sqlancer.common.oracle.TLPWhereOracle;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.postgres.PostgresGlobalState;
+import sqlancer.postgres.PostgresSchema;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
+import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.PostgresVisitor;
+import sqlancer.postgres.ast.PostgresExpression;
+import sqlancer.postgres.ast.PostgresJoin;
+import sqlancer.postgres.gen.PostgresCommon;
+import sqlancer.postgres.gen.PostgresExpressionGenerator;
 
-public class PostgresTLPWhereOracle extends PostgresTLPBase {
+public class PostgresTLPWhereOracle extends PostgresTLPBase implements TestOracle<PostgresGlobalState> {
+
+    private final TLPWhereOracle<PostgresJoin, PostgresExpression, PostgresSchema, PostgresTable, PostgresColumn, PostgresGlobalState> oracle;
 
     public PostgresTLPWhereOracle(PostgresGlobalState state) {
-        super(state);
+        super(state); // TODO remove after updating citus
+        PostgresExpressionGenerator gen = new PostgresExpressionGenerator(state);
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(PostgresCommon.getCommonExpressionErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonFetchErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonExpressionRegexErrors().toArray(new Pattern[0])).build();
+
+        this.oracle = new TLPWhereOracle<>(state, gen, expectedErrors);
     }
 
     @Override
     public void check() throws SQLException {
-        super.check();
-        whereCheck();
+        oracle.check();
     }
 
+    // TODO remove after updating citus
     protected void whereCheck() throws SQLException {
         if (Randomly.getBooleanWithRatherLowProbability()) {
             select.setOrderByClauses(gen.generateOrderBy());
@@ -42,4 +62,10 @@ public class PostgresTLPWhereOracle extends PostgresTLPBase {
         ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
                 state);
     }
+
+    @Override
+    public String getLastQueryString() {
+        return oracle.getLastQueryString();
+    }
+
 }

--- a/src/sqlancer/sqlite3/ast/SQLite3Aggregate.java
+++ b/src/sqlancer/sqlite3/ast/SQLite3Aggregate.java
@@ -6,14 +6,17 @@ import java.util.List;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Aggregate;
 import sqlancer.sqlite3.SQLite3Provider;
+import sqlancer.sqlite3.SQLite3Visitor;
 import sqlancer.sqlite3.schema.SQLite3DataType;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column.SQLite3CollateSequence;
 
 /**
  * @see <a href="https://www.sqlite.org/lang_aggfunc.html">Built-in Aggregate Functions</a>
  */
-public class SQLite3Aggregate extends SQLite3Expression {
+public class SQLite3Aggregate extends SQLite3Expression implements Aggregate<SQLite3Expression, SQLite3Column> {
 
     private final SQLite3AggregateFunction func;
     private final List<SQLite3Expression> expr;
@@ -127,6 +130,22 @@ public class SQLite3Aggregate extends SQLite3Expression {
         assert !SQLite3Provider.mustKnowResult;
         return null;
         // return func.apply(expr.getExpectedValue());
+    }
+
+    @Override
+    public SQLite3Expression asExpression() {
+        return this;
+    }
+
+    @Override
+    public String asString() {
+        return SQLite3Visitor.asString(this);
+    }
+
+    @Override
+    public String asAggregatedString(String... from) {
+        String combinedFrom = String.join(" UNION ALL ", from);
+        return "SELECT " + asString() + "(aggr) FROM (" + combinedFrom + ")";
     }
 
 }

--- a/src/sqlancer/sqlite3/ast/SQLite3Expression.java
+++ b/src/sqlancer/sqlite3/ast/SQLite3Expression.java
@@ -161,7 +161,6 @@ public abstract class SQLite3Expression implements Expression<SQLite3Column> {
             this.type = type;
         }
 
-        @Override
         public SQLite3Table getTable() {
             return table;
         }

--- a/src/sqlancer/sqlite3/ast/SQLite3Expression.java
+++ b/src/sqlancer/sqlite3/ast/SQLite3Expression.java
@@ -161,10 +161,12 @@ public abstract class SQLite3Expression implements Expression<SQLite3Column> {
             this.type = type;
         }
 
+        @Override
         public SQLite3Table getTable() {
             return table;
         }
 
+        @Override
         public SQLite3Expression getOnClause() {
             return onClause;
         }
@@ -178,6 +180,7 @@ public abstract class SQLite3Expression implements Expression<SQLite3Column> {
             return null;
         }
 
+        @Override
         public void setOnClause(SQLite3Expression onClause) {
             this.onClause = onClause;
         }

--- a/src/sqlancer/sqlite3/ast/SQLite3Expression.java
+++ b/src/sqlancer/sqlite3/ast/SQLite3Expression.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import sqlancer.IgnoreMeException;
 import sqlancer.LikeImplementationHelper;
 import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.visitor.BinaryOperation;
 import sqlancer.common.visitor.UnaryOperation;
 import sqlancer.sqlite3.SQLite3CollateHelper;
@@ -18,7 +19,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column.SQLite3CollateSequence;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
-public abstract class SQLite3Expression {
+public abstract class SQLite3Expression implements Expression<SQLite3Column> {
 
     public static class SQLite3TableReference extends SQLite3Expression {
 
@@ -128,7 +129,8 @@ public abstract class SQLite3Expression {
 
     }
 
-    public static class Join extends SQLite3Expression {
+    public static class Join extends SQLite3Expression
+            implements sqlancer.common.ast.newast.Join<SQLite3Expression, SQLite3Table, SQLite3Column> {
 
         public enum JoinType {
             INNER, CROSS, OUTER, NATURAL, RIGHT, FULL;
@@ -183,7 +185,6 @@ public abstract class SQLite3Expression {
         public void setType(JoinType type) {
             this.type = type;
         }
-
     }
 
     public static class Subquery extends SQLite3Expression {

--- a/src/sqlancer/sqlite3/ast/SQLite3Select.java
+++ b/src/sqlancer/sqlite3/ast/SQLite3Select.java
@@ -8,8 +8,8 @@ import sqlancer.common.ast.newast.Select;
 import sqlancer.sqlite3.SQLite3Visitor;
 import sqlancer.sqlite3.ast.SQLite3Expression.Join;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
-import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column.SQLite3CollateSequence;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
 public class SQLite3Select extends SQLite3Expression
         implements Select<Join, SQLite3Expression, SQLite3Table, SQLite3Column> {
@@ -60,66 +60,82 @@ public class SQLite3Select extends SQLite3Expression
         this.fromOptions = fromOptions;
     }
 
+    @Override
     public List<SQLite3Expression> getFromList() {
         return fromList;
     }
 
+    @Override
     public void setFromList(List<SQLite3Expression> fromList) {
         this.fromList = fromList;
     }
 
+    @Override
     public SQLite3Expression getWhereClause() {
         return whereClause;
     }
 
+    @Override
     public void setWhereClause(SQLite3Expression whereClause) {
         this.whereClause = whereClause;
     }
 
+    @Override
     public void setGroupByClause(List<SQLite3Expression> groupByClause) {
         this.groupByClause = groupByClause;
     }
 
+    @Override
     public List<SQLite3Expression> getGroupByClause() {
         return groupByClause;
     }
 
+    @Override
     public void setLimitClause(SQLite3Expression limitClause) {
         this.limitClause = limitClause;
     }
 
+    @Override
     public SQLite3Expression getLimitClause() {
         return limitClause;
     }
 
+    @Override
     public List<SQLite3Expression> getOrderByClauses() {
         return orderByClause;
     }
 
+    @Override
     public void setOrderByClauses(List<SQLite3Expression> orderBy) {
         this.orderByClause = orderBy;
     }
 
+    @Override
     public void setOffsetClause(SQLite3Expression offsetClause) {
         this.offsetClause = offsetClause;
     }
 
+    @Override
     public SQLite3Expression getOffsetClause() {
         return offsetClause;
     }
 
+    @Override
     public void setFetchColumns(List<SQLite3Expression> fetchColumns) {
         this.fetchColumns = fetchColumns;
     }
 
+    @Override
     public List<SQLite3Expression> getFetchColumns() {
         return fetchColumns;
     }
 
+    @Override
     public void setJoinClauses(List<Join> joinStatements) {
         this.joinStatements = joinStatements;
     }
 
+    @Override
     public List<Join> getJoinClauses() {
         return joinStatements;
     }
@@ -130,17 +146,19 @@ public class SQLite3Select extends SQLite3Expression
         return null;
     }
 
+    @Override
     public void setHavingClause(SQLite3Expression havingClause) {
         this.havingClause = havingClause;
     }
 
+    @Override
     public SQLite3Expression getHavingClause() {
         assert orderByClause != null;
         return havingClause;
     }
 
+    @Override
     public String asString() {
         return SQLite3Visitor.asString(this);
     }
-
 }

--- a/src/sqlancer/sqlite3/ast/SQLite3Select.java
+++ b/src/sqlancer/sqlite3/ast/SQLite3Select.java
@@ -158,6 +158,11 @@ public class SQLite3Select extends SQLite3Expression
     }
 
     @Override
+    public void setDistinct() {
+        setSelectType(SelectType.DISTINCT);
+    }
+
+    @Override
     public String asString() {
         return SQLite3Visitor.asString(this);
     }

--- a/src/sqlancer/sqlite3/ast/SQLite3Select.java
+++ b/src/sqlancer/sqlite3/ast/SQLite3Select.java
@@ -4,9 +4,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import sqlancer.common.ast.newast.Select;
+import sqlancer.sqlite3.SQLite3Visitor;
+import sqlancer.sqlite3.ast.SQLite3Expression.Join;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column.SQLite3CollateSequence;
 
-public class SQLite3Select extends SQLite3Expression {
+public class SQLite3Select extends SQLite3Expression
+        implements Select<Join, SQLite3Expression, SQLite3Table, SQLite3Column> {
 
     private SelectType fromOptions = SelectType.ALL;
     private List<SQLite3Expression> fromList = Collections.emptyList();
@@ -131,6 +137,10 @@ public class SQLite3Select extends SQLite3Expression {
     public SQLite3Expression getHavingClause() {
         assert orderByClause != null;
         return havingClause;
+    }
+
+    public String asString() {
+        return SQLite3Visitor.asString(this);
     }
 
 }

--- a/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.gen.ExpressionGenerator;
 import sqlancer.common.gen.TLPAggregateGenerator;
@@ -783,5 +784,19 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
     @Override
     public List<SQLite3Expression> generateExpressions(int size) {
         return getRandomExpressions(size);
+    }
+
+    @Override
+    public List<SQLite3Expression> generateGroupBys() {
+        return generateExpressions(Randomly.smallNumber() + 1);
+    }
+
+    @Override
+    public String combineQueryStrings(String... queryStrings) {
+        String combinedString = String.join(" UNION ALL ", queryStrings);
+        if (combinedString.contains("EXIST")) {
+            throw new IgnoreMeException();
+        }
+        return combinedString;
     }
 }

--- a/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import sqlancer.Randomly;
 import sqlancer.common.gen.ExpressionGenerator;
 import sqlancer.common.gen.TLPGenerator;
+import sqlancer.common.gen.TLPHavingGenerator;
 import sqlancer.common.schema.AbstractTables;
 import sqlancer.sqlite3.SQLite3GlobalState;
 import sqlancer.sqlite3.ast.SQLite3Aggregate;
@@ -50,7 +51,8 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3RowValue;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
 public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Expression>,
-        TLPGenerator<Join, SQLite3Expression, SQLite3Table, SQLite3Column> {
+        TLPGenerator<Join, SQLite3Expression, SQLite3Table, SQLite3Column>,
+        TLPHavingGenerator<Join, SQLite3Expression, SQLite3Table, SQLite3Column> {
 
     private SQLite3RowValue rw;
     private final SQLite3GlobalState globalState;
@@ -687,6 +689,7 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
         return new SQLite3UnaryOperation(unaryOperation, subExpression);
     }
 
+    @Override
     public SQLite3Expression getHavingClause() {
         allowAggreates = true;
         return generateExpression();

--- a/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
@@ -231,12 +231,10 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
         MATCH, AGGREGATE_FUNCTION, ROW_VALUE_COMPARISON, AND_OR_CHAIN
     }
 
-    @Override
     public SQLite3Expression generateExpression() {
         return getRandomExpression(0);
     }
 
-    @Override
     public List<SQLite3Expression> getRandomExpressions(int size) {
         List<SQLite3Expression> expressions = new ArrayList<>();
         for (int i = 0; i < size; i++) {
@@ -777,4 +775,13 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public SQLite3Expression generateBooleanExpression() {
+        return generateExpression();
+    }
+
+    @Override
+    public List<SQLite3Expression> generateExpressions(int size) {
+        return getRandomExpressions(size);
+    }
 }

--- a/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
@@ -739,9 +739,9 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
     }
 
     @Override
-    public List<SQLite3Expression> generateFetchColumns() {
+    public List<SQLite3Expression> generateFetchColumns(boolean shouldCreateDummy) {
         List<SQLite3Expression> columns = new ArrayList<>();
-        if (Randomly.getBoolean()) {
+        if (shouldCreateDummy && Randomly.getBoolean()) {
             columns.add(new SQLite3ColumnName(SQLite3Column.createDummy("*"), null));
         } else {
             columns = Randomly.nonEmptySubset(this.columns).stream().map(c -> new SQLite3ColumnName(c, null))

--- a/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
@@ -755,8 +755,6 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
 
     @Override
     public SQLite3Select generateSelect() {
-        SQLite3Select select = new SQLite3Select();
-        select.setSelectType(SQLite3Select.SelectType.DISTINCT);
         return new SQLite3Select();
     }
 }

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
@@ -1,39 +1,21 @@
 package sqlancer.sqlite3.oracle.tlp;
 
 import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.List;
 
-import sqlancer.ComparatorHelper;
-import sqlancer.IgnoreMeException;
-import sqlancer.Randomly;
+import sqlancer.common.oracle.TLPAggregateOracle;
 import sqlancer.common.oracle.TestOracle;
-import sqlancer.common.query.ExpectedErrors;
-import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
-import sqlancer.sqlite3.SQLite3Visitor;
 import sqlancer.sqlite3.ast.SQLite3Aggregate;
-import sqlancer.sqlite3.ast.SQLite3Aggregate.SQLite3AggregateFunction;
 import sqlancer.sqlite3.ast.SQLite3Expression;
-import sqlancer.sqlite3.ast.SQLite3Expression.SQLite3PostfixText;
-import sqlancer.sqlite3.ast.SQLite3Expression.SQLite3PostfixUnaryOperation;
-import sqlancer.sqlite3.ast.SQLite3Expression.SQLite3PostfixUnaryOperation.PostfixUnaryOperator;
-import sqlancer.sqlite3.ast.SQLite3Select;
-import sqlancer.sqlite3.ast.SQLite3UnaryOperation;
-import sqlancer.sqlite3.ast.SQLite3UnaryOperation.UnaryOperator;
-import sqlancer.sqlite3.gen.SQLite3Common;
 import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema;
-import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
 public class SQLite3TLPAggregateOracle implements TestOracle<SQLite3GlobalState> {
 
-    private final SQLite3GlobalState state;
-    private final ExpectedErrors errors = new ExpectedErrors();
-    private SQLite3ExpressionGenerator gen;
-    private String generatedQueryString;
+    TLPAggregateOracle<SQLite3Aggregate, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
 
     public SQLite3TLPAggregateOracle(SQLite3GlobalState state) {
         SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state);
@@ -44,93 +26,11 @@ public class SQLite3TLPAggregateOracle implements TestOracle<SQLite3GlobalState>
 
     @Override
     public void check() throws SQLException {
-        SQLite3Schema s = state.getSchema();
-        SQLite3Tables targetTables = s.getRandomTableNonEmptyTables();
-        gen = new SQLite3ExpressionGenerator(state).setColumns(targetTables.getColumns());
-        SQLite3Select select = new SQLite3Select();
-        SQLite3AggregateFunction windowFunction = Randomly.fromOptions(SQLite3Aggregate.SQLite3AggregateFunction.MIN,
-                SQLite3Aggregate.SQLite3AggregateFunction.MAX, SQLite3AggregateFunction.SUM,
-                SQLite3AggregateFunction.TOTAL);
-        SQLite3Aggregate aggregate = new SQLite3Aggregate(gen.getRandomExpressions(1), windowFunction);
-        select.setFetchColumns(Arrays.asList(aggregate));
-        List<SQLite3Expression> from = SQLite3Common.getTableRefs(targetTables.getTables(), s);
-        select.setFromList(from);
-        if (Randomly.getBoolean()) {
-            select.setOrderByClauses(gen.generateOrderBys());
-        }
-        String originalQuery = SQLite3Visitor.asString(select);
-        generatedQueryString = originalQuery;
-        SQLite3Expression whereClause = gen.generateExpression();
-        SQLite3UnaryOperation negatedClause = new SQLite3UnaryOperation(UnaryOperator.NOT, whereClause);
-        SQLite3PostfixUnaryOperation notNullClause = new SQLite3PostfixUnaryOperation(PostfixUnaryOperator.ISNULL,
-                whereClause);
-
-        SQLite3Select leftSelect = getSelect(aggregate, from, whereClause);
-        SQLite3Select middleSelect = getSelect(aggregate, from, negatedClause);
-        SQLite3Select rightSelect = getSelect(aggregate, from, notNullClause);
-        String aggreateMethod = aggregate.getFunc() == SQLite3AggregateFunction.COUNT_ALL
-                ? SQLite3AggregateFunction.COUNT.toString()
-                : aggregate.getFunc().toString();
-        String metamorphicText = "SELECT " + aggreateMethod + "(aggr) FROM (";
-        metamorphicText += SQLite3Visitor.asString(leftSelect) + " UNION ALL " + SQLite3Visitor.asString(middleSelect)
-                + " UNION ALL " + SQLite3Visitor.asString(rightSelect);
-        metamorphicText += ")";
-
-        // String finalText = originalQuery + " INTERSECT " + metamorphicText;
-        // state.getState().queryString = "--" + finalText;
-        String firstResult;
-        String secondResult;
-        SQLQueryAdapter q = new SQLQueryAdapter(originalQuery, errors);
-        try (SQLancerResultSet result = q.executeAndGet(state)) {
-            if (result == null) {
-                throw new IgnoreMeException();
-            }
-            firstResult = result.getString(1);
-        } catch (Exception e) {
-            // TODO
-            throw new IgnoreMeException();
-        }
-
-        SQLQueryAdapter q2 = new SQLQueryAdapter(metamorphicText, errors);
-        try (SQLancerResultSet result = q2.executeAndGet(state)) {
-            if (result == null) {
-                throw new IgnoreMeException();
-            }
-            secondResult = result.getString(1);
-        } catch (Exception e) {
-            // TODO
-            throw new IgnoreMeException();
-        }
-        state.getState().getLocalState()
-                .log("--" + originalQuery + "\n--" + metamorphicText + "\n-- " + firstResult + "\n-- " + secondResult);
-        if ((firstResult == null && secondResult != null
-                || firstResult != null && !firstResult.contentEquals(secondResult))
-                && !ComparatorHelper.isEqualDouble(firstResult, secondResult)) {
-
-            throw new AssertionError();
-
-        }
-
-    }
-
-    private SQLite3Select getSelect(SQLite3Aggregate aggregate, List<SQLite3Expression> from,
-            SQLite3Expression whereClause) {
-        SQLite3Select leftSelect = new SQLite3Select();
-        leftSelect.setFetchColumns(Arrays.asList(new SQLite3PostfixText(aggregate, " as aggr", null)));
-        leftSelect.setFromList(from);
-        leftSelect.setWhereClause(whereClause);
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            leftSelect.setGroupByClause(gen.getRandomExpressions(Randomly.smallNumber() + 1));
-        }
-        if (Randomly.getBoolean()) {
-            leftSelect.setOrderByClauses(gen.generateOrderBys());
-        }
-        return leftSelect;
+        oracle.check();
     }
 
     @Override
     public String getLastQueryString() {
-        return generatedQueryString;
+        return oracle.getLastQueryString();
     }
-
 }

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
@@ -4,6 +4,7 @@ import java.sql.SQLException;
 
 import sqlancer.common.oracle.TLPAggregateOracle;
 import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
 import sqlancer.sqlite3.ast.SQLite3Aggregate;
@@ -21,7 +22,7 @@ public class SQLite3TLPAggregateOracle implements TestOracle<SQLite3GlobalState>
         SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state);
         ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
                 .with(SQLite3Errors.getExpectedExpressionErrors().toArray(new String[0])).build();
-        this.oracle = new TLPAggregateOracle<>(state, gen, expectedErrors);
+        this.oracle = new TLPAggregateOracle<>(state, gen, expectedErrors, true);
     }
 
     @Override

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPAggregateOracle.java
@@ -36,8 +36,10 @@ public class SQLite3TLPAggregateOracle implements TestOracle<SQLite3GlobalState>
     private String generatedQueryString;
 
     public SQLite3TLPAggregateOracle(SQLite3GlobalState state) {
-        this.state = state;
-        SQLite3Errors.addExpectedExpressionErrors(errors);
+        SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state);
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(SQLite3Errors.getExpectedExpressionErrors().toArray(new String[0])).build();
+        this.oracle = new TLPAggregateOracle<>(state, gen, expectedErrors);
     }
 
     @Override
@@ -67,7 +69,8 @@ public class SQLite3TLPAggregateOracle implements TestOracle<SQLite3GlobalState>
         SQLite3Select middleSelect = getSelect(aggregate, from, negatedClause);
         SQLite3Select rightSelect = getSelect(aggregate, from, notNullClause);
         String aggreateMethod = aggregate.getFunc() == SQLite3AggregateFunction.COUNT_ALL
-                ? SQLite3AggregateFunction.COUNT.toString() : aggregate.getFunc().toString();
+                ? SQLite3AggregateFunction.COUNT.toString()
+                : aggregate.getFunc().toString();
         String metamorphicText = "SELECT " + aggreateMethod + "(aggr) FROM (";
         metamorphicText += SQLite3Visitor.asString(leftSelect) + " UNION ALL " + SQLite3Visitor.asString(middleSelect)
                 + " UNION ALL " + SQLite3Visitor.asString(rightSelect);

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPDistinctOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPDistinctOracle.java
@@ -1,47 +1,37 @@
 package sqlancer.sqlite3.oracle.tlp;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
-import sqlancer.ComparatorHelper;
+import sqlancer.common.oracle.TLPDistinctOracle;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
-import sqlancer.sqlite3.SQLite3Visitor;
-import sqlancer.sqlite3.ast.SQLite3Select.SelectType;
+import sqlancer.sqlite3.ast.SQLite3Expression;
+import sqlancer.sqlite3.ast.SQLite3Expression.Join;
+import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
+import sqlancer.sqlite3.schema.SQLite3Schema;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
-public class SQLite3TLPDistinctOracle extends SQLite3TLPBase {
+public class SQLite3TLPDistinctOracle implements TestOracle<SQLite3GlobalState> {
 
-    private String generatedQueryString;
+    TLPDistinctOracle<Join, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
 
     public SQLite3TLPDistinctOracle(SQLite3GlobalState state) {
-        super(state);
+        SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state);
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(SQLite3Errors.getExpectedExpressionErrors().toArray(new String[0])).build();
+        this.oracle = new TLPDistinctOracle<>(state, gen, expectedErrors);
     }
 
     @Override
     public void check() throws SQLException {
-        super.check();
-        select.setSelectType(SelectType.DISTINCT);
-        select.setWhereClause(null);
-        String originalQueryString = SQLite3Visitor.asString(select);
-        generatedQueryString = originalQueryString;
-        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
-
-        select.setWhereClause(predicate);
-        String firstQueryString = SQLite3Visitor.asString(select);
-        select.setWhereClause(negatedPredicate);
-        String secondQueryString = SQLite3Visitor.asString(select);
-        select.setWhereClause(isNullPredicate);
-        String thirdQueryString = SQLite3Visitor.asString(select);
-        List<String> combinedString = new ArrayList<>();
-        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
-                secondQueryString, thirdQueryString, combinedString, true, state, errors);
-        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state);
+        oracle.check();
     }
 
     @Override
     public String getLastQueryString() {
-        return generatedQueryString;
+        return oracle.getLastQueryString();
     }
-
 }

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPGroupByOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPGroupByOracle.java
@@ -1,56 +1,38 @@
 package sqlancer.sqlite3.oracle.tlp;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import sqlancer.ComparatorHelper;
-import sqlancer.Randomly;
+import sqlancer.common.oracle.TLPGroupByOracle;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
-import sqlancer.sqlite3.SQLite3Visitor;
 import sqlancer.sqlite3.ast.SQLite3Expression;
-import sqlancer.sqlite3.ast.SQLite3Expression.SQLite3ColumnName;
+import sqlancer.sqlite3.ast.SQLite3Expression.Join;
+import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
+import sqlancer.sqlite3.schema.SQLite3Schema;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
-public class SQLite3TLPGroupByOracle extends SQLite3TLPBase {
+public class SQLite3TLPGroupByOracle implements TestOracle<SQLite3GlobalState> {
 
-    private String generatedQueryString;
+    TLPGroupByOracle<Join, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
 
     public SQLite3TLPGroupByOracle(SQLite3GlobalState state) {
-        super(state);
+        SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state);
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(SQLite3Errors.getExpectedExpressionErrors().toArray(new String[0])).build();
+        oracle = new TLPGroupByOracle<>(state, gen, expectedErrors);
     }
 
     @Override
     public void check() throws SQLException {
-        super.check();
-        select.setGroupByClause(select.getFetchColumns());
-        select.setWhereClause(null);
-        String originalQueryString = SQLite3Visitor.asString(select);
-        generatedQueryString = originalQueryString;
-        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
-
-        select.setWhereClause(predicate);
-        String firstQueryString = SQLite3Visitor.asString(select);
-        select.setWhereClause(negatedPredicate);
-        String secondQueryString = SQLite3Visitor.asString(select);
-        select.setWhereClause(isNullPredicate);
-        String thirdQueryString = SQLite3Visitor.asString(select);
-        List<String> combinedString = new ArrayList<>();
-        List<String> secondResultSet = ComparatorHelper.getCombinedResultSetNoDuplicates(firstQueryString,
-                secondQueryString, thirdQueryString, combinedString, true, state, errors);
-        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state);
-    }
-
-    @Override
-    List<SQLite3Expression> generateFetchColumns() {
-        return Randomly.nonEmptySubset(targetTables.getColumns()).stream().map(c -> new SQLite3ColumnName(c, null))
-                .collect(Collectors.toList());
+        oracle.check();
     }
 
     @Override
     public String getLastQueryString() {
-        return generatedQueryString;
+        return oracle.getLastQueryString();
     }
 
 }

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
@@ -25,7 +25,7 @@ public class SQLite3TLPHavingOracle implements TestOracle<SQLite3GlobalState> {
                                                                                                                  // why?
                         "ON clause references tables to its right")
                 .build();
-        oracle = new TLPHavingOracle<>(state, gen, expectedErrors);
+        oracle = new TLPHavingOracle<>(state, gen, expectedErrors, false, true);
     }
 
     @Override

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPHavingOracle.java
@@ -1,93 +1,40 @@
 package sqlancer.sqlite3.oracle.tlp;
 
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import sqlancer.ComparatorHelper;
-import sqlancer.IgnoreMeException;
-import sqlancer.Randomly;
+import sqlancer.common.oracle.TLPHavingOracle;
 import sqlancer.common.oracle.TestOracle;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
-import sqlancer.sqlite3.SQLite3Visitor;
 import sqlancer.sqlite3.ast.SQLite3Expression;
 import sqlancer.sqlite3.ast.SQLite3Expression.Join;
-import sqlancer.sqlite3.ast.SQLite3Expression.SQLite3ColumnName;
-import sqlancer.sqlite3.ast.SQLite3Expression.SQLite3PostfixUnaryOperation;
-import sqlancer.sqlite3.ast.SQLite3Expression.SQLite3PostfixUnaryOperation.PostfixUnaryOperator;
-import sqlancer.sqlite3.ast.SQLite3Select;
-import sqlancer.sqlite3.ast.SQLite3Select.SelectType;
-import sqlancer.sqlite3.ast.SQLite3UnaryOperation;
-import sqlancer.sqlite3.ast.SQLite3UnaryOperation.UnaryOperator;
-import sqlancer.sqlite3.gen.SQLite3Common;
 import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
-import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Tables;
 
 public class SQLite3TLPHavingOracle implements TestOracle<SQLite3GlobalState> {
 
-    private final SQLite3GlobalState state;
-    private final ExpectedErrors errors = new ExpectedErrors();
-    private String generatedQueryString;
+    private final TLPHavingOracle<Join, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
 
     public SQLite3TLPHavingOracle(SQLite3GlobalState state) {
-        this.state = state;
-        SQLite3Errors.addExpectedExpressionErrors(errors);
-        errors.add("no such column"); // FIXME why?
-        errors.add("ON clause references tables to its right");
+        SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state);
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(SQLite3Errors.getExpectedExpressionErrors().toArray(new String[0])).with("no such column", // FIXME
+                                                                                                                 // why?
+                        "ON clause references tables to its right")
+                .build();
+        oracle = new TLPHavingOracle<>(state, gen, expectedErrors);
     }
 
     @Override
     public void check() throws SQLException {
-        SQLite3Schema s = state.getSchema();
-        SQLite3Tables targetTables = s.getRandomTableNonEmptyTables();
-        List<SQLite3Expression> groupByColumns = Randomly.nonEmptySubset(targetTables.getColumns()).stream()
-                .map(c -> new SQLite3ColumnName(c, null)).collect(Collectors.toList());
-        List<SQLite3Column> columns = targetTables.getColumns();
-        SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state).setColumns(columns);
-        SQLite3Select select = new SQLite3Select();
-        select.setFetchColumns(groupByColumns);
-        List<SQLite3Table> tables = targetTables.getTables();
-        List<Join> joinStatements = gen.getRandomJoinClauses(tables);
-        List<SQLite3Expression> from = SQLite3Common.getTableRefs(tables, state.getSchema());
-        select.setJoinClauses(joinStatements);
-        select.setSelectType(SelectType.ALL);
-        select.setFromList(from);
-        // TODO order by?
-        select.setGroupByClause(groupByColumns);
-        select.setHavingClause(null);
-        String originalQueryString = SQLite3Visitor.asString(select);
-        generatedQueryString = originalQueryString;
-        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
-
-        SQLite3Expression predicate = gen.getHavingClause();
-        select.setHavingClause(predicate);
-        String firstQueryString = SQLite3Visitor.asString(select);
-        select.setHavingClause(new SQLite3UnaryOperation(UnaryOperator.NOT, predicate));
-        String secondQueryString = SQLite3Visitor.asString(select);
-        select.setHavingClause(new SQLite3PostfixUnaryOperation(PostfixUnaryOperator.ISNULL, predicate));
-        String thirdQueryString = SQLite3Visitor.asString(select);
-        String combinedString = firstQueryString + " UNION ALL " + secondQueryString + " UNION ALL " + thirdQueryString;
-        if (combinedString.contains("EXIST")) {
-            throw new IgnoreMeException();
-        }
-        List<String> secondResultSet = ComparatorHelper.getResultSetFirstColumnAsString(combinedString, errors, state);
-        if (state.getOptions().logEachSelect()) {
-            state.getLogger().writeCurrent(originalQueryString);
-            state.getLogger().writeCurrent(combinedString);
-        }
-        if (new HashSet<>(resultSet).size() != new HashSet<>(secondResultSet).size()) {
-            throw new AssertionError(originalQueryString + ";\n" + combinedString + ";");
-        }
+        oracle.check();
     }
 
     @Override
     public String getLastQueryString() {
-        return generatedQueryString;
+        return oracle.getLastQueryString();
     }
 }

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPWhereOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPWhereOracle.java
@@ -2,9 +2,10 @@ package sqlancer.sqlite3.oracle.tlp;
 
 import java.sql.SQLException;
 
-import sqlancer.common.gen.TLPGenerator;
 import sqlancer.common.oracle.TLPWhereOracle;
 import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
 import sqlancer.sqlite3.ast.SQLite3Expression;
 import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
@@ -17,9 +18,10 @@ public class SQLite3TLPWhereOracle implements TestOracle<SQLite3GlobalState> {
     private final TLPWhereOracle<SQLite3Expression.Join, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
 
     public SQLite3TLPWhereOracle(SQLite3GlobalState state) {
-        TLPGenerator<SQLite3Expression.Join, SQLite3Expression, SQLite3Table, SQLite3Column> gen = new SQLite3ExpressionGenerator(
-                state);
-        this.oracle = new TLPWhereOracle<>(state, gen);
+        SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(state);
+        ExpectedErrors expectedErrors = ExpectedErrors.newErrors()
+                .with(SQLite3Errors.getExpectedExpressionErrors().toArray(new String[0])).build();
+        this.oracle = new TLPWhereOracle<>(state, gen, expectedErrors);
     }
 
     @Override

--- a/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPWhereOracle.java
+++ b/src/sqlancer/sqlite3/oracle/tlp/SQLite3TLPWhereOracle.java
@@ -1,50 +1,35 @@
 package sqlancer.sqlite3.oracle.tlp;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 
-import sqlancer.ComparatorHelper;
-import sqlancer.Randomly;
+import sqlancer.common.gen.TLPGenerator;
+import sqlancer.common.oracle.TLPWhereOracle;
+import sqlancer.common.oracle.TestOracle;
 import sqlancer.sqlite3.SQLite3GlobalState;
-import sqlancer.sqlite3.SQLite3Visitor;
+import sqlancer.sqlite3.ast.SQLite3Expression;
+import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
+import sqlancer.sqlite3.schema.SQLite3Schema;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
+import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
-public class SQLite3TLPWhereOracle extends SQLite3TLPBase {
+public class SQLite3TLPWhereOracle implements TestOracle<SQLite3GlobalState> {
 
-    private String generatedQueryString;
+    private final TLPWhereOracle<SQLite3Expression.Join, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
 
     public SQLite3TLPWhereOracle(SQLite3GlobalState state) {
-        super(state);
+        TLPGenerator<SQLite3Expression.Join, SQLite3Expression, SQLite3Table, SQLite3Column> gen = new SQLite3ExpressionGenerator(
+                state);
+        this.oracle = new TLPWhereOracle<>(state, gen);
     }
 
     @Override
     public void check() throws SQLException {
-        super.check();
-        select.setWhereClause(null);
-        String originalQueryString = SQLite3Visitor.asString(select);
-        generatedQueryString = originalQueryString;
-        List<String> resultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
-
-        boolean orderBy = Randomly.getBooleanWithSmallProbability();
-        if (orderBy) {
-            select.setOrderByClauses(gen.generateOrderBys());
-        }
-        select.setWhereClause(predicate);
-        String firstQueryString = SQLite3Visitor.asString(select);
-        select.setWhereClause(negatedPredicate);
-        String secondQueryString = SQLite3Visitor.asString(select);
-        select.setWhereClause(isNullPredicate);
-        String thirdQueryString = SQLite3Visitor.asString(select);
-        List<String> combinedString = new ArrayList<>();
-        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
-                thirdQueryString, combinedString, !orderBy, state, errors);
-        ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet, originalQueryString, combinedString,
-                state);
+        oracle.check();
     }
 
     @Override
     public String getLastQueryString() {
-        return generatedQueryString;
+        return oracle.getLastQueryString();
     }
 
 }


### PR DESCRIPTION
This PR introduces a new common implementation for test oracles that can be used by all DBMS. 
This is done by decoupling test oracles and expression generators. 

This is part of the ongoing effort to reduce code duplication in SQLancer.