### PR TITLE
Inherits should only use tables

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableGenerator.java
@@ -207,7 +207,7 @@ public class PostgresTableGenerator {
     }
 
     private void generateInherits() {
-        if (Randomly.getBoolean() && !newSchema.getDatabaseTables().isEmpty()) {
+        if (Randomly.getBoolean() && !newSchema.getDatabaseTablesWithoutViews().isEmpty()) {
             sb.append(" INHERITS(");
             sb.append(newSchema.getDatabaseTablesRandomSubsetNotEmpty().stream().map(t -> t.getName())
                     .collect(Collectors.joining(", ")));

--- a/src/sqlancer/postgres/gen/PostgresTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableGenerator.java
@@ -207,7 +207,7 @@ public class PostgresTableGenerator {
     }
 
     private void generateInherits() {
-        if (Randomly.getBoolean() && !newSchema.getDatabaseTablesWithoutViews().isEmpty()) {
+        if (Randomly.getBoolean() && !newSchema.getDatabaseTables().isEmpty()) {
             sb.append(" INHERITS(");
             sb.append(newSchema.getDatabaseTablesRandomSubsetNotEmpty().stream().map(t -> t.getName())
                     .collect(Collectors.joining(", ")));


### PR DESCRIPTION
Currently INHERITS() allows all relations (even views) to be used. Postgres complains in such cases, which results in false positives  such as this the one below.

This minor change ensures INHERITS() always uses tables only (not views).

```
--java.lang.AssertionError: CREATE TEMPORARY TABLE IF NOT EXISTS t4(c0 boolean ) INHERITS(pg_buffercache, blocked_functions) USING heap;
--      at sqlancer.common.query.SQLQueryAdapter.checkException(SQLQueryAdapter.java:124)
--      at sqlancer.common.query.SQLQueryAdapter.execute(SQLQueryAdapter.java:106)
--      at sqlancer.Main$QueryManager.execute(Main.java:357)
--      at sqlancer.GlobalState.executeStatement(GlobalState.java:108)
--      at sqlancer.postgres.PostgresProvider.createTables(PostgresProvider.java:306)
--      at sqlancer.postgres.PostgresProvider.generateDatabase(PostgresProvider.java:197)
--      at sqlancer.postgres.PostgresProvider.generateDatabase(PostgresProvider.java:1)
--      at sqlancer.ProviderAdapter.generateAndTestDatabase(ProviderAdapter.java:52)
--      at sqlancer.Main$DBMSExecutor.run(Main.java:456)
--      at sqlancer.Main$2.run(Main.java:670)
--      at sqlancer.Main$2.runThread(Main.java:652)
--      at sqlancer.Main$2.run(Main.java:643)
--      at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
--      at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
--      at java.base/java.lang.Thread.run(Thread.java:840)
--Caused by: org.postgresql.util.PSQLException: ERROR: inherited relation "pg_buffercache" is not a table or foreign table
--      at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676)
--      at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366)
--      at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356)
--      at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:496)
--      at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:413)
--      at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:333)
--      at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:319)
--      at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:295)
--      at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:290)
--      at sqlancer.common.query.SQLQueryAdapter.execute(SQLQueryAdapter.java:100)
--      ... 13 more
---- Time: 2024/07/17 00:07:42
-- Database: db0
-- Database version: 18devel
-- seed value: 1721140652187
\c test;
DROP DATABASE IF EXISTS db0;
CREATE DATABASE db0 WITH ENCODING 'utf8';
\c db0;
db0.log (END)
```
```
db0=# \dt pg_buffercache
Did not find any relation named "pg_buffercache".
db0=# \dv pg_buffercache
            List of relations
 Schema |      Name      | Type | Owner
--------+----------------+------+--------
 public | pg_buffercache | view | lancer
(1 row)

```