### PR TITLE
Update: Add expected error for unsupported punch hole feature on NTFS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.7.3.0</version>
+        <version>4.9.2.0</version>
         <executions>
           <execution>
             <id>spotbugs</id>

--- a/src/sqlancer/mysql/gen/MySQLAlterTable.java
+++ b/src/sqlancer/mysql/gen/MySQLAlterTable.java
@@ -31,7 +31,7 @@ public class MySQLAlterTable {
     private enum Action {
         ALGORITHM, //
         CHECKSUM, //
-        COMPRESSION, //
+        COMPRESSION("Punch hole not supported by the filesystem or the tablespace page size is not large enough."), //
         DISABLE_ENABLE_KEYS("Data truncated for functional index"), /* ignore due to http://bugs.mysql.com/?id=96295 */
         DROP_COLUMN("Cannot drop column", "ALGORITHM=INPLACE is not supported.", "ALGORITHM=INSTANT is not supported.",
                 "Duplicate entry", "has a partitioning function dependency and cannot be dropped or renamed.",

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -96,6 +96,8 @@ public class MySQLTableGenerator {
         list.add("Too many keys specified; max 1 keys allowed");
         list.add("The total length of the partitioning fields is too large");
         list.add("Got error -1 - 'Unknown error -1' from storage engine");
+        list.add(
+                "Compression failed with the following error : Punch hole not supported by the filesystem or the tablespace page size is not large enough.");
     }
 
     private enum PartitionOptions {


### PR DESCRIPTION
Hi @mrigger 

I am getting this error quite often while running sqlancer with mysql
`Compression failed with the following error : Punch hole not supported by the filesystem or the tablespace page size is not large enough.`

After going through official documentation, I believe that this error should be added to `PotentialErrors` because it will generally occur in windows with default settings.


[**Hole Punch Size on Windows**](https://dev.mysql.com/doc/refman/8.4/en/innodb-page-compression.html#:~:text=Hole%20Punch%20Size%20on%20Windows,value%20of%2016K%20or%20greater)

System : Windows 10
File System : NTFS
Database : MySQL 8.0.41














