### PR TITLE
 add error handling in TiDBOracleFactory to prevent crashes

### DIFF
--- a/src/sqlancer/tidb/TiDBOracleFactory.java
+++ b/src/sqlancer/tidb/TiDBOracleFactory.java
@@ -50,12 +50,36 @@ public enum TiDBOracleFactory implements OracleFactory<TiDBProvider.TiDBGlobalSt
             TiDBExpressionGenerator gen = new TiDBExpressionGenerator(globalState);
             ExpectedErrors expectedErrors = ExpectedErrors.newErrors().with(TiDBErrors.getExpressionErrors()).build();
             CERTOracle.CheckedFunction<SQLancerResultSet, Optional<Long>> rowCountParser = (rs) -> {
-                String content = rs.getString(2);
-                return Optional.of((long) Double.parseDouble(content));
+                try {
+                    String content = rs.getString(2);
+                    if (content == null || content.trim().isEmpty()) {
+                        return Optional.empty();
+                    }
+
+                    String numStr = content.replaceAll("[^0-9.-]", "");
+                    if (!numStr.isEmpty()) {
+                        return Optional.of((long) Double.parseDouble(numStr));
+                    }
+                } catch (Exception e) {
+                    // Ignore parsing erors
+                }
+                return Optional.empty();
             };
             CERTOracle.CheckedFunction<SQLancerResultSet, Optional<String>> queryPlanParser = (rs) -> {
-                String operation = rs.getString(1).split("_")[0]; // Extract operation names for query plans
-                return Optional.of(operation);
+                try {
+                    String operation = rs.getString(1);
+                    if (operation == null || operation.trim().isEmpty()) {
+                        return Optional.empty();
+                    }
+                    // Extract operation name and handle TiDB's specific format
+                    String[] parts = operation.split("_");
+                    if (parts.length > 0) {
+                        return Optional.of(parts[0].toLowerCase());
+                    }
+                } catch (Exception e) {
+                    // Ignore parsing errors
+                }
+                return Optional.empty();
             };
 
             return new CERTOracle<>(globalState, gen, expectedErrors, rowCountParser, queryPlanParser);


### PR DESCRIPTION
this issue is related https://github.com/sqlancer/sqlancer/pull/1127 after crashes when adding unit tests to Randomly class 
and this change makes the rowCountParser more robust by:
Proper error handling
And makes the queryPlanParser more robust by:
Adding null/empty checks
Converting operation names to lowercase for consistency
Proper handling of TiDB's specific operation format