### PR TITLE
[CockroachDB] Add 'excluded' support for 'ON CONFLICT' clause

### DIFF
--- a/src/sqlancer/cockroachdb/gen/CockroachDBInsertGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBInsertGenerator.java
@@ -81,8 +81,6 @@ public final class CockroachDBInsertGenerator {
             if (Randomly.getBoolean()) {
                 sb.append(" NOTHING ");
             } else {
-                // TODO: also support excluded. (see
-                // https://www.cockroachlabs.com/docs/stable/insert.html)
                 sb.append(" UPDATE SET ");
                 List<CockroachDBColumn> columns = table.getRandomNonEmptyColumnSubset();
                 int i = 0;
@@ -92,7 +90,12 @@ public final class CockroachDBInsertGenerator {
                     }
                     sb.append(c.getName());
                     sb.append(" = ");
-                    sb.append(CockroachDBVisitor.asString(gen.generateConstant(c.getType())));
+                    if (Randomly.getBoolean()) {
+                        sb.append(CockroachDBVisitor.asString(gen.generateConstant(c.getType())));
+                    } else {
+                        sb.append("excluded.");
+                        sb.append(c.getName());
+                    }
                 }
                 errors.add("UPSERT or INSERT...ON CONFLICT command cannot affect row a second time");
             }


### PR DESCRIPTION
# Support `EXCLUDED` Usage in `ON CONFLICT DO UPDATE` Clause in CockroachDB Insert Generator

## Description for the Issue

Our current implementation of the CockroachDB insert generator does not support the use of the `EXCLUDED` pseudo-table in the `ON CONFLICT` clause. When performing an upsert operation, the generated SQL always uses a constant value for updates instead of referencing the value that would have been inserted (using `EXCLUDED`). The updated file now optionally supports using `excluded.<column>` in the update clause, but this change needs to be reviewed and finalized.

## Proposed Changes

- Update the `CockroachDBInsertGenerator` to randomly choose between using a generated constant and referencing the `EXCLUDED` pseudo-table when constructing the `ON CONFLICT DO UPDATE SET` clause.
- Control the update strategy with a flag (or random boolean) so that both approaches are exercised during tests.

## Impact

- **Improved Test Coverage:** Incorporating `EXCLUDED` in generated queries will ensure that our tests cover CockroachDB’s upsert behavior more comprehensively.
- **Increased Realism:** Using `EXCLUDED` makes the generated SQL more similar to real-world UPSERT queries, improving the fidelity of our testing.

Feedback and suggestions for further improvements are welcome!
Resolves #1106 