### PR TITLE
Add ORDER BY support for MySQLDeleteGenerator

### DIFF
--- a/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
@@ -1,12 +1,14 @@
 package sqlancer.mysql.gen;
 
 import java.util.Arrays;
+import java.util.List;
 
 import sqlancer.Randomly;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.mysql.MySQLErrors;
 import sqlancer.mysql.MySQLGlobalState;
+import sqlancer.mysql.MySQLSchema.MySQLColumn;
 import sqlancer.mysql.MySQLSchema.MySQLTable;
 import sqlancer.mysql.MySQLVisitor;
 
@@ -51,6 +53,31 @@ public class MySQLDeleteGenerator {
                                                     */, "Truncated incorrect INTEGER value",
                 "Truncated incorrect DECIMAL value", "Data truncated for functional index"));
         // TODO: support ORDER BY
+        if (Randomly.getBoolean() && !randomTable.getColumns().isEmpty()) {
+            sb.append(" ORDER BY ");
+
+            List<MySQLColumn> columns = randomTable.getColumns();
+            List<MySQLColumn> selectedColumns = Randomly.nonEmptySubset(columns);
+
+            boolean firstColumn = true;
+            for (MySQLColumn column : selectedColumns) {
+                if (!firstColumn) {
+                    sb.append(", ");
+                }
+                firstColumn = false;
+
+                sb.append(column.getName());
+
+                if (Randomly.getBoolean()) {
+                    if (Randomly.getBoolean()) {
+                        sb.append(" ASC");
+                    } else {
+                        sb.append(" DESC");
+                    }
+                }
+            }
+        }
+
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 


### PR DESCRIPTION
Added order by expression for MySQLDeleteGenerator
Tests ran: 

- [x] ```mvn package -DskipTests```
- [x] ```mvn formatter:format```
- [x] ```mvn verify -DskipTests=true```
- [x] ```mvn test -Dtest=TestMySQLPQS```
- [x] ```mvn test -Dtest=TestMySQLTLP```
- [x] ```mvn test -Dtest=TestMySQLCERT```

Closes #1118 
