### PR TITLE
Update: Add OrderBy in MySQLDeleteGenerator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -406,7 +406,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:8.0.36
+        image: mysql:8.0.41
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.7.3.0</version>
+        <version>4.9.2.0</version>
         <executions>
           <execution>
             <id>spotbugs</id>

--- a/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
@@ -52,14 +52,29 @@ public class MySQLDeleteGenerator {
                                                     */, "Truncated incorrect INTEGER value",
                 "Truncated incorrect DECIMAL value", "Data truncated for functional index"));
 
-        if(Randomly.getBoolean()) {
+        if (Randomly.getBoolean()) {
             HashSet<String> columnSet = new HashSet<>();
             sb.append(" ORDER BY ");
-            sb.append(randomTable.getRandomColumn().getName());
-            if (Randomly.getBoolean()) {
-                sb.append(" DESC");
-            }
 
+            int numColumns = 3; // TODO : Generate Columns Randomly
+
+            for (int i = 0; i < numColumns; i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+
+                String columnName;
+                do {
+                    columnName = randomTable.getRandomColumn().getName();
+                } while (columnSet.contains(columnName));
+
+                columnSet.add(columnName);
+                sb.append(columnName);
+
+                if (Randomly.getBoolean()) {
+                    sb.append(" DESC");
+                }
+            }
         }
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
@@ -1,6 +1,7 @@
 package sqlancer.mysql.gen;
 
 import java.util.Arrays;
+import java.util.HashSet;
 
 import sqlancer.Randomly;
 import sqlancer.common.query.ExpectedErrors;
@@ -50,7 +51,16 @@ public class MySQLDeleteGenerator {
                                                     * ignore as a workaround for https://bugs.mysql.com/bug.php?id=95997
                                                     */, "Truncated incorrect INTEGER value",
                 "Truncated incorrect DECIMAL value", "Data truncated for functional index"));
-        // TODO: support ORDER BY
+
+        if(Randomly.getBoolean()) {
+            HashSet<String> columnSet = new HashSet<>();
+            sb.append(" ORDER BY ");
+            sb.append(randomTable.getRandomColumn().getName());
+            if (Randomly.getBoolean()) {
+                sb.append(" DESC");
+            }
+
+        }
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -41,8 +41,7 @@ public class MySQLInsertGenerator {
     private SQLQueryAdapter generateReplace() {
         sb.append("REPLACE");
         if (Randomly.getBoolean()) {
-            sb.append(" ");
-            sb.append(Randomly.fromOptions("LOW_PRIORITY", "DELAYED"));
+            sb.append(" LOW_PRIORITY");
         }
         return generateInto();
 
@@ -52,7 +51,7 @@ public class MySQLInsertGenerator {
         sb.append("INSERT");
         if (Randomly.getBoolean()) {
             sb.append(" ");
-            sb.append(Randomly.fromOptions("LOW_PRIORITY", "DELAYED", "HIGH_PRIORITY"));
+            sb.append(Randomly.fromOptions("LOW_PRIORITY", "HIGH_PRIORITY"));
         }
         if (Randomly.getBoolean()) {
             sb.append(" IGNORE");

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -46,30 +46,18 @@ public class MySQLTableGenerator {
         ExpectedErrors errors = new ExpectedErrors();
 
         sb.append("CREATE");
+        // TODO support temporary tables in the schema
 
-        boolean isTemporary = false;
-        if (Randomly.getBoolean()) {
-            sb.append(" TEMPORARY");
-            isTemporary = true;
-        }
         sb.append(" TABLE");
-        if (Randomly.getBoolean() && isTemporary) { // Temporary table automatically deletes once session ends.
+        if (Randomly.getBoolean()) {
             sb.append(" IF NOT EXISTS");
         }
         sb.append(" ");
         sb.append(tableName);
         if (Randomly.getBoolean() && !schema.getDatabaseTables().isEmpty()) {
-
-            if (!isTemporary) {
-                sb.append(" LIKE ");
-                sb.append(schema.getRandomTable().getName());
-                return new SQLQueryAdapter(sb.toString(), true);
-            } else {
-                sb.append(" AS SELECT * FROM ");
-                sb.append(schema.getRandomTable().getName());
-                sb.append(" WHERE 1=0");
-                return new SQLQueryAdapter(sb.toString(), true);
-            }
+            sb.append(" LIKE ");
+            sb.append(schema.getRandomTable().getName());
+            return new SQLQueryAdapter(sb.toString(), true);
         } else {
             sb.append("(");
             for (int i = 0; i < 1 + Randomly.smallNumber(); i++) {

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -48,9 +48,9 @@ public class MySQLTableGenerator {
         sb.append("CREATE");
 
         boolean isTemporary = false;
-        if(Randomly.getBoolean()){
+        if (Randomly.getBoolean()) {
             sb.append(" TEMPORARY");
-            isTemporary=true;
+            isTemporary = true;
         }
         sb.append(" TABLE");
         if (Randomly.getBoolean() && isTemporary) { // Temporary table automatically deletes once session ends.
@@ -64,8 +64,7 @@ public class MySQLTableGenerator {
                 sb.append(" LIKE ");
                 sb.append(schema.getRandomTable().getName());
                 return new SQLQueryAdapter(sb.toString(), true);
-            }
-            else{
+            } else {
                 sb.append(" AS SELECT * FROM ");
                 sb.append(schema.getRandomTable().getName());
                 sb.append(" WHERE 1=0");

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -59,13 +59,14 @@ public class MySQLTableGenerator {
         sb.append(" ");
         sb.append(tableName);
         if (Randomly.getBoolean() && !schema.getDatabaseTables().isEmpty()) {
-            sb.append(" LIKE ");
+
             if (!isTemporary) {
+                sb.append(" LIKE ");
                 sb.append(schema.getRandomTable().getName());
                 return new SQLQueryAdapter(sb.toString(), true);
             }
             else{
-                sb.append("SELECT * FROM ");
+                sb.append(" AS SELECT * FROM ");
                 sb.append(schema.getRandomTable().getName());
                 sb.append(" WHERE 1=0");
                 return new SQLQueryAdapter(sb.toString(), true);

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -46,17 +46,30 @@ public class MySQLTableGenerator {
         ExpectedErrors errors = new ExpectedErrors();
 
         sb.append("CREATE");
-        // TODO support temporary tables in the schema
+
+        boolean isTemporary = false;
+        if(Randomly.getBoolean()){
+            sb.append(" TEMPORARY");
+            isTemporary=true;
+        }
         sb.append(" TABLE");
-        if (Randomly.getBoolean()) {
+        if (Randomly.getBoolean() && isTemporary) { // Temporary table automatically deletes once session ends.
             sb.append(" IF NOT EXISTS");
         }
         sb.append(" ");
         sb.append(tableName);
         if (Randomly.getBoolean() && !schema.getDatabaseTables().isEmpty()) {
             sb.append(" LIKE ");
-            sb.append(schema.getRandomTable().getName());
-            return new SQLQueryAdapter(sb.toString(), true);
+            if (!isTemporary) {
+                sb.append(schema.getRandomTable().getName());
+                return new SQLQueryAdapter(sb.toString(), true);
+            }
+            else{
+                sb.append("SELECT * FROM ");
+                sb.append(schema.getRandomTable().getName());
+                sb.append(" WHERE 1=0");
+                return new SQLQueryAdapter(sb.toString(), true);
+            }
         } else {
             sb.append("(");
             for (int i = 0; i < 1 + Randomly.smallNumber(); i++) {


### PR DESCRIPTION
- Add OrderBy in `MySQLDeleteGenerator`
- Remove usage of `DELAYED`

Resolves #1118 

I tried adding temporary table But after adding it I noticed that each
*   `CREATE TEMPORARY TABLE` got followed by `CREATE TABLE`  and query was generated on the basis of permanent table But temporary table shadows the permanent table. As both table have different attributes, It resulted in Error.

I didn't understand the cause of it.
Any guidance will be highly appreciated @mrigger @robins
