### PR TITLE
Resolves #1163 Add function that supports query index dynamically

### DIFF
--- a/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
@@ -23,7 +23,7 @@ public final class DuckDBIndexGenerator {
             sb.append("UNIQUE ");
         }
         sb.append("INDEX ");
-        sb.append(Randomly.fromOptions("i0", "i1", "i2", "i3", "i4")); // cannot query this information
+        sb.append(globalState.getSchema().getFreeIndexName());
         sb.append(" ON ");
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());


### PR DESCRIPTION
If I understand correctly, I just need to remove hard-coded index and use
```globalState.getSchema().getFreeIndexName()``` instead
Tests ran:
- [x] ```mvn package -DskipTests```
- [x] ```mvn formatter:format```
- [x] ```mvn verify -DskipTests=true```
- [x] ```mvn -Dtest=TestDuckDBTLP test```
- [x] ```mvn -Dtest=TestDuckDBNoREC test```

I don't think duckdb supports b-tree and hash index for the index type therefore I didn't include them in here