### PR TITLE
Updated MariaDB Version from 11.3.2 to 11.7.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,7 +322,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mariadb:11.3.2
+        image: mariadb:11.7.2
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:


### PR DESCRIPTION
@mrigger @suyZhong ,

I was interested in contributing to this project, Supporting Automated Scripts for DBMS Deployment, for GSoC 2025. As you previously advised, before jumping into any major contributions, I am first focusing on understanding the databases available in SQLancer, modifying them, updating them, and ensuring compatibility.

As part of this, I have updated the MariaDB version in main.yml from 11.3.2 to 11.7.2 to maintain support for the latest stable version.

While testing this update in GitHub workflows, I encountered some test failures.

![SQLancer Errors](https://github.com/user-attachments/assets/e48ac197-a1f8-4721-a6d2-1c3676fbe1bb)

The MariaDB update is working fine, but I wanted to clarify whether I should address all the test errors appearing in main.yml (which I am capable of fixing) or if you’d prefer a separate approach for them.

Please review the changes and let me know how you'd like me to proceed.

Thank you
