### PR TITLE
Bump duckdb version to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
     <dependency>
       <groupId>org.duckdb</groupId>
       <artifactId>duckdb_jdbc</artifactId>
-      <version>1.1.3</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.facebook.presto</groupId>

--- a/src/sqlancer/duckdb/DuckDBErrors.java
+++ b/src/sqlancer/duckdb/DuckDBErrors.java
@@ -115,7 +115,7 @@ public final class DuckDBErrors {
         errors.addAll(getFunctionErrors());
 
         errors.add("NOT NULL constraint failed");
-        errors.add("PRIMARY KEY or UNIQUE constraint violated");
+        errors.add("PRIMARY KEY or UNIQUE constraint violation");
         errors.add("Duplicate key");
         errors.add("can't be cast because the value is out of range for the destination type");
         errors.add("Could not convert string");

--- a/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
@@ -42,7 +42,7 @@ public final class DuckDBIndexGenerator {
         sb.append(")");
         errors.add("already exists!");
         if (globalState.getDbmsSpecificOptions().testRowid) {
-            errors.add("Cannot create an index on the rowid!");
+            errors.add("cannot create an index on the rowid");
         }
         return new SQLQueryAdapter(sb.toString(), errors, true);
     }


### PR DESCRIPTION
The only assertion errors I found were due to rewordings of error messages.

I ran these two tests and they passed:
```
mvn clean -Dtest=TestDuckDBTLP test
mvn clean -Dtest=TestDuckDBNoREC test
```

The [release notes](https://duckdb.org/2025/02/05/announcing-duckdb-120#breaking-changes) mention breaking changes to `map` and `list_reduce`, but I don't think sqlancer uses either.