### PR TITLE
[MySQL] Add support for generating aggregates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.11.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId> slf4j-simple</artifactId>
       <version>2.0.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -328,12 +328,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>5.11.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId> slf4j-simple</artifactId>
       <version>2.0.6</version>

--- a/src/sqlancer/mysql/MySQLExpectedValueVisitor.java
+++ b/src/sqlancer/mysql/MySQLExpectedValueVisitor.java
@@ -1,6 +1,7 @@
 package sqlancer.mysql;
 
 import sqlancer.IgnoreMeException;
+import sqlancer.mysql.ast.MySQLAggregate;
 import sqlancer.mysql.ast.MySQLBetweenOperation;
 import sqlancer.mysql.ast.MySQLBinaryComparisonOperation;
 import sqlancer.mysql.ast.MySQLBinaryLogicalOperation;
@@ -164,6 +165,12 @@ public class MySQLExpectedValueVisitor implements MySQLVisitor {
     @Override
     public void visit(MySQLText text) {
         print(text);
+    }
+
+    @Override
+    public void visit(MySQLAggregate aggr) {
+        print(aggr);
+        visit(aggr.getExpr());
     }
 
 }

--- a/src/sqlancer/mysql/MySQLExpectedValueVisitor.java
+++ b/src/sqlancer/mysql/MySQLExpectedValueVisitor.java
@@ -169,8 +169,6 @@ public class MySQLExpectedValueVisitor implements MySQLVisitor {
 
     @Override
     public void visit(MySQLAggregate aggr) {
-        print(aggr);
-        visit(aggr.getExpr());
     }
 
 }

--- a/src/sqlancer/mysql/MySQLExpectedValueVisitor.java
+++ b/src/sqlancer/mysql/MySQLExpectedValueVisitor.java
@@ -169,6 +169,7 @@ public class MySQLExpectedValueVisitor implements MySQLVisitor {
 
     @Override
     public void visit(MySQLAggregate aggr) {
+        // do nothing
     }
 
 }

--- a/src/sqlancer/mysql/MySQLToStringVisitor.java
+++ b/src/sqlancer/mysql/MySQLToStringVisitor.java
@@ -328,10 +328,14 @@ public class MySQLToStringVisitor extends ToStringVisitor<MySQLExpression> imple
     @Override
     public void visit(MySQLAggregate aggr) {
         MySQLAggregateFunction func = aggr.getFunc();
+        String option = aggr.getOption();
 
         sb.append(func);
         sb.append("(");
-        sb.append(func.getRandomOption());
+        if (option != null) {
+            sb.append(option);
+            sb.append(" ");
+        }
         visit(aggr.getExpr());
         sb.append(")");
     }

--- a/src/sqlancer/mysql/MySQLToStringVisitor.java
+++ b/src/sqlancer/mysql/MySQLToStringVisitor.java
@@ -328,15 +328,21 @@ public class MySQLToStringVisitor extends ToStringVisitor<MySQLExpression> imple
     @Override
     public void visit(MySQLAggregate aggr) {
         MySQLAggregateFunction func = aggr.getFunc();
-        String option = aggr.getOption();
+        String option = func.getOption();
+        List<MySQLExpression> exprs = aggr.getExprs();
 
-        sb.append(func);
+        sb.append(func.getName());
         sb.append("(");
         if (option != null) {
             sb.append(option);
             sb.append(" ");
         }
-        visit(aggr.getExpr());
+        for (int i = 0; i < exprs.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            visit(exprs.get(i));
+        }
         sb.append(")");
     }
 }

--- a/src/sqlancer/mysql/MySQLToStringVisitor.java
+++ b/src/sqlancer/mysql/MySQLToStringVisitor.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
 import sqlancer.common.visitor.ToStringVisitor;
+import sqlancer.mysql.ast.MySQLAggregate;
 import sqlancer.mysql.ast.MySQLBetweenOperation;
 import sqlancer.mysql.ast.MySQLBinaryComparisonOperation;
 import sqlancer.mysql.ast.MySQLBinaryLogicalOperation;
@@ -25,6 +26,7 @@ import sqlancer.mysql.ast.MySQLStringExpression;
 import sqlancer.mysql.ast.MySQLTableReference;
 import sqlancer.mysql.ast.MySQLText;
 import sqlancer.mysql.ast.MySQLUnaryPostfixOperation;
+import sqlancer.mysql.ast.MySQLAggregate.MySQLAggregateFunction;
 
 public class MySQLToStringVisitor extends ToStringVisitor<MySQLExpression> implements MySQLVisitor {
 
@@ -321,5 +323,16 @@ public class MySQLToStringVisitor extends ToStringVisitor<MySQLExpression> imple
     @Override
     public void visit(MySQLText text) {
         sb.append(text.getText());
+    }
+
+    @Override
+    public void visit(MySQLAggregate aggr) {
+        MySQLAggregateFunction func = aggr.getFunc();
+
+        sb.append(func);
+        sb.append("(");
+        sb.append(func.getRandomOption());
+        visit(aggr.getExpr());
+        sb.append(")");
     }
 }

--- a/src/sqlancer/mysql/MySQLVisitor.java
+++ b/src/sqlancer/mysql/MySQLVisitor.java
@@ -1,5 +1,6 @@
 package sqlancer.mysql;
 
+import sqlancer.mysql.ast.MySQLAggregate;
 import sqlancer.mysql.ast.MySQLBetweenOperation;
 import sqlancer.mysql.ast.MySQLBinaryComparisonOperation;
 import sqlancer.mysql.ast.MySQLBinaryLogicalOperation;
@@ -58,6 +59,8 @@ public interface MySQLVisitor {
 
     void visit(MySQLText text);
 
+    void visit(MySQLAggregate aggregate);
+
     default void visit(MySQLExpression expr) {
         if (expr instanceof MySQLConstant) {
             visit((MySQLConstant) expr);
@@ -95,6 +98,8 @@ public interface MySQLVisitor {
             visit((MySQLCollate) expr);
         } else if (expr instanceof MySQLText) {
             visit((MySQLText) expr);
+        } else if (expr instanceof MySQLAggregate) {
+            visit((MySQLAggregate) expr);
         } else {
             throw new AssertionError(expr);
         }

--- a/src/sqlancer/mysql/ast/MySQLAggregate.java
+++ b/src/sqlancer/mysql/ast/MySQLAggregate.java
@@ -6,44 +6,54 @@ public class MySQLAggregate implements MySQLExpression {
     
     public enum MySQLAggregateFunction {
         // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_count.
-        COUNT("DISTINCT"),
+        COUNT("COUNT", null, false),
+        COUNT_DISTINCT("COUNT", "DISTINCT", true),
         // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_sum.
-        SUM("DISTINCT"),
+        SUM("SUM", null, false),
+        SUM_DISTINCT("SUM", "DISTINCT", false),
         // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_min.
-        MIN("DISTINCT"),
+        MIN("MIN", null, false),
+        MIN_DISTINCT("MIN", "DISTINCT", false),
         // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_max.
-        MAX("DISTINCT");
+        MAX("MAX", null, false),
+        MAX_DISTINCT("MAX", "DISTINCT", false);
 
-        private final List<String> options;
+        private final String name;
+        private final String option;
+        private final boolean isVariadic;
 
-        private MySQLAggregateFunction(String... options) {
-            this.options = List.of(options);
+        private MySQLAggregateFunction(String name, String option, boolean isVariadic) {
+            this.name = name;
+            this.option = option;
+            this.isVariadic = isVariadic;
         }
 
-        public List<String> getOptions() {
-            return options;
+        public String getName() {
+            return this.name;
+        }
+
+        public String getOption() {
+            return option;
+        }
+
+        public boolean isVariadic() {
+            return this.isVariadic;
         }
     }
 
-    private final MySQLExpression expr;
+    private final List<MySQLExpression> exprs;
     private final MySQLAggregateFunction func;
-    private final String option;
 
-    public MySQLAggregate(MySQLExpression expr, MySQLAggregateFunction func, String option) {
-        this.expr = expr;
+    public MySQLAggregate(List<MySQLExpression> exprs, MySQLAggregateFunction func) {
+        this.exprs = exprs;
         this.func = func;
-        this.option = option;
     }
 
-    public MySQLExpression getExpr() {
-        return expr;
+    public List<MySQLExpression> getExprs() {
+        return exprs;
     }
 
     public MySQLAggregateFunction getFunc() {
         return func;
-    }
-
-    public String getOption() {
-        return option;
     }
 }

--- a/src/sqlancer/mysql/ast/MySQLAggregate.java
+++ b/src/sqlancer/mysql/ast/MySQLAggregate.java
@@ -1,6 +1,6 @@
 package sqlancer.mysql.ast;
 
-import sqlancer.Randomly;
+import java.util.List;
 
 public class MySQLAggregate implements MySQLExpression {
     
@@ -14,27 +14,25 @@ public class MySQLAggregate implements MySQLExpression {
         // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_max.
         MAX("DISTINCT");
 
-        private final String[] options;
+        private final List<String> options;
 
         private MySQLAggregateFunction(String... options) {
-            this.options = options.clone();
+            this.options = List.of(options);
         }
 
-        public String getRandomOption() {
-            if (options.length == 0 || Randomly.getBoolean()) {
-                return "";
-            }
-
-            return Randomly.fromOptions(options);
+        public List<String> getOptions() {
+            return options;
         }
     }
 
     private final MySQLExpression expr;
     private final MySQLAggregateFunction func;
+    private final String option;
 
-    public MySQLAggregate(MySQLExpression expr, MySQLAggregateFunction func) {
+    public MySQLAggregate(MySQLExpression expr, MySQLAggregateFunction func, String option) {
         this.expr = expr;
         this.func = func;
+        this.option = option;
     }
 
     public MySQLExpression getExpr() {
@@ -43,5 +41,9 @@ public class MySQLAggregate implements MySQLExpression {
 
     public MySQLAggregateFunction getFunc() {
         return func;
+    }
+
+    public String getOption() {
+        return option;
     }
 }

--- a/src/sqlancer/mysql/ast/MySQLAggregate.java
+++ b/src/sqlancer/mysql/ast/MySQLAggregate.java
@@ -1,0 +1,47 @@
+package sqlancer.mysql.ast;
+
+import sqlancer.Randomly;
+
+public class MySQLAggregate implements MySQLExpression {
+    
+    public enum MySQLAggregateFunction {
+        // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_count.
+        COUNT("DISTINCT"),
+        // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_sum.
+        SUM("DISTINCT"),
+        // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_min.
+        MIN("DISTINCT"),
+        // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_max.
+        MAX("DISTINCT");
+
+        private final String[] options;
+
+        private MySQLAggregateFunction(String... options) {
+            this.options = options.clone();
+        }
+
+        public String getRandomOption() {
+            if (options.length == 0 || Randomly.getBoolean()) {
+                return "";
+            }
+
+            return Randomly.fromOptions(options);
+        }
+    }
+
+    private final MySQLExpression expr;
+    private final MySQLAggregateFunction func;
+
+    public MySQLAggregate(MySQLExpression expr, MySQLAggregateFunction func) {
+        this.expr = expr;
+        this.func = func;
+    }
+
+    public MySQLExpression getExpr() {
+        return expr;
+    }
+
+    public MySQLAggregateFunction getFunc() {
+        return func;
+    }
+}

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -253,7 +253,13 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
     public MySQLAggregate generateAggregate() {
         MySQLAggregateFunction func = Randomly.fromOptions(MySQLAggregateFunction.values());
         MySQLExpression expr = generateExpression();
-        return new MySQLAggregate(expr, func);
+
+        if (Randomly.getBoolean() && func.getOptions().size() > 0) {
+            String option = Randomly.fromList(func.getOptions());
+            return new MySQLAggregate(expr, func, option);
+        } else {
+            return new MySQLAggregate(expr, func, null);
+        }
     }
 
     @Override

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
@@ -252,13 +253,16 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
 
     public MySQLAggregate generateAggregate() {
         MySQLAggregateFunction func = Randomly.fromOptions(MySQLAggregateFunction.values());
-        MySQLExpression expr = generateExpression();
 
-        if (Randomly.getBoolean() && func.getOptions().size() > 0) {
-            String option = Randomly.fromList(func.getOptions());
-            return new MySQLAggregate(expr, func, option);
+        if (func.isVariadic()) {
+            int nrExprs = Randomly.smallNumber() + 1;
+            List<MySQLExpression> exprs = IntStream.range(0, nrExprs)
+                .mapToObj(index -> generateExpression())
+                .collect(Collectors.toList());
+            
+            return new MySQLAggregate(exprs, func);
         } else {
-            return new MySQLAggregate(expr, func, null);
+            return new MySQLAggregate(List.of(generateExpression()), func);
         }
     }
 

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -16,6 +16,7 @@ import sqlancer.mysql.MySQLGlobalState;
 import sqlancer.mysql.MySQLSchema.MySQLColumn;
 import sqlancer.mysql.MySQLSchema.MySQLRowValue;
 import sqlancer.mysql.MySQLSchema.MySQLTable;
+import sqlancer.mysql.ast.MySQLAggregate;
 import sqlancer.mysql.ast.MySQLBetweenOperation;
 import sqlancer.mysql.ast.MySQLBinaryComparisonOperation;
 import sqlancer.mysql.ast.MySQLBinaryComparisonOperation.BinaryComparisonOperator;
@@ -40,6 +41,7 @@ import sqlancer.mysql.ast.MySQLStringExpression;
 import sqlancer.mysql.ast.MySQLTableReference;
 import sqlancer.mysql.ast.MySQLUnaryPostfixOperation;
 import sqlancer.mysql.ast.MySQLUnaryPrefixOperation;
+import sqlancer.mysql.ast.MySQLAggregate.MySQLAggregateFunction;
 import sqlancer.mysql.ast.MySQLUnaryPrefixOperation.MySQLUnaryPrefixOperator;
 
 public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLExpression, MySQLColumn>
@@ -246,6 +248,12 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
     @Override
     public String generateExplainQuery(MySQLSelect select) {
         return "EXPLAIN " + select.asString();
+    }
+
+    public MySQLAggregate generateAggregate() {
+        MySQLAggregateFunction func = Randomly.fromOptions(MySQLAggregateFunction.values());
+        MySQLExpression expr = generateExpression();
+        return new MySQLAggregate(expr, func);
     }
 
     @Override

--- a/src/sqlancer/mysql/gen/MySQLRandomQuerySynthesizer.java
+++ b/src/sqlancer/mysql/gen/MySQLRandomQuerySynthesizer.java
@@ -25,6 +25,8 @@ public final class MySQLRandomQuerySynthesizer {
         List<MySQLExpression> allColumns = new ArrayList<>();
         List<MySQLExpression> columnsWithoutAggregations = new ArrayList<>();
 
+        boolean hasGeneratedAggregate = false;
+
         select.setSelectType(Randomly.fromOptions(MySQLSelect.SelectType.values()));
         for (int i = 0; i < nrColumns; i++) {
             if (Randomly.getBoolean()) {
@@ -33,6 +35,7 @@ public final class MySQLRandomQuerySynthesizer {
                 columnsWithoutAggregations.add(expression);
             } else {
                 allColumns.add(gen.generateAggregate());
+                hasGeneratedAggregate = true;
             }
         }
         select.setFetchColumns(allColumns);
@@ -46,7 +49,7 @@ public final class MySQLRandomQuerySynthesizer {
         if (Randomly.getBooleanWithRatherLowProbability()) {
             select.setOrderByClauses(gen.generateOrderBys());
         }
-        if (Randomly.getBoolean()) {
+        if (hasGeneratedAggregate || Randomly.getBoolean()) {
             select.setGroupByExpressions(columnsWithoutAggregations);
             if (Randomly.getBoolean()) {
                 select.setHavingClause(gen.generateHavingClause());

--- a/test/sqlancer/mysql/MySQLToStringVisitorTest.java
+++ b/test/sqlancer/mysql/MySQLToStringVisitorTest.java
@@ -1,39 +1,67 @@
 package sqlancer.mysql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 import sqlancer.mysql.ast.MySQLAggregate;
 import sqlancer.mysql.ast.MySQLColumnReference;
 
 public class MySQLToStringVisitorTest {
-    
-    @ParameterizedTest
-    @EnumSource(MySQLAggregate.MySQLAggregateFunction.class)
-    void visitAggregateWithOptions(MySQLAggregate.MySQLAggregateFunction function) {
+
+    @Test
+    void visitAggregateToString() {
         MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a",
                 MySQLSchema.MySQLDataType.INT, false, 0);
         MySQLColumnReference aRef = new MySQLColumnReference(aCol, null);
 
-        MySQLToStringVisitor visitor = new MySQLToStringVisitor();
+        MySQLAggregate aggrCount = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.COUNT
+        );
+        assertEquals("COUNT(a)", MySQLVisitor.asString(aggrCount));
 
-        for (String option : function.getOptions()) {
-            visitor.visit(new MySQLAggregate(aRef, function, option));
-            assertEquals(String.format("%s(%s a)", function, option), visitor.get());
-        }
+        MySQLAggregate aggrSum = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.SUM
+        );
+        assertEquals("SUM(a)", MySQLVisitor.asString(aggrSum));
+
+        MySQLAggregate aggrMin = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.MIN
+        );
+        assertEquals("MIN(a)", MySQLVisitor.asString(aggrMin));
+
+        MySQLAggregate aggrMax = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.MAX
+        );
+        assertEquals("MAX(a)", MySQLVisitor.asString(aggrMax));
     }
 
-    @ParameterizedTest
-    @EnumSource(MySQLAggregate.MySQLAggregateFunction.class)
-    void visitAggregateWithoutOptions(MySQLAggregate.MySQLAggregateFunction function) {
+    @Test
+    void visitAggregateWithDistinctToString() {
         MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a",
                 MySQLSchema.MySQLDataType.INT, false, 0);
         MySQLColumnReference aRef = new MySQLColumnReference(aCol, null);
 
-        MySQLToStringVisitor visitor = new MySQLToStringVisitor();
+        MySQLAggregate aggrCountDistinct = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.COUNT_DISTINCT
+        );
+        assertEquals("COUNT(DISTINCT a)", MySQLVisitor.asString(aggrCountDistinct));
 
-        visitor.visit(new MySQLAggregate(aRef, function, null));
-        assertEquals(String.format("%s(a)", function), visitor.get());
+        MySQLAggregate aggrSumDistinct = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.SUM_DISTINCT
+        );
+        assertEquals("SUM(DISTINCT a)", MySQLVisitor.asString(aggrSumDistinct));
+
+        MySQLAggregate aggrMinDistinct = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.MIN_DISTINCT
+        );
+        assertEquals("MIN(DISTINCT a)", MySQLVisitor.asString(aggrMinDistinct));
+
+        MySQLAggregate aggrMaxDistinct = new MySQLAggregate(
+            List.of(aRef), MySQLAggregate.MySQLAggregateFunction.MAX_DISTINCT
+        );
+        assertEquals("MAX(DISTINCT a)", MySQLVisitor.asString(aggrMaxDistinct));
     }
 }

--- a/test/sqlancer/mysql/MySQLToStringVisitorTest.java
+++ b/test/sqlancer/mysql/MySQLToStringVisitorTest.java
@@ -1,0 +1,39 @@
+package sqlancer.mysql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import sqlancer.mysql.ast.MySQLAggregate;
+import sqlancer.mysql.ast.MySQLColumnReference;
+
+public class MySQLToStringVisitorTest {
+    
+    @ParameterizedTest
+    @EnumSource(MySQLAggregate.MySQLAggregateFunction.class)
+    void visitAggregateWithOptions(MySQLAggregate.MySQLAggregateFunction function) {
+        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a",
+                MySQLSchema.MySQLDataType.INT, false, 0);
+        MySQLColumnReference aRef = new MySQLColumnReference(aCol, null);
+
+        MySQLToStringVisitor visitor = new MySQLToStringVisitor();
+
+        for (String option : function.getOptions()) {
+            visitor.visit(new MySQLAggregate(aRef, function, option));
+            assertEquals(String.format("%s(%s a)", function, option), visitor.get());
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(MySQLAggregate.MySQLAggregateFunction.class)
+    void visitAggregateWithoutOptions(MySQLAggregate.MySQLAggregateFunction function) {
+        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a",
+                MySQLSchema.MySQLDataType.INT, false, 0);
+        MySQLColumnReference aRef = new MySQLColumnReference(aCol, null);
+
+        MySQLToStringVisitor visitor = new MySQLToStringVisitor();
+
+        visitor.visit(new MySQLAggregate(aRef, function, null));
+        assertEquals(String.format("%s(a)", function), visitor.get());
+    }
+}


### PR DESCRIPTION
This PR adds support for generating the following aggregate functions in MySQL:
- `COUNT(expr)`, `COUNT(DISTINCT expr, [expr...])`: [MySQL 8.4 Reference Manual](https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_count)
- `SUM(expr)`, `SUM(DISTINCT expr)`:  [MySQL 8.4 Reference Manual](https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_sum)
- `MAX(expr)`, `MAX(DISTINCT expr)`: [MySQL 8.4 Reference Manual](https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_max)
- `MIN(expr)`, `MIN(DISTINCT expr)`: [MySQL 8.4 Reference Manual](https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_min)