### PR TITLE
Mark support for v13, update test / comment URLs accordingly.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -467,7 +467,7 @@ jobs:
       - name: Set up PostgreSQL
         uses: harmon758/postgresql-action@v1.0.0
         with:
-          postgresql version: '12'
+          postgresql version: '13'
           postgresql user: 'sqlancer'
           postgresql password: 'sqlancer'
           postgresql db: 'test'

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -109,7 +109,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         RESET_ROLE((g) -> new SQLQueryAdapter("RESET ROLE")), //
         COMMENT_ON(PostgresCommentGenerator::generate), //
         RESET((g) -> new SQLQueryAdapter("RESET ALL") /*
-                                                       * https://www.postgresql.org/docs/devel/sql-reset.html TODO: also
+                                                       * https://www.postgresql.org/docs/13/sql-reset.html TODO: also
                                                        * configuration parameter
                                                        */), //
         NOTIFY(PostgresNotifyGenerator::createNotify), //

--- a/src/sqlancer/postgres/ast/PostgresFunctionWithUnknownResult.java
+++ b/src/sqlancer/postgres/ast/PostgresFunctionWithUnknownResult.java
@@ -19,11 +19,11 @@ public enum PostgresFunctionWithUnknownResult {
     TEXT("text", PostgresDataType.TEXT, PostgresDataType.INET),
     INET_SAME_FAMILY("inet_same_family", PostgresDataType.BOOLEAN, PostgresDataType.INET, PostgresDataType.INET),
 
-    // https://www.postgresql.org/docs/devel/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL-TABLE
+    // https://www.postgresql.org/docs/13/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL-TABLE
     // PG_RELOAD_CONF("pg_reload_conf", PostgresDataType.BOOLEAN), // too much output
     // PG_ROTATE_LOGFILE("pg_rotate_logfile", PostgresDataType.BOOLEAN), prints warning
 
-    // https://www.postgresql.org/docs/devel/functions-info.html#FUNCTIONS-INFO-SESSION-TABLE
+    // https://www.postgresql.org/docs/13/functions-info.html#FUNCTIONS-INFO-SESSION-TABLE
     CURRENT_DATABASE("current_database", PostgresDataType.TEXT), // name
     // CURRENT_QUERY("current_query", PostgresDataType.TEXT), // can generate false positives
     CURRENT_SCHEMA("current_schema", PostgresDataType.TEXT), // name
@@ -87,7 +87,7 @@ public enum PostgresFunctionWithUnknownResult {
     TO_HEX("to_hex", PostgresDataType.INT, PostgresDataType.TEXT),
     TRANSLATE("translate", PostgresDataType.TEXT, PostgresDataType.TEXT, PostgresDataType.TEXT, PostgresDataType.TEXT),
     // mathematical functions
-    // https://www.postgresql.org/docs/9.5/functions-math.html
+    // https://www.postgresql.org/docs/13/functions-math.html
     ABS("abs", PostgresDataType.REAL, PostgresDataType.REAL),
     CBRT("cbrt", PostgresDataType.REAL, PostgresDataType.REAL), CEILING("ceiling", PostgresDataType.REAL), //
     DEGREES("degrees", PostgresDataType.REAL), EXP("exp", PostgresDataType.REAL), LN("ln", PostgresDataType.REAL),
@@ -98,7 +98,7 @@ public enum PostgresFunctionWithUnknownResult {
     FLOOR("floor", PostgresDataType.REAL),
 
     // trigonometric functions - complete
-    // https://www.postgresql.org/docs/12/functions-math.html#FUNCTIONS-MATH-TRIG-TABLE
+    // https://www.postgresql.org/docs/13/functions-math.html#FUNCTIONS-MATH-TRIG-TABLE
     ACOS("acos", PostgresDataType.REAL), //
     ACOSD("acosd", PostgresDataType.REAL), //
     ASIN("asin", PostgresDataType.REAL), //
@@ -117,7 +117,7 @@ public enum PostgresFunctionWithUnknownResult {
     TAND("tand", PostgresDataType.REAL), //
 
     // hyperbolic functions - complete
-    // https://www.postgresql.org/docs/12/functions-math.html#FUNCTIONS-MATH-HYP-TABLE
+    // https://www.postgresql.org/docs/13/functions-math.html#FUNCTIONS-MATH-HYP-TABLE
     SINH("sinh", PostgresDataType.REAL), //
     COSH("cosh", PostgresDataType.REAL), //
     TANH("tanh", PostgresDataType.REAL), //
@@ -125,12 +125,12 @@ public enum PostgresFunctionWithUnknownResult {
     ACOSH("acosh", PostgresDataType.REAL), //
     ATANH("atanh", PostgresDataType.REAL), //
 
-    // https://www.postgresql.org/docs/devel/functions-binarystring.html
+    // https://www.postgresql.org/docs/13/functions-binarystring.html
     GET_BIT("get_bit", PostgresDataType.INT, PostgresDataType.TEXT, PostgresDataType.INT),
     GET_BYTE("get_byte", PostgresDataType.INT, PostgresDataType.TEXT, PostgresDataType.INT),
 
     // range functions
-    // https://www.postgresql.org/docs/devel/functions-range.html#RANGE-FUNCTIONS-TABLE
+    // https://www.postgresql.org/docs/13/functions-range.html#RANGE-FUNCTIONS-TABLE
     RANGE_LOWER("lower", PostgresDataType.INT, PostgresDataType.RANGE), //
     RANGE_UPPER("upper", PostgresDataType.INT, PostgresDataType.RANGE), //
     RANGE_ISEMPTY("isempty", PostgresDataType.BOOLEAN, PostgresDataType.RANGE), //
@@ -140,7 +140,7 @@ public enum PostgresFunctionWithUnknownResult {
     RANGE_UPPER_INF("upper_inf", PostgresDataType.BOOLEAN, PostgresDataType.RANGE), //
     RANGE_MERGE("range_merge", PostgresDataType.RANGE, PostgresDataType.RANGE, PostgresDataType.RANGE), //
 
-    // https://www.postgresql.org/docs/devel/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE
+    // https://www.postgresql.org/docs/13/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE
     GET_COLUMN_SIZE("get_column_size", PostgresDataType.INT, PostgresDataType.TEXT);
     // PG_DATABASE_SIZE("pg_database_size", PostgresDataType.INT, PostgresDataType.INT);
     // PG_SIZE_BYTES("pg_size_bytes", PostgresDataType.INT, PostgresDataType.TEXT);

--- a/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
@@ -206,6 +206,7 @@ public class PostgresAlterTableGenerator {
                     sb.append("DROP NOT NULL");
                     errors.add("is in a primary key");
                     errors.add("is an identity column");
+                    errors.add("is in index used as replica identity");
                 }
                 break;
             case ALTER_COLUMN_SET_STATISTICS:

--- a/src/sqlancer/postgres/gen/PostgresSetGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresSetGenerator.java
@@ -14,7 +14,7 @@ public final class PostgresSetGenerator {
     }
 
     private enum ConfigurationOption {
-        // https://www.postgresql.org/docs/11/runtime-config-wal.html
+        // https://www.postgresql.org/docs/13/runtime-config-wal.html
         // This parameter can only be set at server start.
         // WAL_LEVEL("wal_level", (r) -> Randomly.fromOptions("replica", "minimal", "logical")),
         // FSYNC("fsync", (r) -> Randomly.fromOptions(1, 0)),
@@ -37,7 +37,7 @@ public final class PostgresSetGenerator {
         // archive_mode
         // archive_command
         // archive_timeout
-        // https://www.postgresql.org/docs/11/runtime-config-statistics.html
+        // https://www.postgresql.org/docs/13/runtime-config-statistics.html
         // 19.9.1. Query and Index Statistics Collector
         TRACK_ACTIVITIES("track_activities", (r) -> Randomly.fromOptions(1, 0)),
         // track_activity_query_size
@@ -46,7 +46,7 @@ public final class PostgresSetGenerator {
         TRACK_FUNCTIONS("track_functions", (r) -> Randomly.fromOptions("'none'", "'pl'", "'all'")),
         // stats_temp_directory
         // TODO 19.9.2. Statistics Monitoring
-        // https://www.postgresql.org/docs/11/runtime-config-autovacuum.html
+        // https://www.postgresql.org/docs/13/runtime-config-autovacuum.html
         // all can only be set at server-conf time
         // 19.11. Client Connection Defaults
         VACUUM_FREEZE_TABLE_AGE("vacuum_freeze_table_age", (r) -> Randomly.fromOptions(0, 5, 10, 100, 500, 2000000000)),
@@ -60,7 +60,7 @@ public final class PostgresSetGenerator {
         // 19.13. Version and Platform Compatibility
         DEFAULT_WITH_OIDS("default_with_oids", (r) -> Randomly.fromOptions(0, 1)),
         SYNCHRONIZED_SEQSCANS("synchronize_seqscans", (r) -> Randomly.fromOptions(0, 1)),
-        // https://www.postgresql.org/docs/devel/runtime-config-query.html
+        // https://www.postgresql.org/docs/13/runtime-config-query.html
         ENABLE_BITMAPSCAN("enable_bitmapscan", (r) -> Randomly.fromOptions(1, 0)),
         ENABLE_GATHERMERGE("enable_gathermerge", (r) -> Randomly.fromOptions(1, 0)),
         ENABLE_HASHJOIN("enable_hashjoin", (r) -> Randomly.fromOptions(1, 0)),
@@ -78,7 +78,7 @@ public final class PostgresSetGenerator {
         ENABLE_SORT("enable_sort", (r) -> Randomly.fromOptions(1, 0)),
         ENABLE_TIDSCAN("enable_tidscan", (r) -> Randomly.fromOptions(1, 0)),
         // 19.7.2. Planner Cost Constants (complete as of March 2020)
-        // https://www.postgresql.org/docs/current/runtime-config-query.html#RUNTIME-CONFIG-QUERY-CONSTANTS
+        // https://www.postgresql.org/docs/13/runtime-config-query.html#RUNTIME-CONFIG-QUERY-CONSTANTS
         SEQ_PAGE_COST("seq_page_cost", (r) -> Randomly.fromOptions(0d, 0.00001, 0.05, 0.1, 1, 10, 10000)),
         RANDOM_PAGE_COST("random_page_cost", (r) -> Randomly.fromOptions(0d, 0.00001, 0.05, 0.1, 1, 10, 10000)),
         CPU_TUPLE_COST("cpu_tuple_cost", (r) -> Randomly.fromOptions(0d, 0.00001, 0.05, 0.1, 1, 10, 10000)),
@@ -94,7 +94,7 @@ public final class PostgresSetGenerator {
         JIT_OPTIMIZE_ABOVE_COST("jit_optimize_above_cost",
                 (r) -> Randomly.fromOptions(0, r.getLong(-1, Long.MAX_VALUE))),
         // 19.7.3. Genetic Query Optimizer (complete as of March 2020)
-        // https://www.postgresql.org/docs/current/runtime-config-query.html#RUNTIME-CONFIG-QUERY-GEQO
+        // https://www.postgresql.org/docs/13/runtime-config-query.html#RUNTIME-CONFIG-QUERY-GEQO
         GEQO("geqo", (r) -> Randomly.fromOptions(1, 0)),
         GEQO_THRESHOLD("geqo_threshold", (r) -> r.getInteger(2, 2147483647)),
         GEQO_EFFORT("geqo_effort", (r) -> r.getInteger(1, 10)),
@@ -103,7 +103,7 @@ public final class PostgresSetGenerator {
         GEQO_SELECTION_BIAS("geqo_selection_bias", (r) -> Randomly.fromOptions(1.5, 1.8, 2.0)),
         GEQO_SEED("geqo_seed", (r) -> Randomly.fromOptions(0, 0.5, 1)),
         // 19.7.4. Other Planner Options (complete as of March 2020)
-        // https://www.postgresql.org/docs/current/runtime-config-query.html#RUNTIME-CONFIG-QUERY-OTHER
+        // https://www.postgresql.org/docs/13/runtime-config-query.html#RUNTIME-CONFIG-QUERY-OTHER
         DEFAULT_STATISTICS_TARGET("default_statistics_target", (r) -> r.getInteger(1, 10000)),
         CONSTRAINT_EXCLUSION("constraint_exclusion", (r) -> Randomly.fromOptions("on", "off", "partition")),
         CURSOR_TUPLE_FRACTION("cursor_tuple_fraction",


### PR DESCRIPTION
As per discussionsin Issue #912 , SQLancer works fine with Postgres v13.

This commit updates the test harness to run against Postgres v13 (instead of v12 currently).

Also, the documentation links in README & code-comment URLs point to unreleased / outdated postgres documentation versions - For e.g. links were pointing to different postgres version documentations like devel (unreleased) / current / v12 or even v9.5 / v11 (both already EOL).

This commit ensures that all www.postgresql.org documentation links in the comments, point to the supported version of postgres (which as of this commit is v13). As and when we advance support for a more recent version, we should update the doc links accordingly too.