### PR TITLE
Update SQLite3 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,14 @@ on:
       - main
     paths:
       - 'src/**'
+      - 'test/**'
       - '.github/workflows/*.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'src/**'
+      - 'test/**'
       - '.github/workflows/*.yml'
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -383,7 +383,8 @@ jobs:
       - name: SQLite Tests
         run: |
           mvn -Dtest=TestSQLitePQS test
-          mvn -Dtest=TestSQLite3 test
+          mvn -Dtest=TestSQLiteTLP test
+          mvn -Dtest=TestSQLiteNoREC test
 
   sqlite-qpg:
     name: QPG Tests (SQLite)

--- a/test/sqlancer/dbms/TestSQLiteNoREC.java
+++ b/test/sqlancer/dbms/TestSQLiteNoREC.java
@@ -6,13 +6,12 @@ import org.junit.jupiter.api.Test;
 
 import sqlancer.Main;
 
-public class TestSQLite3 {
+public class TestSQLiteNoREC {
 
     @Test
-    public void testSqlite() {
-        // run with one thread due to multithreading issues, see https://github.com/sqlancer/sqlancer/pull/45
+    public void testSqliteNoREC() {
         assertEquals(0, Main.executeMain(new String[] { "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
-                "--num-threads", "1", "--num-queries", "0", "sqlite3" }));
+                "--num-threads", "1", "--num-queries", TestConfig.NUM_QUERIES, "sqlite3", "--oracle", "NoREC" }));
     }
 
 }

--- a/test/sqlancer/dbms/TestSQLiteTLP.java
+++ b/test/sqlancer/dbms/TestSQLiteTLP.java
@@ -1,0 +1,19 @@
+package sqlancer.dbms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import sqlancer.Main;
+
+public class TestSQLiteTLP {
+
+    @Test
+    public void testSqliteTLP() {
+        // run with one thread due to multithreading issues, see https://github.com/sqlancer/sqlancer/pull/45
+        assertEquals(0,
+                Main.executeMain(new String[] {"--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
+                        "--num-threads", "1", "--num-queries", TestConfig.NUM_QUERIES, "sqlite3", "--oracle",
+                        "QUERY_PARTITIONING"}));
+    }
+}


### PR DESCRIPTION
Originally, the test did not include query partitioning oracles as the default was NoREC.

Also, `--num-queries` was previously set to 0, and is now changed to what is specified in `TestConfig`