### PR TITLE
Unified Reducer Interface for Internal and External Reducers

### DIFF
--- a/src/sqlancer/ASTBasedReducer.java
+++ b/src/sqlancer/ASTBasedReducer.java
@@ -47,8 +47,8 @@ public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpeci
         this.newGlobalState = newGlobalState;
         this.reproducer = reproducer;
 
-        long maxReduceTime = state.getOptions().getMaxStatementReduceTime();
-        long maxReduceSteps = state.getOptions().getMaxStatementReduceSteps();
+        long maxReduceTime = state.getOptions().getMaxReduceTime();
+        long maxReduceSteps = state.getOptions().getMaxReduceSteps();
 
         List<Query<?>> initialBugInducingStatements = state.getState().getStatements();
         newGlobalState.getState().setStatements(new ArrayList<>(initialBugInducingStatements));

--- a/src/sqlancer/CReduceReducer.java
+++ b/src/sqlancer/CReduceReducer.java
@@ -1,0 +1,18 @@
+package sqlancer;
+
+public class CReduceReducer<G extends GlobalState<?, ?, ?>> implements Reducer<G> {
+
+    public CReduceReducer() {
+    }
+
+    @Override
+    public void reduce(G state, Reproducer<G> reproducer, G newGlobalState) throws Exception {
+
+        System.out.println("CReduceReducer is running...");
+
+        if (state == null || reproducer == null || newGlobalState == null) {
+            throw new IllegalArgumentException("Invalid state or reproducer");
+        }
+
+    }
+}

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -12,6 +12,9 @@ public class MainOptions {
     public static final int NO_SET_PORT = -1;
     public static final int NO_REDUCE_LIMIT = -1;
     public static final MainOptions DEFAULT_OPTIONS = new MainOptions();
+    public enum ReducerType {
+        NONE, STATEMENT, AST, CREDUCE
+    }
 
     @Parameter(names = { "--help", "-h" }, description = "Lists all supported options and commands", help = true)
     private boolean help; // NOPMD
@@ -123,23 +126,14 @@ public class MainOptions {
     @Parameter(names = "--database-prefix", description = "The prefix used for each database created")
     private String databasePrefix = "database"; // NOPMD
 
-    @Parameter(names = "--use-reducer", description = "EXPERIMENTAL Attempt to reduce queries using a simple reducer")
-    private boolean useReducer = false; // NOPMD
+    @Parameter(names = "--reducer-type", description = "Reducer strategy (NONE|STATEMENT|AST|CREDUCE|PERSES)")
+    private ReducerType reducerType = ReducerType.NONE; // NOPMD
 
-    @Parameter(names = "--reduce-ast", description = "EXPERIMENTAL perform AST reduction after statement reduction")
-    private boolean reduceAST = false; // NOPMD
+    @Parameter(names = "--reducer-max-steps", description = "EXPERIMENTAL Maximum steps the reducer will do")
+    private long maxReduceSteps = NO_REDUCE_LIMIT; // NOPMD
 
-    @Parameter(names = "--statement-reducer-max-steps", description = "EXPERIMENTAL Maximum steps the statement reducer will do")
-    private long maxStatementReduceSteps = NO_REDUCE_LIMIT; // NOPMD
-
-    @Parameter(names = "--statement-reducer-max-time", description = "EXPERIMENTAL Maximum time duration (secs) the AST-based reducer will do")
-    private long maxASTReduceTime = NO_REDUCE_LIMIT; // NOPMD
-
-    @Parameter(names = "--ast-reducer-max-steps", description = "EXPERIMENTAL Maximum steps the AST-based reducer will do")
-    private long maxASTReduceSteps = NO_REDUCE_LIMIT; // NOPMD
-
-    @Parameter(names = "--ast-reducer-max-time", description = "EXPERIMENTAL Maximum time duration (secs) the statement reducer will do")
-    private long maxStatementReduceTime = NO_REDUCE_LIMIT; // NOPMD
+    @Parameter(names = "--reducer-max-time", description = "EXPERIMENTAL Maximum time duration (secs) the reducer will do")
+    private long maxReduceTime = NO_REDUCE_LIMIT; // NOPMD
 
     @Parameter(names = "--validate-result-size-only", description = "Should validate result size only and skip comparing content of the result set ", arity = 1)
     private boolean validateResultSizeOnly = false; // NOPMD
@@ -304,28 +298,16 @@ public class MainOptions {
         return useConnectionTest;
     }
 
-    public boolean useReducer() {
-        return useReducer;
+    public ReducerType getReducerType() {
+        return reducerType;
     }
 
-    public boolean reduceAST() {
-        return reduceAST;
+    public long getMaxReduceSteps() {
+        return maxReduceSteps;
     }
 
-    public long getMaxStatementReduceSteps() {
-        return maxStatementReduceSteps;
-    }
-
-    public long getMaxStatementReduceTime() {
-        return maxStatementReduceTime;
-    }
-
-    public long getMaxASTReduceSteps() {
-        return maxASTReduceSteps;
-    }
-
-    public long getMaxASTReduceTime() {
-        return maxASTReduceTime;
+    public long getMaxReduceTime() {
+        return maxReduceTime;
     }
 
     public boolean validateResultSizeOnly() {

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -36,8 +36,8 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
     @Override
     public void reduce(G state, Reproducer<G> reproducer, G newGlobalState) throws Exception {
 
-        maxReduceTime = state.getOptions().getMaxStatementReduceTime();
-        maxReduceSteps = state.getOptions().getMaxStatementReduceSteps();
+        maxReduceTime = state.getOptions().getMaxReduceTime();
+        maxReduceSteps = state.getOptions().getMaxReduceSteps();
 
         List<Query<C>> knownToReproduceBugStatements = new ArrayList<>();
         for (Query<?> stat : state.getState().getStatements()) {


### PR DESCRIPTION
**Link to the issue:** Fixes #1138 

This PR introduces a unified `Reducer` interface that supports both internal and external reducers, simplifying the overall structure and making it easier to extend with external tools like C-Reduce.

**Key Changes:**

- Added `ReducerType` enum to unify reducer configuration
- Created `CReduceReducer` class that inherits from the unified `Reducer` interface (WIP implementation)
- Added CLI parameters: `--reducer-type` (NONE|STATEMENT|AST|CREDUCE), `--reducer-max-steps`, `--reducer-max-time`

**Next Steps:**

- [ ] Implement C-Reduce execution logic in `CReduceReducer`
- [ ] Add fault recovery mechanisms
- [ ] Update test cases (TestStatementReducer etc.)
- [ ] Improve documentation and usage examples

**Questions for Feedback:**

Before proceeding with the testing and full integration, I’d like to confirm the following:

1. Does the current approach to unifying the reducer interface make sense?
2. Are there any concerns or suggestions regarding the new option configuration or class structure?
3. Should I go ahead and modify existing test files based on this new unified structure?
<img width="892" alt="Unified Reducer" src="https://github.com/user-attachments/assets/87edd0d8-40a1-4ba9-baa5-7b3cf1bf2cdc" />