### PR TITLE
update: update MySQL to 8.0.41 and removed deprecated keywords.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -406,7 +406,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:8.0.36
+        image: mysql:8.0.41
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -41,8 +41,7 @@ public class MySQLInsertGenerator {
     private SQLQueryAdapter generateReplace() {
         sb.append("REPLACE");
         if (Randomly.getBoolean()) {
-            sb.append(" ");
-            sb.append(Randomly.fromOptions("LOW_PRIORITY", "DELAYED"));
+            sb.append(" LOW_PRIORITY");
         }
         return generateInto();
 
@@ -52,7 +51,7 @@ public class MySQLInsertGenerator {
         sb.append("INSERT");
         if (Randomly.getBoolean()) {
             sb.append(" ");
-            sb.append(Randomly.fromOptions("LOW_PRIORITY", "DELAYED", "HIGH_PRIORITY"));
+            sb.append(Randomly.fromOptions("LOW_PRIORITY", "HIGH_PRIORITY"));
         }
         if (Randomly.getBoolean()) {
             sb.append(" IGNORE");


### PR DESCRIPTION
## Description
This PR updates the MySQL version to **8.0.41** and removes the deprecated `DELAYED` keyword from SQLancer. The `DELAYED` modifier was officially removed in MySQL 8.0, and its usage is no longer supported.

## Changes
1. **MySQL Version Update**:
   - Updated the MySQL Docker image to `mysql:8.0.41` in `main.yml` to benefit from the latest bug fixes, performance improvements, and security patches.

2. **Removal of `DELAYED` Keyword**:
   - Removed the `DELAYED` keyword from SQLancer as it is no longer supported in MySQL 8.0.
   - Verified that the removal does not impact existing functionality.


## Why This Change Is Necessary
- The `DELAYED` keyword was deprecated in MySQL 5.6 and removed in MySQL 8.0. Using it in MySQL 8.0.41 would result in errors or unexpected behavior.
- Upgrading to MySQL 8.0.41 ensures that we are using the latest stable version with improved performance, security, and bug fixes.
