### PR TITLE
Avoid storage parameters during CREATE TABLE for partitioned tables

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableGenerator.java
@@ -113,7 +113,9 @@ public class PostgresTableGenerator {
         generateInherits();
         generatePartitionBy();
         generateUsing();
-        PostgresCommon.generateWith(sb, globalState, errors);
+        if (!isPartitionedTable) {
+            PostgresCommon.generateWith(sb, globalState, errors);
+        }
         if (Randomly.getBoolean() && isTemporaryTable) {
             sb.append(" ON COMMIT ");
             sb.append(Randomly.fromOptions("PRESERVE ROWS", "DELETE ROWS", "DROP"));


### PR DESCRIPTION
In Postgres, CREATE TABLE WITH() allows storage parameters, but partitioned tables emit an error (given below) if attempted. This is because partitioned non-leaf tables are virutal tables [1] and don't accept storage parameters.

Sample Error:
"ERROR: cannot specify storage parameters for a partitioned table"

This patch skips storage parameter generation for partitioned tables.

Ref:
1. https://www.postgresql.org/docs/current/ddl-partitioning.html