### PR TITLE
[ClickHouse] Added pattern for changed error message

### DIFF
--- a/src/sqlancer/clickhouse/ClickHouseErrors.java
+++ b/src/sqlancer/clickhouse/ClickHouseErrors.java
@@ -45,6 +45,7 @@ public final class ClickHouseErrors {
                 "Positional argument numeric constant expression is not representable as",
                 "Positional argument must be constant with numeric type", " is out of bounds. Expected in range",
                 "with constants is not supported. (INVALID_JOIN_ON_EXPRESSION)",
+                "Cannot get JOIN keys from JOIN ON section",
                 "Unexpected inf or nan to integer conversion", "Unsigned type must not contain",
                 "Unexpected inf or nan to integer conversion",
 

--- a/src/sqlancer/clickhouse/ClickHouseErrors.java
+++ b/src/sqlancer/clickhouse/ClickHouseErrors.java
@@ -45,9 +45,8 @@ public final class ClickHouseErrors {
                 "Positional argument numeric constant expression is not representable as",
                 "Positional argument must be constant with numeric type", " is out of bounds. Expected in range",
                 "with constants is not supported. (INVALID_JOIN_ON_EXPRESSION)",
-                "Cannot get JOIN keys from JOIN ON section",
-                "Unexpected inf or nan to integer conversion", "Unsigned type must not contain",
-                "Unexpected inf or nan to integer conversion",
+                "Cannot get JOIN keys from JOIN ON section", "Unexpected inf or nan to integer conversion",
+                "Unsigned type must not contain", "Unexpected inf or nan to integer conversion",
 
                 // The way we generate JOINs we can have ambiguous left table column without
                 // alias


### PR DESCRIPTION
https://fiddle.clickhouse.com/a3a95024-4da7-4275-baff-86f116014744

```
Received exception from server (version 24.2.3):
Code: 403. DB::Exception: Received from localhost:9000. DB::Exception: Cannot get JOIN keys from JOIN ON section: '476505718 = `_--right_2.c0`', found keys: [Left keys: [] Right keys [] Condition columns: '', 'equals(476505718, _--right_2.c0)']. (INVALID_JOIN_ON_EXPRESSION)
(query: SELECT SUM(check <> 0) FROM ((SELECT right_0.c0 AS `check` FROM t0 AS left FULL OUTER JOIN t0 AS right_0 ON ((left.c0)=(right_0.c0)) LEFT OUTER JOIN t0 AS right_1 ON ((left.c0)=(right_1.c0)) LEFT ANTI JOIN t0 AS right_2 ON ((476505718)=(right_2.c0)))) as res;)
```