### PR TITLE
Remove redundant text.length() checks

### DIFF
--- a/src/sqlancer/mysql/ast/MySQLBinaryOperation.java
+++ b/src/sqlancer/mysql/ast/MySQLBinaryOperation.java
@@ -78,20 +78,20 @@ public class MySQLBinaryOperation implements MySQLExpression {
         /* workaround for https://bugs.mysql.com/bug.php?id=95960 */
         if (leftExpected.isString()) {
             String text = leftExpected.castAsString();
-            while ((text.startsWith(" ") || text.startsWith("\t")) && !text.isEmpty()) {
+            while (text.startsWith(" ") || text.startsWith("\t")) {
                 text = text.substring(1);
             }
-            if (!text.isEmpty() && (text.startsWith("\n") || text.startsWith("."))) {
+            if (text.startsWith("\n") || text.startsWith(".")) {
                 throw new IgnoreMeException();
             }
         }
 
         if (rightExpected.isString()) {
             String text = rightExpected.castAsString();
-            while ((text.startsWith(" ") || text.startsWith("\t")) && !text.isEmpty()) {
+            while (text.startsWith(" ") || text.startsWith("\t")) {
                 text = text.substring(1);
             }
-            if (!text.isEmpty() && (text.startsWith("\n") || text.startsWith("."))) {
+            if (text.startsWith("\n") || text.startsWith(".")) {
                 throw new IgnoreMeException();
             }
         }


### PR DESCRIPTION
Closes #1104 

Follow-up on Redundant Checks Removal

@mrigger I’ve updated the code by removing unnecessary text.length() > 0 and isEmpty() checks, since startsWith() already handles empty strings correctly.