### PR TITLE
[SQLite3] Optimize 'excluded' usage

### DIFF
--- a/src/sqlancer/sqlite3/gen/dml/SQLite3InsertGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3InsertGenerator.java
@@ -103,10 +103,8 @@ public class SQLite3InsertGenerator {
                         sb.append(
                                 SQLite3Visitor.asString(SQLite3ExpressionGenerator.getRandomLiteralValue(globalState)));
                     } else {
-                        if (Randomly.getBoolean()) {
-                            sb.append("excluded.");
-                        }
-                        sb.append(table.getRandomColumn().getName());
+                        sb.append("excluded.");
+                        sb.append(columns.get(i).getName());
                     }
 
                 }


### PR DESCRIPTION
# Ensure Consistent Use of Corresponding Excluded Columns in `ON CONFLICT UPDATE` Clause

## Description
The current implementation in the `ON CONFLICT UPDATE` clause randomly selects a column from the table when generating the update set expression. This randomness can lead to applying an excluded value from a column that may not share the same constraints (e.g., `nullable` vs. `non-nullable`) as the target column, potentially triggering constraint violations.

## Proposed Changes
- Modify the `UPDATE SET` clause to always reference the corresponding column from the excluded row (i.e., use `excluded.<column>` for the target column being updated) instead of randomly selecting a different column.
- Remove the randomness that currently allows a different column to be used, ensuring that the update expression consistently uses the correct matching column.

## Impact
- **Correctness:** Ensures that updates adhere to the column's constraints, reducing the risk of runtime errors due to constraint violations (e.g., non-nullable constraints or datatype mismatches).
- **Reduced Unsuccessful Queries:** Decreases the number of Unsuccessful queries generated by ensuring that the correct columns are used, minimizing errors due to constraint mismatches.

Feedback and suggestions for further improvements are welcome!
Resolves #1124 