### PR TITLE
Fix a formatting error

### DIFF
--- a/test/sqlancer/dbms/TestSQLiteTLP.java
+++ b/test/sqlancer/dbms/TestSQLiteTLP.java
@@ -12,8 +12,8 @@ public class TestSQLiteTLP {
     public void testSqliteTLP() {
         // run with one thread due to multithreading issues, see https://github.com/sqlancer/sqlancer/pull/45
         assertEquals(0,
-                Main.executeMain(new String[] {"--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
+                Main.executeMain(new String[] { "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS,
                         "--num-threads", "1", "--num-queries", TestConfig.NUM_QUERIES, "sqlite3", "--oracle",
-                        "QUERY_PARTITIONING"}));
+                        "QUERY_PARTITIONING" }));
     }
 }


### PR DESCRIPTION
@malwaregarry: You can avoid such errors by running `mvn formatter:format` before committing.