### PR TITLE
Bump SQLite3 to version 3.46.1.0, recognize new bad JSON path error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.40.0.0</version>
+      <version>3.46.1.0</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>

--- a/src/sqlancer/sqlite3/SQLite3Errors.java
+++ b/src/sqlancer/sqlite3/SQLite3Errors.java
@@ -56,6 +56,7 @@ public final class SQLite3Errors {
         errors.add("malformed JSON");
         errors.add("JSON cannot hold BLOB values");
         errors.add("JSON path error");
+        errors.add("bad JSON path");
         errors.add("json_insert() needs an odd number of arguments");
         errors.add("json_object() labels must be TEXT");
         errors.add("json_object() requires an even number of arguments");


### PR DESCRIPTION
* bump SQLite to 3.46.1.0 (from 3.44.0.0)

* recognize `bad JSON path`, the new `JSON path error` since https://sqlite.org/src/info/7f0c79b94e8f55e5