### PR TITLE
[Postgres][v13] Skip errors around VACUUM FULL not supporting PARALLEL

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
@@ -60,6 +60,7 @@ public final class PostgresVacuumGenerator {
                                  */
         errors.add("ERROR: ANALYZE option must be specified when a column list is provided");
         errors.add("VACUUM option DISABLE_PAGE_SKIPPING cannot be used with FULL");
+        errors.add("VACUUM FULL cannot be performed in parallel");
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 


### PR DESCRIPTION
Once PR #1040 gets accepted, we'd need to skip the corner case where VACUUM FULL cannot accept PARALLEL.

This is similar to the existing rule where DISABLE_PAGE_SKIPPING is not allowed during VACUUM FULL [1]

Note: This is working towards support for Postgres v13 ( #912 ). 

Reference:
1. https://github.com/sqlancer/sqlancer/blob/main/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java#L62