### PR TITLE
refactor: Redundant boundary check in getInteger and getLong methods #1100

### DIFF
--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -443,19 +443,14 @@ public final class Randomly {
     }
 
     public int getInteger(int left, int right) {
-        if (left == right) {
-            return left;
-        }
         return (int) getLong(left, right);
     }
-
+        
     // TODO redundant?
     public long getLong(long left, long right) {
-        if (left == right) {
-            return left;
-        }
         return getNextLong(left, right);
-    }
+        }
+        
 
     public BigInteger getBigInteger(BigInteger left, BigInteger right) {
         if (left.equals(right)) {


### PR DESCRIPTION
This code should remove redundancy.