### PR TITLE
[Postgres & Citus] Use generic NoREC oracle  

### DIFF
--- a/src/sqlancer/citus/oracle/CitusNoRECOracle.java
+++ b/src/sqlancer/citus/oracle/CitusNoRECOracle.java
@@ -1,14 +1,49 @@
 package sqlancer.citus.oracle;
 
-import sqlancer.citus.gen.CitusCommon;
-import sqlancer.postgres.PostgresGlobalState;
-import sqlancer.postgres.oracle.PostgresNoRECOracle;
+import java.sql.SQLException;
+import java.util.regex.Pattern;
 
-public class CitusNoRECOracle extends PostgresNoRECOracle {
+import sqlancer.Reproducer;
+import sqlancer.citus.gen.CitusCommon;
+import sqlancer.common.oracle.NoRECOracle;
+import sqlancer.common.oracle.TestOracle;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.postgres.PostgresGlobalState;
+import sqlancer.postgres.PostgresSchema;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
+import sqlancer.postgres.PostgresSchema.PostgresTable;
+import sqlancer.postgres.ast.PostgresExpression;
+import sqlancer.postgres.ast.PostgresJoin;
+import sqlancer.postgres.ast.PostgresSelect;
+import sqlancer.postgres.gen.PostgresCommon;
+import sqlancer.postgres.gen.PostgresExpressionGenerator;
+
+public class CitusNoRECOracle implements TestOracle<PostgresGlobalState> {
+    private final NoRECOracle<PostgresSelect, PostgresJoin, PostgresExpression, PostgresSchema, PostgresTable, PostgresColumn, PostgresGlobalState> oracle;
 
     public CitusNoRECOracle(PostgresGlobalState globalState) {
-        super(globalState);
-        CitusCommon.addCitusErrors(errors);
+        PostgresExpressionGenerator gen = new PostgresExpressionGenerator(globalState);
+        ExpectedErrors errors = ExpectedErrors.newErrors()
+                .with(PostgresCommon.getCommonExpressionErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonFetchErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonExpressionRegexErrors().toArray(new Pattern[0]))
+                .with(CitusCommon.getCitusErrors().toArray(new String[0])).build();
+        this.oracle = new NoRECOracle<>(globalState, gen, errors);
+    }
+
+    @Override
+    public void check() throws SQLException {
+        oracle.check();
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return oracle.getLastQueryString();
+    }
+
+    @Override
+    public Reproducer<PostgresGlobalState> getLastReproducer() {
+        return oracle.getLastReproducer();
     }
 
 }

--- a/src/sqlancer/common/ast/SelectBase.java
+++ b/src/sqlancer/common/ast/SelectBase.java
@@ -36,6 +36,10 @@ public class SelectBase<T> {
         this.fromList = fromList;
     }
 
+    public void setFromTables(List<T> tables) {
+        setFromList(tables);
+    }
+
     public List<T> getFromList() {
         if (fromList == null) {
             throw new IllegalStateException();
@@ -115,4 +119,11 @@ public class SelectBase<T> {
         this.joinList = joinList;
     }
 
+    public List<T> getGroupByClause() {
+        return getGroupByExpressions();
+    }
+
+    public void setGroupByClause(List<T> groupByExpressions) {
+        setGroupByExpressions(groupByExpressions);
+    }
 }

--- a/src/sqlancer/common/gen/NoRECGenerator.java
+++ b/src/sqlancer/common/gen/NoRECGenerator.java
@@ -9,13 +9,13 @@ import sqlancer.common.schema.AbstractTable;
 import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.common.schema.AbstractTables;
 
-public interface NoRECGenerator<J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
+public interface NoRECGenerator<S extends Select<J, E, T, C>, J extends Join<E, T, C>, E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
 
-    NoRECGenerator<J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
+    NoRECGenerator<S, J, E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
 
     E generateBooleanExpression();
 
-    Select<J, E, T, C> generateSelect();
+    S generateSelect();
 
     List<J> getRandomJoinClauses();
 
@@ -33,7 +33,7 @@ public interface NoRECGenerator<J extends Join<E, T, C>, E extends Expression<C>
      *
      * @return a query string to be executed
      */
-    String generateOptimizedQueryString(Select<J, E, T, C> select, E whereCondition, boolean shouldUseAggregate);
+    String generateOptimizedQueryString(S select, E whereCondition, boolean shouldUseAggregate);
 
     /**
      * Generates a query string that is unlikely to be optimized by the DBMS.
@@ -45,5 +45,5 @@ public interface NoRECGenerator<J extends Join<E, T, C>, E extends Expression<C>
      *
      * @return a query string to be executed
      */
-    String generateUnoptimizedQueryString(Select<J, E, T, C> select, E whereCondition);
+    String generateUnoptimizedQueryString(S select, E whereCondition);
 }

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -20,12 +20,12 @@ import sqlancer.common.schema.AbstractTable;
 import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.common.schema.AbstractTables;
 
-public class NoRECOracle<J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
         implements TestOracle<G> {
 
     private final G state;
 
-    private NoRECGenerator<J, E, T, C> gen;
+    private NoRECGenerator<Z, J, E, T, C> gen;
     private final ExpectedErrors errors;
 
     private Reproducer<G> reproducer;
@@ -46,7 +46,7 @@ public class NoRECOracle<J extends Join<E, T, C>, E extends Expression<C>, S ext
         }
     }
 
-    public NoRECOracle(G state, NoRECGenerator<J, E, T, C> gen, ExpectedErrors expectedErrors) {
+    public NoRECOracle(G state, NoRECGenerator<Z, J, E, T, C> gen, ExpectedErrors expectedErrors) {
         if (state == null || gen == null || expectedErrors == null) {
             throw new IllegalArgumentException("Null variables used to initialize test oracle.");
         }
@@ -63,7 +63,7 @@ public class NoRECOracle<J extends Join<E, T, C>, E extends Expression<C>, S ext
         AbstractTables<T, C> targetTables = TestOracleUtils.getRandomTableNonEmptyTables(schema);
         gen = gen.setTablesAndColumns(targetTables);
 
-        Select<J, E, T, C> select = gen.generateSelect();
+        Z select = gen.generateSelect();
         select.setJoinClauses(gen.getRandomJoinClauses());
         select.setFromList(gen.getTableRefs());
 

--- a/src/sqlancer/mariadb/ast/MariaDBSelectStatement.java
+++ b/src/sqlancer/mariadb/ast/MariaDBSelectStatement.java
@@ -16,6 +16,7 @@ public class MariaDBSelectStatement extends SelectBase<MariaDBExpression> implem
     private MariaDBSelectType selectType = MariaDBSelectType.ALL;
     private MariaDBExpression whereCondition;
 
+    @Override
     public void setGroupByClause(List<MariaDBExpression> groupBys) {
         this.groupBys = groupBys;
     }

--- a/src/sqlancer/oceanbase/ast/OceanBaseSelect.java
+++ b/src/sqlancer/oceanbase/ast/OceanBaseSelect.java
@@ -29,10 +29,12 @@ public class OceanBaseSelect extends SelectBase<OceanBaseExpression> implements 
         this.fromOptions = fromOptions;
     }
 
+    @Override
     public void setGroupByClause(List<OceanBaseExpression> groupBys) {
         this.groupBys = groupBys;
     }
 
+    @Override
     public List<OceanBaseExpression> getGroupByClause() {
         return this.groupBys;
     }

--- a/src/sqlancer/postgres/ast/PostgresExpression.java
+++ b/src/sqlancer/postgres/ast/PostgresExpression.java
@@ -1,8 +1,10 @@
 package sqlancer.postgres.ast;
 
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 
-public interface PostgresExpression {
+public interface PostgresExpression extends Expression<PostgresColumn> {
 
     default PostgresDataType getExpressionType() {
         return null;

--- a/src/sqlancer/postgres/ast/PostgresJoin.java
+++ b/src/sqlancer/postgres/ast/PostgresJoin.java
@@ -5,12 +5,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Join;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
+import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
 
-public class PostgresJoin implements PostgresExpression {
+public class PostgresJoin implements PostgresExpression, Join<PostgresExpression, PostgresTable, PostgresColumn> {
 
     public enum PostgresJoinType {
         INNER, LEFT, RIGHT, FULL, CROSS;
@@ -77,6 +79,7 @@ public class PostgresJoin implements PostgresExpression {
         return joinExpressions;
     }
 
+    @Override
     public void setOnClause(PostgresExpression clause) {
         this.onClause = clause;
     }
@@ -97,6 +100,7 @@ public class PostgresJoin implements PostgresExpression {
         return rightTable;
     }
 
+    @Override
     public PostgresExpression getOnClause() {
         return onClause;
     }

--- a/src/sqlancer/postgres/ast/PostgresSelect.java
+++ b/src/sqlancer/postgres/ast/PostgresSelect.java
@@ -5,10 +5,14 @@ import java.util.List;
 
 import sqlancer.Randomly;
 import sqlancer.common.ast.SelectBase;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
+import sqlancer.postgres.PostgresVisitor;
 
-public class PostgresSelect extends SelectBase<PostgresExpression> implements PostgresExpression {
+public class PostgresSelect extends SelectBase<PostgresExpression>
+        implements PostgresExpression, Select<PostgresJoin, PostgresExpression, PostgresTable, PostgresColumn> {
 
     private SelectType selectOption = SelectType.ALL;
     private List<PostgresJoin> joinClauses = Collections.emptyList();
@@ -111,11 +115,13 @@ public class PostgresSelect extends SelectBase<PostgresExpression> implements Po
         return null;
     }
 
+    @Override
     public void setJoinClauses(List<PostgresJoin> joinStatements) {
         this.joinClauses = joinStatements;
 
     }
 
+    @Override
     public List<PostgresJoin> getJoinClauses() {
         return joinClauses;
     }
@@ -132,4 +138,8 @@ public class PostgresSelect extends SelectBase<PostgresExpression> implements Po
         return forClause;
     }
 
+    @Override
+    public String asString() {
+        return PostgresVisitor.asString(this);
+    }
 }

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -1,77 +1,57 @@
 package sqlancer.postgres.oracle;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 
-import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
-import sqlancer.common.oracle.NoRECBase;
+import sqlancer.Reproducer;
+import sqlancer.common.oracle.NoRECOracle;
 import sqlancer.common.oracle.TestOracle;
-import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.query.SQLancerResultSet;
-import sqlancer.postgres.PostgresCompoundDataType;
+import sqlancer.common.query.ExpectedErrors;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema;
 import sqlancer.postgres.PostgresSchema.PostgresColumn;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.PostgresSchema.PostgresTables;
-import sqlancer.postgres.PostgresVisitor;
-import sqlancer.postgres.ast.PostgresCastOperation;
-import sqlancer.postgres.ast.PostgresColumnValue;
 import sqlancer.postgres.ast.PostgresExpression;
 import sqlancer.postgres.ast.PostgresJoin;
 import sqlancer.postgres.ast.PostgresJoin.PostgresJoinType;
-import sqlancer.postgres.ast.PostgresPostfixText;
 import sqlancer.postgres.ast.PostgresSelect;
 import sqlancer.postgres.ast.PostgresSelect.PostgresFromTable;
 import sqlancer.postgres.ast.PostgresSelect.PostgresSubquery;
-import sqlancer.postgres.ast.PostgresSelect.SelectType;
 import sqlancer.postgres.gen.PostgresCommon;
 import sqlancer.postgres.gen.PostgresExpressionGenerator;
 import sqlancer.postgres.oracle.tlp.PostgresTLPBase;
 
-public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implements TestOracle<PostgresGlobalState> {
+public class PostgresNoRECOracle implements TestOracle<PostgresGlobalState> {
 
-    private final PostgresSchema s;
+    private final NoRECOracle<PostgresSelect, PostgresJoin, PostgresExpression, PostgresSchema, PostgresTable, PostgresColumn, PostgresGlobalState> oracle;
 
     public PostgresNoRECOracle(PostgresGlobalState globalState) {
-        super(globalState);
-        this.s = globalState.getSchema();
-        PostgresCommon.addCommonExpressionErrors(errors);
-        PostgresCommon.addCommonFetchErrors(errors);
+        PostgresExpressionGenerator gen = new PostgresExpressionGenerator(globalState);
+        ExpectedErrors errors = ExpectedErrors.newErrors()
+                .with(PostgresCommon.getCommonExpressionErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonFetchErrors().toArray(new String[0]))
+                .with(PostgresCommon.getCommonExpressionRegexErrors().toArray(new Pattern[0])).build();
+        this.oracle = new NoRECOracle<>(globalState, gen, errors);
     }
 
     @Override
     public void check() throws SQLException {
-        PostgresTables randomTables = s.getRandomTableNonEmptyTables();
-        List<PostgresColumn> columns = randomTables.getColumns();
-        PostgresExpression randomWhereCondition = getRandomWhereCondition(columns);
-        List<PostgresTable> tables = randomTables.getTables();
+        oracle.check();
+    }
 
-        List<PostgresJoin> joinStatements = getJoinStatements(state, columns, tables);
-        List<PostgresExpression> fromTables = tables.stream().map(t -> new PostgresFromTable(t, Randomly.getBoolean()))
-                .collect(Collectors.toList());
-        int secondCount = getUnoptimizedQueryCount(fromTables, randomWhereCondition, joinStatements);
-        int firstCount = getOptimizedQueryCount(fromTables, columns, randomWhereCondition, joinStatements);
-        if (firstCount == -1 || secondCount == -1) {
-            throw new IgnoreMeException();
-        }
-        if (firstCount != secondCount) {
-            String queryFormatString = "-- %s;\n-- count: %d";
-            String firstQueryStringWithCount = String.format(queryFormatString, optimizedQueryString, firstCount);
-            String secondQueryStringWithCount = String.format(queryFormatString, unoptimizedQueryString, secondCount);
-            state.getState().getLocalState()
-                    .log(String.format("%s\n%s", firstQueryStringWithCount, secondQueryStringWithCount));
-            String assertionMessage = String.format("the counts mismatch (%d and %d)!\n%s\n%s", firstCount, secondCount,
-                    firstQueryStringWithCount, secondQueryStringWithCount);
-            throw new AssertionError(assertionMessage);
-        }
+    @Override
+    public String getLastQueryString() {
+        return oracle.getLastQueryString();
+    }
+
+    @Override
+    public Reproducer<PostgresGlobalState> getLastReproducer() {
+        return oracle.getLastReproducer();
     }
 
     public static List<PostgresJoin> getJoinStatements(PostgresGlobalState globalState, List<PostgresColumn> columns,
@@ -98,71 +78,4 @@ public class PostgresNoRECOracle extends NoRECBase<PostgresGlobalState> implemen
         }
         return joinStatements;
     }
-
-    private PostgresExpression getRandomWhereCondition(List<PostgresColumn> columns) {
-        return new PostgresExpressionGenerator(state).setColumns(columns).generateExpression(PostgresDataType.BOOLEAN);
-    }
-
-    private int getUnoptimizedQueryCount(List<PostgresExpression> fromTables, PostgresExpression randomWhereCondition,
-            List<PostgresJoin> joinStatements) throws SQLException {
-        PostgresSelect select = new PostgresSelect();
-        PostgresCastOperation isTrue = new PostgresCastOperation(randomWhereCondition,
-                PostgresCompoundDataType.create(PostgresDataType.INT));
-        PostgresPostfixText asText = new PostgresPostfixText(isTrue, " as count", null, PostgresDataType.INT);
-        select.setFetchColumns(Arrays.asList(asText));
-        select.setFromList(fromTables);
-        select.setSelectType(SelectType.ALL);
-        select.setJoinClauses(joinStatements);
-        int secondCount = 0;
-        unoptimizedQueryString = "SELECT SUM(count) FROM (" + PostgresVisitor.asString(select) + ") as res";
-        if (options.logEachSelect()) {
-            logger.writeCurrent(unoptimizedQueryString);
-        }
-        errors.add("canceling statement due to statement timeout");
-        SQLQueryAdapter q = new SQLQueryAdapter(unoptimizedQueryString, errors);
-        SQLancerResultSet rs;
-        try {
-            rs = q.executeAndGet(state);
-        } catch (Exception e) {
-            throw new AssertionError(unoptimizedQueryString, e);
-        }
-        if (rs == null) {
-            return -1;
-        }
-        if (rs.next()) {
-            secondCount += rs.getLong(1);
-        }
-        rs.close();
-        return secondCount;
-    }
-
-    private int getOptimizedQueryCount(List<PostgresExpression> randomTables, List<PostgresColumn> columns,
-            PostgresExpression randomWhereCondition, List<PostgresJoin> joinStatements) throws SQLException {
-        PostgresSelect select = new PostgresSelect();
-        PostgresColumnValue allColumns = new PostgresColumnValue(Randomly.fromList(columns), null);
-        select.setFetchColumns(Arrays.asList(allColumns));
-        select.setFromList(randomTables);
-        select.setWhereClause(randomWhereCondition);
-        if (Randomly.getBooleanWithSmallProbability()) {
-            select.setOrderByClauses(new PostgresExpressionGenerator(state).setColumns(columns).generateOrderBy());
-        }
-        select.setSelectType(SelectType.ALL);
-        select.setJoinClauses(joinStatements);
-        int firstCount = 0;
-        try (Statement stat = con.createStatement()) {
-            optimizedQueryString = PostgresVisitor.asString(select);
-            if (options.logEachSelect()) {
-                logger.writeCurrent(optimizedQueryString);
-            }
-            try (ResultSet rs = stat.executeQuery(optimizedQueryString)) {
-                while (rs.next()) {
-                    firstCount++;
-                }
-            }
-        } catch (SQLException e) {
-            throw new IgnoreMeException();
-        }
-        return firstCount;
-    }
-
 }

--- a/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
+++ b/src/sqlancer/sqlite3/gen/SQLite3ExpressionGenerator.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
-import sqlancer.common.ast.newast.Select;
 import sqlancer.common.gen.ExpressionGenerator;
 import sqlancer.common.gen.NoRECGenerator;
 import sqlancer.common.schema.AbstractTables;
@@ -51,7 +50,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3RowValue;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
 public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Expression>,
-        NoRECGenerator<Join, SQLite3Expression, SQLite3Table, SQLite3Column> {
+        NoRECGenerator<SQLite3Select, Join, SQLite3Expression, SQLite3Table, SQLite3Column> {
 
     private SQLite3RowValue rw;
     private final SQLite3GlobalState globalState;
@@ -749,8 +748,8 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
     }
 
     @Override
-    public String generateOptimizedQueryString(Select<Join, SQLite3Expression, SQLite3Table, SQLite3Column> select,
-            SQLite3Expression whereCondition, boolean shouldUseAggregate) {
+    public String generateOptimizedQueryString(SQLite3Select select, SQLite3Expression whereCondition,
+            boolean shouldUseAggregate) {
         if (Randomly.getBoolean()) {
             select.setOrderByClauses(generateOrderBys());
         }
@@ -767,8 +766,7 @@ public class SQLite3ExpressionGenerator implements ExpressionGenerator<SQLite3Ex
     }
 
     @Override
-    public String generateUnoptimizedQueryString(Select<Join, SQLite3Expression, SQLite3Table, SQLite3Column> select,
-            SQLite3Expression whereCondition) {
+    public String generateUnoptimizedQueryString(SQLite3Select select, SQLite3Expression whereCondition) {
         SQLite3PostfixUnaryOperation isTrue = new SQLite3PostfixUnaryOperation(PostfixUnaryOperator.IS_TRUE,
                 whereCondition);
         SQLite3PostfixText asText = new SQLite3PostfixText(isTrue, " as count", null);

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -10,6 +10,7 @@ import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
 import sqlancer.sqlite3.ast.SQLite3Expression;
 import sqlancer.sqlite3.ast.SQLite3Expression.Join;
+import sqlancer.sqlite3.ast.SQLite3Select;
 import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
@@ -17,7 +18,7 @@ import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
 public class SQLite3NoRECOracle implements TestOracle<SQLite3GlobalState> {
 
-    NoRECOracle<Join, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
+    NoRECOracle<SQLite3Select, Join, SQLite3Expression, SQLite3Schema, SQLite3Table, SQLite3Column, SQLite3GlobalState> oracle;
 
     public SQLite3NoRECOracle(SQLite3GlobalState globalState) {
         SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(globalState);


### PR DESCRIPTION
Changes
* Implemented expression interfaces for Postgres (not sure why the verification checks required updating Oceanbase and Mariadb with `@Override` for certain functions)
* Changed NoREC generator to use specific `Select` type
* Updated NoREC oracle for Postgres
* Updated NoREC oracle for Citus as it depended on Postgres

Note: The reproducer didn't seem specific to SQLite so I enabled them for Postgres and Citus as well 