### PR TITLE
[Postgres][v13] Add PARALLEL option for VACUUM

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
@@ -24,15 +24,20 @@ public final class PostgresVacuumGenerator {
             sb.append("(");
             for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
                 ArrayList<String> opts = new ArrayList<>(Arrays.asList("FULL", "FREEZE", "ANALYZE", "VERBOSE",
-                        "DISABLE_PAGE_SKIPPING", "SKIP_LOCKED", "INDEX_CLEANUP", "TRUNCATE"));
+                        "DISABLE_PAGE_SKIPPING", "SKIP_LOCKED", "INDEX_CLEANUP", "TRUNCATE", "PARALLEL"));
                 String option = Randomly.fromList(opts);
                 if (i != 0) {
                     sb.append(", ");
                 }
                 sb.append(option);
-                if (Randomly.getBoolean()) {
+                if (option.equals("PARALLEL")) {
                     sb.append(" ");
-                    sb.append(Randomly.fromOptions(1, 0));
+                    sb.append(Randomly.smallNumber());
+                } else {
+                    if (Randomly.getBoolean()) {
+                        sb.append(" ");
+                        sb.append(Randomly.fromOptions(1, 0));
+                    }
                 }
             }
             sb.append(")");


### PR DESCRIPTION
This patch adds `PARALLEL` support to `VACUUM` command in Postgres (launched in v13)

This is working towards the Issue #912 .

- Sample Postgres ERROR logfile capture given below
```
lancer@lenovo:~/proj/lancerpg$ grep VACUUM logfile | grep PARALLEL
2024-12-08 17:39:51.042 ACDT [653315] LOG:  execute <unnamed>: VACUUM (PARALLEL 0)
2024-12-08 17:39:51.315 ACDT [653285] LOG:  execute <unnamed>: VACUUM (VERBOSE, PARALLEL 0) t5
2024-12-08 17:39:51.375 ACDT [653283] LOG:  execute <unnamed>: VACUUM (PARALLEL 0, VERBOSE 1)
2024-12-08 17:45:03.234 ACDT [673926] LOG:  execute <unnamed>: VACUUM (SKIP_LOCKED 0, PARALLEL 2)
2024-12-08 17:47:22.036 ACDT [702212] LOG:  execute <unnamed>: VACUUM (FULL 1, PARALLEL 0)
2024-12-08 17:48:07.203 ACDT [712462] LOG:  execute <unnamed>: VACUUM (PARALLEL 6) t5
```

- `mvn package -DskipTests` works
- `mvn package` fails with #799 .
```
[INFO] Running sqlancer.TestUsageNamingConvention
No DBMS implementations (i.e., instantiations of the DatabaseProvider class) were found. You likely ran into an issue described in https://github.com/sqlancer/sqlancer/issues/799. As a workaround, I now statically load all supported providers as of June 7, 2023.
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.057 s <<< FAILURE! - in sqlancer.TestUsageNamingConvention
[ERROR] testNonEmptyDescription  Time elapsed: 0.043 s  <<< ERROR!
java.lang.reflect.InaccessibleObjectException: Unable to make private static java.lang.annotation.Annotation java.lang.reflect.AnnotatedElement.lambda$getDeclaredAnnotationsByType$0(java.lang.annotation.Annotation,java.lang.annotation.Annotation) accessible: module java.base does not "opens java.lang.reflect" to unnamed module @1376c05c
        at sqlancer.TestUsageNamingConvention.testNonEmptyDescription(TestUsageNamingConvention.java:25)
```