### PR TITLE
Add support for FULLTEXT indexes in MySQLIndexGenerator

### DIFF
--- a/src/sqlancer/mysql/MySQLSchema.java
+++ b/src/sqlancer/mysql/MySQLSchema.java
@@ -27,7 +27,7 @@ public class MySQLSchema extends AbstractSchema<MySQLGlobalState, MySQLTable> {
     private static final int NR_SCHEMA_READ_TRIES = 10;
 
     public enum MySQLDataType {
-        INT, VARCHAR, FLOAT, DOUBLE, DECIMAL;
+        INT, VARCHAR, FLOAT, DOUBLE, DECIMAL , TEXT, LONGTEXT;
 
         public static MySQLDataType getRandom(MySQLGlobalState globalState) {
             if (globalState.usesPQS()) {

--- a/src/sqlancer/mysql/ast/MySQLBinaryOperation.java
+++ b/src/sqlancer/mysql/ast/MySQLBinaryOperation.java
@@ -10,7 +10,7 @@ public class MySQLBinaryOperation implements MySQLExpression {
 
     private final MySQLExpression left;
     private final MySQLExpression right;
-    private final MySQLBinaryOperator op;
+    private final MySQLBinaryOperator binaryOperator;
 
     public enum MySQLBinaryOperator {
 
@@ -37,13 +37,13 @@ public class MySQLBinaryOperation implements MySQLExpression {
         private String textRepresentation;
 
         private static MySQLConstant applyBitOperation(MySQLConstant left, MySQLConstant right,
-                BinaryOperator<Long> op) {
+                BinaryOperator<Long> binaryOperator) {
             if (left.isNull() || right.isNull()) {
                 return MySQLConstant.createNullConstant();
             } else {
                 long leftVal = left.castAs(CastType.SIGNED).getInt();
                 long rightVal = right.castAs(CastType.SIGNED).getInt();
-                long value = op.apply(leftVal, rightVal);
+                long value = binaryOperator.apply(leftVal, rightVal);
                 return MySQLConstant.createUnsignedIntConstant(value);
             }
         }
@@ -64,10 +64,10 @@ public class MySQLBinaryOperation implements MySQLExpression {
 
     }
 
-    public MySQLBinaryOperation(MySQLExpression left, MySQLExpression right, MySQLBinaryOperator op) {
+    public MySQLBinaryOperation(MySQLExpression left, MySQLExpression right, MySQLBinaryOperator binaryOperator) {
         this.left = left;
         this.right = right;
-        this.op = op;
+        this.binaryOperator = binaryOperator;
     }
 
     @Override
@@ -96,7 +96,7 @@ public class MySQLBinaryOperation implements MySQLExpression {
             }
         }
 
-        return op.apply(leftExpected, rightExpected);
+        return binaryOperator.apply(leftExpected, rightExpected);
     }
 
     public MySQLExpression getLeft() {
@@ -104,7 +104,7 @@ public class MySQLBinaryOperation implements MySQLExpression {
     }
 
     public MySQLBinaryOperator getOp() {
-        return op;
+        return binaryOperator;
     }
 
     public MySQLExpression getRight() {

--- a/src/sqlancer/mysql/gen/datadef/MySQLIndexGenerator.java
+++ b/src/sqlancer/mysql/gen/datadef/MySQLIndexGenerator.java
@@ -40,17 +40,25 @@ public class MySQLIndexGenerator {
         ExpectedErrors errors = new ExpectedErrors();
         MySQLErrors.addExpressionErrors(errors);
         sb.append("CREATE ");
+        MySQLTable table = schema.getRandomTable();
         if (Randomly.getBoolean()) {
             // "FULLTEXT" TODO Column 'c3' cannot be part of FULLTEXT index
             // A SPATIAL index may only contain a geometrical type column
-            sb.append("UNIQUE ");
-            errors.add("Duplicate entry");
+
+            // A FULLTEXT index may only contain a FULLTEXT index
+            if (table.getColumns().stream().anyMatch(c -> c.getType() == MySQLDataType.TEXT
+                    || c.getType() == MySQLDataType.LONGTEXT)) {
+                sb.append("FULLTEXT ");
+            } else {
+                sb.append("UNIQUE ");
+                errors.add("Duplicate entry");
+            }
+
         }
         sb.append("INDEX ");
         sb.append(globalState.getSchema().getFreeIndexName());
         indexType();
         sb.append(" ON ");
-        MySQLTable table = schema.getRandomTable();
         MySQLExpressionGenerator gen = new MySQLExpressionGenerator(globalState).setColumns(table.getColumns());
         sb.append(table.getName());
         sb.append("(");


### PR DESCRIPTION

Currently, the code randomly chooses to add "UNIQUE" before the index, but many MySQL databases support FULLTEXT indexes. 
I checked if the table contains any TEXT or VARCHAR columns suitable for FULLTEXT indexing and 
I added a branch to randomly choose between UNIQUE and FULLTEXT indexes based on column types. 
if there is another better way to do that tell me


