### PR TITLE
Update `with` in `ExpectedErrorsBuilder` to support Collections

### DIFF
--- a/src/sqlancer/citus/oracle/CitusNoRECOracle.java
+++ b/src/sqlancer/citus/oracle/CitusNoRECOracle.java
@@ -1,7 +1,6 @@
 package sqlancer.citus.oracle;
 
 import java.sql.SQLException;
-import java.util.regex.Pattern;
 
 import sqlancer.Reproducer;
 import sqlancer.citus.gen.CitusCommon;
@@ -23,10 +22,8 @@ public class CitusNoRECOracle implements TestOracle<PostgresGlobalState> {
 
     public CitusNoRECOracle(PostgresGlobalState globalState) {
         PostgresExpressionGenerator gen = new PostgresExpressionGenerator(globalState);
-        ExpectedErrors errors = ExpectedErrors.newErrors()
-                .with(PostgresCommon.getCommonExpressionErrors().toArray(new String[0]))
-                .with(PostgresCommon.getCommonFetchErrors().toArray(new String[0]))
-                .with(PostgresCommon.getCommonExpressionRegexErrors().toArray(new Pattern[0]))
+        ExpectedErrors errors = ExpectedErrors.newErrors().with(PostgresCommon.getCommonExpressionErrors())
+                .with(PostgresCommon.getCommonFetchErrors()).withRegex(PostgresCommon.getCommonExpressionRegexErrors())
                 .with(CitusCommon.getCitusErrors().toArray(new String[0])).build();
         this.oracle = new NoRECOracle<>(globalState, gen, errors);
     }

--- a/src/sqlancer/common/query/ExpectedErrors.java
+++ b/src/sqlancer/common/query/ExpectedErrors.java
@@ -110,16 +110,28 @@ public class ExpectedErrors {
             return this;
         }
 
-        public ExpectedErrorsBuilder with(Pattern... list) {
+        public ExpectedErrorsBuilder with(Collection<String> list) {
+            return with(list.toArray(new String[0]));
+        }
+
+        public ExpectedErrorsBuilder withRegex(Pattern... list) {
             regexes.addAll(Arrays.asList(list));
             return this;
         }
 
-        public ExpectedErrorsBuilder withRegex(String... list) {
+        public ExpectedErrorsBuilder withRegex(Collection<Pattern> list) {
+            return withRegex(list.toArray(new Pattern[0]));
+        }
+
+        public ExpectedErrorsBuilder withRegexString(String... list) {
             for (String error : list) {
                 regexes.add(Pattern.compile(error));
             }
             return this;
+        }
+
+        public ExpectedErrorsBuilder withRegexString(Collection<String> list) {
+            return withRegexString(list.toArray(new String[0]));
         }
 
         public ExpectedErrors build() {

--- a/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
+++ b/src/sqlancer/postgres/oracle/PostgresNoRECOracle.java
@@ -3,7 +3,6 @@ package sqlancer.postgres.oracle;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import sqlancer.Randomly;
 import sqlancer.Reproducer;
@@ -32,10 +31,9 @@ public class PostgresNoRECOracle implements TestOracle<PostgresGlobalState> {
 
     public PostgresNoRECOracle(PostgresGlobalState globalState) {
         PostgresExpressionGenerator gen = new PostgresExpressionGenerator(globalState);
-        ExpectedErrors errors = ExpectedErrors.newErrors()
-                .with(PostgresCommon.getCommonExpressionErrors().toArray(new String[0]))
-                .with(PostgresCommon.getCommonFetchErrors().toArray(new String[0]))
-                .with(PostgresCommon.getCommonExpressionRegexErrors().toArray(new Pattern[0])).build();
+        ExpectedErrors errors = ExpectedErrors.newErrors().with(PostgresCommon.getCommonExpressionErrors())
+                .with(PostgresCommon.getCommonFetchErrors()).withRegex(PostgresCommon.getCommonExpressionRegexErrors())
+                .build();
         this.oracle = new NoRECOracle<>(globalState, gen, errors);
     }
 

--- a/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
+++ b/src/sqlancer/sqlite3/oracle/SQLite3NoRECOracle.java
@@ -22,10 +22,8 @@ public class SQLite3NoRECOracle implements TestOracle<SQLite3GlobalState> {
 
     public SQLite3NoRECOracle(SQLite3GlobalState globalState) {
         SQLite3ExpressionGenerator gen = new SQLite3ExpressionGenerator(globalState);
-        ExpectedErrors errors = ExpectedErrors.newErrors()
-                .with(SQLite3Errors.getExpectedExpressionErrors().toArray(new String[0]))
-                .with(SQLite3Errors.getMatchQueryErrors().toArray(new String[0]))
-                .with(SQLite3Errors.getQueryErrors().toArray(new String[0]))
+        ExpectedErrors errors = ExpectedErrors.newErrors().with(SQLite3Errors.getExpectedExpressionErrors())
+                .with(SQLite3Errors.getMatchQueryErrors()).with(SQLite3Errors.getQueryErrors())
                 .with("misuse of aggregate", "misuse of window function",
                         "second argument to nth_value must be a positive integer", "no such table", "no query solution",
                         "unable to use function MATCH in the requested context")

--- a/test/sqlancer/TestExpectedErrors.java
+++ b/test/sqlancer/TestExpectedErrors.java
@@ -118,14 +118,38 @@ public class TestExpectedErrors {
         assertTrue(errors.errorIsExpected("aa"));
         assertFalse(errors.errorIsExpected("d"));
 
-        errors = ExpectedErrors.newErrors().withRegex("a\\d", "b\\D").with("c").build();
+        errors = ExpectedErrors.newErrors().with(List.of("a", "b", "c")).build();
+
+        assertTrue(errors.errorIsExpected("a"));
+        assertTrue(errors.errorIsExpected("b"));
+        assertTrue(errors.errorIsExpected("c"));
+        assertTrue(errors.errorIsExpected("aa"));
+        assertFalse(errors.errorIsExpected("d"));
+
+        errors = ExpectedErrors.newErrors().withRegexString("a\\d", "b\\D").with("c").build();
 
         assertTrue(errors.errorIsExpected("a0"));
         assertTrue(errors.errorIsExpected("bb"));
         assertTrue(errors.errorIsExpected("c"));
         assertFalse(errors.errorIsExpected("aa"));
 
-        errors = ExpectedErrors.newErrors().with(Pattern.compile("a\\d"), Pattern.compile("b\\D")).with("c").build();
+        errors = ExpectedErrors.newErrors().withRegexString(List.of("a\\d", "b\\D")).with("c").build();
+
+        assertTrue(errors.errorIsExpected("a0"));
+        assertTrue(errors.errorIsExpected("bb"));
+        assertTrue(errors.errorIsExpected("c"));
+        assertFalse(errors.errorIsExpected("aa"));
+
+        errors = ExpectedErrors.newErrors().withRegex(Pattern.compile("a\\d"), Pattern.compile("b\\D")).with("c")
+                .build();
+
+        assertTrue(errors.errorIsExpected("a0"));
+        assertTrue(errors.errorIsExpected("bb"));
+        assertTrue(errors.errorIsExpected("c"));
+        assertFalse(errors.errorIsExpected("aa"));
+
+        errors = ExpectedErrors.newErrors().withRegex(List.of(Pattern.compile("a\\d"), Pattern.compile("b\\D")))
+                .with("c").build();
 
         assertTrue(errors.errorIsExpected("a0"));
         assertTrue(errors.errorIsExpected("bb"));


### PR DESCRIPTION
Used the trick stated in https://stackoverflow.com/a/74411632.

Opted to use this method so that we still have compile-time type checks, but we can still change to the generic method if this is too unorthodox 