### PR TITLE
Fix Javadoc annotations, expired reference links and addresses #1121

### DIFF
--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -154,12 +154,14 @@ public final class Randomly {
         return extractNrRandomColumns(columns, nr);
     }
 
+    @SafeVarargs
     public static <T> List<T> subset(int nr, @SuppressWarnings("unchecked") T... values) {
         List<T> list = new ArrayList<>();
         Collections.addAll(list, values);
         return extractNrRandomColumns(list, nr);
     }
 
+    @SafeVarargs
     public static <T> List<T> subset(@SuppressWarnings("unchecked") T... values) {
         List<T> list = new ArrayList<>(Arrays.asList(values));
         return subset(list);

--- a/src/sqlancer/mysql/gen/MySQLSetGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLSetGenerator.java
@@ -128,8 +128,8 @@ public class MySQLSetGenerator {
             this.scopes = scopes.clone();
         }
 
-        /*
-         * @see https://dev.mysql.com/doc/refman/8.0/en/switchable-optimizations.html
+        /**
+         * @see <a href="https://dev.mysql.com/doc/refman/8.0/en/switchable-optimizations.html">...</a>
          */
         private static String getOptimizerSwitchConfiguration(Randomly r) {
             StringBuilder sb = new StringBuilder();

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3TableGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3TableGenerator.java
@@ -157,7 +157,7 @@ public class SQLite3TableGenerator {
     }
 
     /**
-     * @see https://www.sqlite.org/foreignkeys.html
+     * @see <a href="https://www.sqlite.org/foreignkeys.html">Foreign Keys in SQLite</a>
      */
     private void addForeignKey() {
         assert globalState.getDbmsSpecificOptions().testForeignKeys;

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3ViewGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3ViewGenerator.java
@@ -67,7 +67,7 @@ public final class SQLite3ViewGenerator {
      * from the CREATE TABLE and CREATE VIEW statements. This is non-trivial, and currently not implemented. Rather, we
      * avoid generating expressions with an affinity or view.
      *
-     * @see http://sqlite.1065341.n5.nabble.com/Determining-column-collating-functions-td108157.html#a108159
+     * @see <a href="https://www.sqlite.org/datatype3.html">Datatypes and Affinity in SQLite</a>
      *
      * @param randomQuery
      *


### PR DESCRIPTION
Updated annotations according to best Javadoc practices and outdated documentation links

- Updated an outdated reference link(no more active) to a relevant SQLite documentation page.
- Replaced raw URLs with `<a>` tags for proper Javadoc rendering.