### PR TITLE
Add Support for more String Data Types MySQL 

### DIFF
--- a/src/sqlancer/mysql/MySQLSchema.java
+++ b/src/sqlancer/mysql/MySQLSchema.java
@@ -139,12 +139,25 @@ public class MySQLSchema extends AbstractSchema<MySQLGlobalState, MySQLTable> {
         case "mediumint":
         case "int":
         case "bigint":
+        case "integer":
             return MySQLDataType.INT;
         case "varchar":
         case "tinytext":
         case "mediumtext":
         case "text":
         case "longtext":
+        case "char":
+        case "character":
+        case "binary":
+        case "varbinary":
+        case "tinyblob":
+        case "blob":
+        case "mediumblob":
+        case "longblob":
+        case "enum":
+        case "set":
+        case "national char":
+        case "national varchar":
             return MySQLDataType.VARCHAR;
         case "double":
             return MySQLDataType.DOUBLE;


### PR DESCRIPTION
According to MySQL documentation, additional data types need to be included, such as `INTEGER`, which falls under the numeric category, and `NATIONAL CHAR`, `NATIONAL VARCHAR`, `BLOB`, etc., which belong to the string category.
Any suggested improvements are much welcomed :rocket: :rocket: