### PR TITLE
Resolves #1089 update force_parallel_mode to debug_parallel_query

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresSetGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresSetGenerator.java
@@ -112,7 +112,7 @@ public final class PostgresSetGenerator {
         JIT("jit", (r) -> Randomly.fromOptions(1, 0)),
         JOIN_COLLAPSE_LIMIT("join_collapse_limit", (r) -> r.getInteger(1, Integer.MAX_VALUE)),
         PARALLEL_LEADER_PARTICIPATION("parallel_leader_participation", (r) -> Randomly.fromOptions(1, 0)),
-        DEBUG_PARALLEL_QUERY("debug_parallel_query",(r)->Randomly.fromOptions("off","on","regress")),
+        DEBUG_PARALLEL_QUERY("debug_parallel_query", (r) -> Randomly.fromOptions("off", "on", "regress")),
         PLAN_CACHE_MODE("plan_cache_mode",
                 (r) -> Randomly.fromOptions("auto", "force_generic_plan", "force_custom_plan"));
 

--- a/src/sqlancer/postgres/gen/PostgresSetGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresSetGenerator.java
@@ -112,7 +112,7 @@ public final class PostgresSetGenerator {
         JIT("jit", (r) -> Randomly.fromOptions(1, 0)),
         JOIN_COLLAPSE_LIMIT("join_collapse_limit", (r) -> r.getInteger(1, Integer.MAX_VALUE)),
         PARALLEL_LEADER_PARTICIPATION("parallel_leader_participation", (r) -> Randomly.fromOptions(1, 0)),
-        FORCE_PARALLEL_MODE("force_parallel_mode", (r) -> Randomly.fromOptions("off", "on", "regress")),
+        DEBUG_PARALLEL_QUERY("debug_parallel_query",(r)->Randomly.fromOptions("off","on","regress")),
         PLAN_CACHE_MODE("plan_cache_mode",
                 (r) -> Randomly.fromOptions("auto", "force_generic_plan", "force_custom_plan"));
 


### PR DESCRIPTION
this PR resolves #1089 
`force_parallel_mode ` is no longer supported in PostgreSQL v 16 and above, and it is already deprecated in PostgreSQL v15
in contrast, `debug_parallel_query` is supported in PostgreSQL latest version

Ref:
[force_parallel_mode](https://postgresqlco.nf/doc/en/param/force_parallel_mode/)
[degub_parallel_query](https://www.postgresql.org/docs/17/runtime-config-developer.html#GUC-DEBUG-PARALLEL-QUERY)
