### PR TITLE
[Postgres][v16] Rename force_parallel_mode to debug_parallel_query

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresSetGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresSetGenerator.java
@@ -112,7 +112,7 @@ public final class PostgresSetGenerator {
         JIT("jit", (r) -> Randomly.fromOptions(1, 0)),
         JOIN_COLLAPSE_LIMIT("join_collapse_limit", (r) -> r.getInteger(1, Integer.MAX_VALUE)),
         PARALLEL_LEADER_PARTICIPATION("parallel_leader_participation", (r) -> Randomly.fromOptions(1, 0)),
-        FORCE_PARALLEL_MODE("force_parallel_mode", (r) -> Randomly.fromOptions("off", "on", "regress")),
+        DEBUG_PARALLEL_QUERY("debug_parallel_query", (r) -> Randomly.fromOptions("off", "on", "regress")),
         PLAN_CACHE_MODE("plan_cache_mode",
                 (r) -> Randomly.fromOptions("auto", "force_generic_plan", "force_custom_plan"));
 


### PR DESCRIPTION
This is working towards #1044 - Ensuring that SQLancer works well with Postgres 16

In Postgres v16 [1] `force_parallel_mode` was renamed to `debug_parallel_query`. This causes avoidable errors during SQLancer runs. 

One way here is to put in `Errors` for both `debug_parallel_query` AND `force_parallel_mode` - which reduces irrespective of old or newer version. However IMHO this would reduce efficiency unnecessarily and thus this patch that renames the parameter, since now 2 Major versions (v16 and v17) already are on the newer parameter.

Reference:
1. https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=5352ca22e