### PR TITLE
Fix: Add final keyword to method parameters in DBMSExecutor constructor

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -396,8 +396,8 @@ public final class Main {
         private StateToReproduce stateToRepro;
         private final Randomly r;
 
-        public DBMSExecutor(DatabaseProvider<G, O, C> provider, MainOptions options, O dbmsSpecificOptions,
-                String databaseName, Randomly r) {
+        public DBMSExecutor(final DatabaseProvider<G, O, C> provider, final MainOptions options,
+                final O dbmsSpecificOptions, final String databaseName, final Randomly r) {
             this.provider = provider;
             this.options = options;
             this.databaseName = databaseName;


### PR DESCRIPTION
Fix: Add final keyword to method parameters in DBMSExecutor constructor

- Updated DBMSExecutor constructor parameters to be final
- Ensured code formatting: mvn net.revelc.code.formatter:formatter-maven-plugin:2.20.0:format
- Passed: mvn verify -DskipTests=true
