### PR TITLE
[TIDB] Add expected insert errors for v7.5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -459,7 +459,7 @@ jobs:
       - name: Set up TiDB
         run: |
           docker pull pingcap/tidb:latest
-          docker run --name tidb-server -d -p 4000:4000 pingcap/tidb:latest
+          docker run --name tidb-server -d -p 4000:4000 pingcap/tidb:v7.5.1
           sleep 10
       - name: Create SQLancer user
         run: sudo mysql -h 127.0.0.1 -P 4000 -u root -D test -e "CREATE USER 'sqlancer'@'%' IDENTIFIED WITH mysql_native_password BY 'sqlancer'; GRANT ALL PRIVILEGES ON *.* TO 'sqlancer'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;"

--- a/src/sqlancer/tidb/TiDBErrors.java
+++ b/src/sqlancer/tidb/TiDBErrors.java
@@ -29,6 +29,7 @@ public final class TiDBErrors {
         errors.add("doesn't have a default value"); // default
         errors.add("is not valid for CHARACTER SET");
         errors.add("DOUBLE value is out of range");
+        errors.add("Result of space() was larger than max_allowed_packet");
 
         errors.add("Data truncat");
         errors.add("Truncated incorrect FLOAT value");
@@ -105,6 +106,8 @@ public final class TiDBErrors {
         errors.add("Incorrect decimal value");
         errors.add("error parsing regexp");
         errors.add("is not valid for CHARACTER SET");
+        errors.add("for function inet_aton");
+        errors.add("'Empty pattern is invalid' from regexp");
 
         return errors;
     }

--- a/src/sqlancer/tidb/gen/TiDBAlterTableGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBAlterTableGenerator.java
@@ -33,6 +33,7 @@ public final class TiDBAlterTableGenerator {
         errors.add("A PRIMARY must include all columns in the table's partitioning function");
         errors.add("key was too long");
         errors.add("Duplicate entry");
+        errors.add("has a partitioning function dependency and cannot be dropped or renamed");
         StringBuilder sb = new StringBuilder("ALTER TABLE ");
         TiDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         TiDBColumn column = table.getRandomColumn();


### PR DESCRIPTION
rebased from #931 

Adding the four to the insert errors fixes the CI. 
1. `Incorrect string value: '18446744073709551615' for function inet_aton` caused by an invalid parameter for inet_aton
2. `Got error 'Empty pattern is invalid' from regexp` caused by regexp applied to an empty string ie. `REGEX('')`
3. `Result of space() was larger than max_allowed_packet (67108864)` caused by space being called with a large number
4. `Column 'c0' has a partitioning function dependency and cannot be dropped or renamed`. Not sure about this one but could be because of the change here https://github.com/pingcap/tidb/issues/38739 


Also pinned TiDB version in checks to the current latest (v7.5.1)

