### PR TITLE
[WIP] Generic NoREC oracle

### DIFF
--- a/src/sqlancer/common/ast/newast/Select.java
+++ b/src/sqlancer/common/ast/newast/Select.java
@@ -44,7 +44,5 @@ public interface Select<J extends Join<E, T, C>, E extends Expression<C>, T exte
 
     Expression<C> getHavingClause();
 
-    Expression<C> toSum();
-
     String asString();
 }

--- a/src/sqlancer/common/ast/newast/Select.java
+++ b/src/sqlancer/common/ast/newast/Select.java
@@ -44,5 +44,7 @@ public interface Select<J extends Join<E, T, C>, E extends Expression<C>, T exte
 
     Expression<C> getHavingClause();
 
+    Expression<C> toSum();
+
     String asString();
 }

--- a/src/sqlancer/common/gen/NoRECGenerator.java
+++ b/src/sqlancer/common/gen/NoRECGenerator.java
@@ -1,0 +1,27 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public interface NoRECGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
+
+    NoRECGenerator<J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
+
+    E generateBooleanExpression();
+
+    Select<J, E, T, C> generateSelect();
+
+    List<J> getRandomJoinClauses();
+
+    List<E> getTableRefs();
+
+    E generateOptimizedFetchColumn(boolean shouldUseAggregate);
+
+    E generateUnoptimizedFetchColumn(E whereCondition);
+}

--- a/src/sqlancer/common/gen/NoRECGenerator.java
+++ b/src/sqlancer/common/gen/NoRECGenerator.java
@@ -21,7 +21,29 @@ public interface NoRECGenerator<J extends Join<E, T, C>, E extends Expression<C>
 
     List<E> getTableRefs();
 
-    E generateOptimizedFetchColumn(boolean shouldUseAggregate);
+    /**
+     * Generates a query string that is likely to be optimized by the DBMS.
+     *
+     * @param select
+     *            the base select expression used to generate the query
+     * @param whereCondition
+     *            a condition where records will be checked with
+     * @param shouldUseAggregate
+     *            whether to aggregate the record counts (`true`) or display records as is (`false`)
+     *
+     * @return a query string to be executed
+     */
+    String generateOptimizedQueryString(Select<J, E, T, C> select, E whereCondition, boolean shouldUseAggregate);
 
-    E generateUnoptimizedFetchColumn(E whereCondition);
+    /**
+     * Generates a query string that is unlikely to be optimized by the DBMS.
+     *
+     * @param select
+     *            the base select expression used to generate the query
+     * @param whereCondition
+     *            the condition each record will be checked with
+     *
+     * @return a query string to be executed
+     */
+    String generateUnoptimizedQueryString(Select<J, E, T, C> select, E whereCondition);
 }

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -29,6 +29,9 @@ public class NoRECOracle<J extends Join<E, T, C>, E extends Expression<C>, S ext
     private String lastQueryString;
 
     public NoRECOracle(G state, NoRECGenerator<J, E, T, C> gen, ExpectedErrors expectedErrors) {
+        if (state == null || gen == null || expectedErrors == null) {
+            throw new IllegalArgumentException("Null variables used to initialize test oracle.");
+        }
         this.state = state;
         this.gen = gen;
         this.errors = expectedErrors;

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -1,7 +1,6 @@
 package sqlancer.common.oracle;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
@@ -50,14 +49,11 @@ public class NoRECOracle<J extends Join<E, T, C>, E extends Expression<C>, S ext
         E randomWhereCondition = gen.generateBooleanExpression();
 
         boolean shouldUseAggregate = Randomly.getBoolean();
-        select.setFetchColumns(Arrays.asList(gen.generateOptimizedFetchColumn(shouldUseAggregate)));
-        select.setWhereClause(randomWhereCondition);
-        String optimizedQueryString = select.asString();
+        String optimizedQueryString = gen.generateOptimizedQueryString(select, randomWhereCondition,
+                shouldUseAggregate);
         lastQueryString = optimizedQueryString;
 
-        select.setFetchColumns(Arrays.asList(gen.generateUnoptimizedFetchColumn(randomWhereCondition)));
-        select.setWhereClause(null);
-        String unoptimizedQueryString = select.toSum().toString();
+        String unoptimizedQueryString = gen.generateUnoptimizedQueryString(select, randomWhereCondition);
 
         int optimizedCount = shouldUseAggregate ? extractCounts(optimizedQueryString, errors, state)
                 : countRows(optimizedQueryString, errors, state);

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -1,0 +1,142 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLGlobalState;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.ast.newast.Join;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.common.gen.NoRECGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public class NoRECOracle<J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+        implements TestOracle<G> {
+
+    private final G state;
+
+    private NoRECGenerator<J, E, T, C> gen;
+    private final ExpectedErrors errors;
+
+    private String lastQueryString;
+
+    public NoRECOracle(G state, NoRECGenerator<J, E, T, C> gen, ExpectedErrors expectedErrors) {
+        this.state = state;
+        this.gen = gen;
+        this.errors = expectedErrors;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        S schema = state.getSchema();
+        AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(schema);
+        gen = gen.setTablesAndColumns(targetTables);
+
+        Select<J, E, T, C> select = gen.generateSelect();
+        select.setJoinClauses(gen.getRandomJoinClauses());
+        select.setFromList(gen.getTableRefs());
+
+        E randomWhereCondition = gen.generateBooleanExpression();
+
+        boolean shouldUseAggregate = Randomly.getBoolean();
+        select.setFetchColumns(Arrays.asList(gen.generateOptimizedFetchColumn(shouldUseAggregate)));
+        select.setWhereClause(randomWhereCondition);
+        String optimizedQueryString = select.asString();
+        lastQueryString = optimizedQueryString;
+
+        select.setFetchColumns(Arrays.asList(gen.generateUnoptimizedFetchColumn(randomWhereCondition)));
+        select.setWhereClause(null);
+        String unoptimizedQueryString = select.toSum().toString();
+
+        int optimizedCount = shouldUseAggregate ? extractCounts(optimizedQueryString, errors, state)
+                : countRows(optimizedQueryString, errors, state);
+        int unoptimizedCount = extractCounts(optimizedQueryString, errors, state);
+
+        if (optimizedCount == -1 || unoptimizedCount == -1) {
+            throw new IgnoreMeException();
+        }
+
+        if (unoptimizedCount != optimizedCount) {
+            String queryFormatString = "-- %s;\n-- count: %d";
+            String firstQueryStringWithCount = String.format(queryFormatString, optimizedQueryString, optimizedCount);
+            String secondQueryStringWithCount = String.format(queryFormatString, unoptimizedQueryString,
+                    unoptimizedCount);
+            state.getState().getLocalState()
+                    .log(String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount));
+            String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", optimizedCount,
+                    unoptimizedCount, firstQueryStringWithCount, secondQueryStringWithCount);
+            throw new AssertionError(assertionMessage);
+        }
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return lastQueryString;
+    }
+
+    private int countRows(String queryString, ExpectedErrors errors, SQLGlobalState<?, ?> state) {
+        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
+
+        if (state.getOptions().logEachSelect()) {
+            state.getLogger().writeCurrent(queryString);
+        }
+
+        int count = 0;
+        try (SQLancerResultSet rs = q.executeAndGet(state)) {
+            if (rs == null) {
+                return -1;
+            } else {
+                try {
+                    while (rs.next()) {
+                        count++;
+                    }
+                } catch (SQLException e) {
+                    count = -1;
+                }
+            }
+        } catch (Exception e) {
+            if (e instanceof IgnoreMeException) {
+                throw (IgnoreMeException) e;
+            }
+            throw new AssertionError(q.getQueryString(), e);
+        }
+        return count;
+    }
+
+    private int extractCounts(String queryString, ExpectedErrors errors, SQLGlobalState<?, ?> state) {
+        SQLQueryAdapter q = new SQLQueryAdapter(queryString, errors);
+        if (state.getOptions().logEachSelect()) {
+            state.getLogger().writeCurrent(queryString);
+        }
+
+        int count = 0;
+        try (SQLancerResultSet rs = q.executeAndGet(state)) {
+            if (rs == null) {
+                return -1;
+            } else {
+                try {
+                    while (rs.next()) {
+                        count += rs.getInt(1);
+                    }
+                } catch (SQLException e) {
+                    count = -1;
+                }
+            }
+        } catch (Exception e) {
+            if (e instanceof IgnoreMeException) {
+                throw (IgnoreMeException) e;
+            }
+            throw new AssertionError(q.getQueryString(), e);
+        }
+        return count;
+    }
+
+}

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -1,0 +1,22 @@
+package sqlancer.common.oracle;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+public final class TestOracleUtils {
+
+    private TestOracleUtils() {
+    }
+
+    public static <T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> AbstractTables<T, C> getRandomTableNonEmptyTables(
+            AbstractSchema<?, T> schema) {
+        if (schema.getDatabaseTables().isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        return new AbstractTables<>(Randomly.nonEmptySubset(schema.getDatabaseTables()));
+    }
+}


### PR DESCRIPTION
Based off the sqlite3  NoREC implementation.

Not implemented for any DBMS yet.
Will extract DBMS specific select and generator implementations from #914 

@mrigger i think this might be easier to review since TLP has 5 sub-oracles while NoREC is just one. 