### PR TITLE
refactor: updated javadoc annotations, outdated reference links and closes #1121

### DIFF
--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -155,14 +155,14 @@ public final class Randomly {
     }
 
     @SafeVarargs
-    public static <T> List<T> subset(int nr, @SuppressWarnings("unchecked") T... values) {
+    public static <T> List<T> subset(int nr, T... values) {
         List<T> list = new ArrayList<>();
         Collections.addAll(list, values);
         return extractNrRandomColumns(list, nr);
     }
 
     @SafeVarargs
-    public static <T> List<T> subset(@SuppressWarnings("unchecked") T... values) {
+    public static <T> List<T> subset(T... values) {
         List<T> list = new ArrayList<>(Arrays.asList(values));
         return subset(list);
     }

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -154,12 +154,14 @@ public final class Randomly {
         return extractNrRandomColumns(columns, nr);
     }
 
+    @SafeVarargs
     public static <T> List<T> subset(int nr, @SuppressWarnings("unchecked") T... values) {
         List<T> list = new ArrayList<>();
         Collections.addAll(list, values);
         return extractNrRandomColumns(list, nr);
     }
 
+    @SafeVarargs
     public static <T> List<T> subset(@SuppressWarnings("unchecked") T... values) {
         List<T> list = new ArrayList<>(Arrays.asList(values));
         return subset(list);

--- a/src/sqlancer/common/query/Query.java
+++ b/src/sqlancer/common/query/Query.java
@@ -27,8 +27,21 @@ public abstract class Query<C extends SQLancerDBConnection> implements Loggable 
      */
     public abstract boolean couldAffectSchema();
 
+    /**
+     * Executes the query against the database.
+     *
+     * @param globalState the global state containing the database connection.
+     * @param fills optional parameters to fill placeholders in the query.
+     * @return true if the query executed successfully, false otherwise.
+     * @throws Exception if an error occurs during execution.
+     */
     public abstract <G extends GlobalState<?, ?, C>> boolean execute(G globalState, String... fills) throws Exception;
 
+    /**
+     * Gets the set of expected errors for this query.
+     *
+     * @return the expected errors.
+     */
     public abstract ExpectedErrors getExpectedErrors();
 
     @Override
@@ -36,21 +49,48 @@ public abstract class Query<C extends SQLancerDBConnection> implements Loggable 
         return getQueryString();
     }
 
+    /**
+     * Executes the query and returns the result set.
+     *
+     * @param globalState the global state containing the database connection.
+     * @param fills optional parameters to fill placeholders in the query.
+     * @return the result set.
+     * @throws Exception if an error occurs during execution.
+     */
     public <G extends GlobalState<?, ?, C>> SQLancerResultSet executeAndGet(G globalState, String... fills)
             throws Exception {
         throw new AssertionError();
     }
 
+    /**
+     * Executes the query and logs the query string.
+     *
+     * @param globalState the global state containing the database connection.
+     * @return true if the query executed successfully, false otherwise.
+     * @throws Exception if an error occurs during execution.
+     */
     public <G extends GlobalState<?, ?, C>> boolean executeLogged(G globalState) throws Exception {
         logQueryString(globalState);
         return execute(globalState);
     }
 
+    /**
+     * Executes the query, logs the query string, and returns the result set.
+     *
+     * @param globalState the global state containing the database connection.
+     * @return the result set.
+     * @throws Exception if an error occurs during execution.
+     */
     public <G extends GlobalState<?, ?, C>> SQLancerResultSet executeAndGetLogged(G globalState) throws Exception {
         logQueryString(globalState);
         return executeAndGet(globalState);
     }
 
+    /**
+     * Logs the query string if logging is enabled.
+     *
+     * @param globalState the global state containing the logger and options.
+     */
     private <G extends GlobalState<?, ?, C>> void logQueryString(G globalState) {
         if (globalState.getOptions().logEachSelect()) {
             globalState.getLogger().writeCurrent(getQueryString());

--- a/src/sqlancer/mysql/gen/MySQLSetGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLSetGenerator.java
@@ -128,8 +128,8 @@ public class MySQLSetGenerator {
             this.scopes = scopes.clone();
         }
 
-        /*
-         * @see https://dev.mysql.com/doc/refman/8.0/en/switchable-optimizations.html
+        /**
+         * @see <a href="https://dev.mysql.com/doc/refman/8.0/en/switchable-optimizations.html">...</a>
          */
         private static String getOptimizerSwitchConfiguration(Randomly r) {
             StringBuilder sb = new StringBuilder();

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3TableGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3TableGenerator.java
@@ -157,7 +157,7 @@ public class SQLite3TableGenerator {
     }
 
     /**
-     * @see https://www.sqlite.org/foreignkeys.html
+     * @see <a href="https://www.sqlite.org/foreignkeys.html">Foreign Keys in SQLite</a>
      */
     private void addForeignKey() {
         assert globalState.getDbmsSpecificOptions().testForeignKeys;

--- a/src/sqlancer/sqlite3/gen/ddl/SQLite3ViewGenerator.java
+++ b/src/sqlancer/sqlite3/gen/ddl/SQLite3ViewGenerator.java
@@ -67,7 +67,7 @@ public final class SQLite3ViewGenerator {
      * from the CREATE TABLE and CREATE VIEW statements. This is non-trivial, and currently not implemented. Rather, we
      * avoid generating expressions with an affinity or view.
      *
-     * @see http://sqlite.1065341.n5.nabble.com/Determining-column-collating-functions-td108157.html#a108159
+     * @see <a href="https://www.sqlite.org/datatype3.html">Datatypes and Affinity in SQLite</a>
      *
      * @param randomQuery
      *


### PR DESCRIPTION
Closes #1121 

* Fixes Issue#1121
* Updated outdated reference link(no more active) to a relevant SQLite documentation page.
* Replaced raw URLs with `<a>` tags for proper Javadoc rendering.
