### PR TITLE
[TiDB] Use common TLP where oracle

### DIFF
--- a/src/sqlancer/tidb/ast/TiDBExpression.java
+++ b/src/sqlancer/tidb/ast/TiDBExpression.java
@@ -1,5 +1,8 @@
 package sqlancer.tidb.ast;
 
-public interface TiDBExpression {
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.tidb.TiDBSchema.TiDBColumn;
+
+public interface TiDBExpression extends Expression<TiDBColumn> {
 
 }

--- a/src/sqlancer/tidb/ast/TiDBJoin.java
+++ b/src/sqlancer/tidb/ast/TiDBJoin.java
@@ -5,11 +5,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.common.ast.newast.Join;
 import sqlancer.tidb.TiDBExpressionGenerator;
 import sqlancer.tidb.TiDBProvider.TiDBGlobalState;
 import sqlancer.tidb.TiDBSchema.TiDBColumn;
+import sqlancer.tidb.TiDBSchema.TiDBTable;
 
-public class TiDBJoin implements TiDBExpression {
+public class TiDBJoin implements TiDBExpression, Join<TiDBExpression, TiDBTable, TiDBColumn> {
 
     private final TiDBExpression leftTable;
     private final TiDBExpression rightTable;
@@ -101,8 +103,8 @@ public class TiDBJoin implements TiDBExpression {
         return outerType;
     }
 
-    public static List<TiDBExpression> getJoins(List<TiDBExpression> tableList, TiDBGlobalState globalState) {
-        List<TiDBExpression> joinExpressions = new ArrayList<>();
+    public static List<TiDBJoin> getJoins(List<TiDBExpression> tableList, TiDBGlobalState globalState) {
+        List<TiDBJoin> joinExpressions = new ArrayList<>();
         while (tableList.size() >= 2 && Randomly.getBoolean()) {
             TiDBTableReference leftTable = (TiDBTableReference) tableList.remove(0);
             TiDBTableReference rightTable = (TiDBTableReference) tableList.remove(0);
@@ -172,4 +174,8 @@ public class TiDBJoin implements TiDBExpression {
         this.onCondition = generateExpression;
     }
 
+    @Override
+    public void setOnClause(TiDBExpression onClause) {
+        onCondition = onClause;
+    }
 }

--- a/src/sqlancer/tidb/ast/TiDBSelect.java
+++ b/src/sqlancer/tidb/ast/TiDBSelect.java
@@ -1,8 +1,16 @@
 package sqlancer.tidb.ast;
 
-import sqlancer.common.ast.SelectBase;
+import java.util.List;
+import java.util.stream.Collectors;
 
-public class TiDBSelect extends SelectBase<TiDBExpression> implements TiDBExpression {
+import sqlancer.common.ast.SelectBase;
+import sqlancer.common.ast.newast.Select;
+import sqlancer.tidb.TiDBSchema.TiDBColumn;
+import sqlancer.tidb.TiDBSchema.TiDBTable;
+import sqlancer.tidb.visitor.TiDBVisitor;
+
+public class TiDBSelect extends SelectBase<TiDBExpression>
+        implements TiDBExpression, Select<TiDBJoin, TiDBExpression, TiDBTable, TiDBColumn> {
 
     private TiDBExpression hint;
 
@@ -14,4 +22,20 @@ public class TiDBSelect extends SelectBase<TiDBExpression> implements TiDBExpres
         return hint;
     }
 
+    @Override
+    public void setJoinClauses(List<TiDBJoin> joinStatements) {
+        List<TiDBExpression> expressions = joinStatements.stream().map(e -> (TiDBExpression) e)
+                .collect(Collectors.toList());
+        setJoinList(expressions);
+    }
+
+    @Override
+    public List<TiDBJoin> getJoinClauses() {
+        return getJoinList().stream().map(e -> (TiDBJoin) e).collect(Collectors.toList());
+    }
+
+    @Override
+    public String asString() {
+        return TiDBVisitor.asString(this);
+    }
 }

--- a/src/sqlancer/tidb/oracle/TiDBDQPOracle.java
+++ b/src/sqlancer/tidb/oracle/TiDBDQPOracle.java
@@ -47,7 +47,7 @@ public class TiDBDQPOracle implements TestOracle<TiDBGlobalState> {
 
         List<TiDBExpression> tableList = tables.getTables().stream().map(t -> new TiDBTableReference(t))
                 .collect(Collectors.toList());
-        List<TiDBExpression> joins = TiDBJoin.getJoins(tableList, state);
+        List<TiDBExpression> joins = TiDBJoin.getJoins(tableList, state).stream().collect(Collectors.toList());
         select.setJoinList(joins);
         select.setFromList(tableList);
         if (Randomly.getBoolean()) {

--- a/src/sqlancer/tidb/oracle/TiDBTLPBase.java
+++ b/src/sqlancer/tidb/oracle/TiDBTLPBase.java
@@ -50,7 +50,7 @@ public abstract class TiDBTLPBase extends TernaryLogicPartitioningOracleBase<TiD
 
         List<TiDBExpression> tableList = tables.stream().map(t -> new TiDBTableReference(t))
                 .collect(Collectors.toList());
-        List<TiDBExpression> joins = TiDBJoin.getJoins(tableList, state);
+        List<TiDBExpression> joins = TiDBJoin.getJoins(tableList, state).stream().collect(Collectors.toList());
         select.setJoinList(joins);
         select.setFromList(tableList);
         select.setWhereClause(null);

--- a/test/sqlancer/dbms/TestConfig.java
+++ b/test/sqlancer/dbms/TestConfig.java
@@ -15,6 +15,7 @@ public class TestConfig {
     public static final String OCEANBASE_ENV = "OCEANBASE_AVAILABLE";
     public static final String POSTGRES_ENV = "POSTGRES_AVAILABLE";
     public static final String PRESTO_ENV = "PRESTO_AVAILABLE";
+    public static final String TIDB_ENV = "TIDB_AVAILABLE";
     public static final String YUGABYTE_ENV = "YUGABYTE_AVAILABLE";
 
     public static boolean isEnvironmentTrue(String key) {


### PR DESCRIPTION
Just noticed that `num_queries` is set 0. Increasing this value results in assertion errors, which could explain why the DQP tests have been failing