### PR TITLE
Missing Exception Handling in catch Block

### DIFF
--- a/src/sqlancer/ASTBasedReducer.java
+++ b/src/sqlancer/ASTBasedReducer.java
@@ -137,6 +137,11 @@ public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpeci
                 }
             } catch (Throwable ignoredException) {
 
+                newGlobalState.getLogger().logError(
+                    "Exception while checking if bug still triggers. State: " + newGlobalState.getState(),
+                    ignoredException
+                );
+  
             }
         }
         return false;


### PR DESCRIPTION
### **Description**
[#1147](https://github.com/sqlancer/sqlancer/issues/1147) 

fixes the issue of  ** exception handling** in the `catch` block of the `bugStillTriggers` method. Previously, exceptions were silently ignored, making it difficult to debug issues. This PR adds proper exception handling by logging the exception and providing meaningful context.