### PR TITLE
Update: Add Support for PostgreSQL v13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -467,7 +467,7 @@ jobs:
       - name: Set up PostgreSQL
         uses: harmon758/postgresql-action@v1.0.0
         with:
-          postgresql version: '12'
+          postgresql version: '13'
           postgresql user: 'sqlancer'
           postgresql password: 'sqlancer'
           postgresql db: 'test'

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.7.3.0</version>
+        <version>4.9.2.0</version>
         <executions>
           <execution>
             <id>spotbugs</id>

--- a/src/sqlancer/postgres/PostgresToStringVisitor.java
+++ b/src/sqlancer/postgres/PostgresToStringVisitor.java
@@ -331,9 +331,8 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
         visit(op.getString());
         sb.append(" SIMILAR TO ");
         visit(op.getSimilarTo());
-        if (op.getEscapeCharacter() != null) {
-            visit(op.getEscapeCharacter());
-        }
+        sb.append(" ESCAPE ");
+        visit(op.getEscapeCharacter());
         sb.append(")");
     }
 

--- a/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
@@ -212,9 +212,20 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
                     generateExpression(depth + 1, type), generateExpression(depth + 1, type), Randomly.getBoolean());
         case SIMILAR_TO:
             assert !expectedResult;
-            // TODO also generate the escape character
+            PostgresExpression escapeChar = PostgresConstant.createTextConstant("\\");
+            if (Randomly.getBoolean()) {
+                if (Randomly.getBoolean()) {
+                    escapeChar = PostgresConstant.createTextConstant(Randomly.fromList(Arrays.asList("0", "1", "2", "3",
+                            "4", "5", "6", "7", "8", "9", "!", "@", "#", "$", "%", "^", "&", "*", "/")));
+                } else {
+                    escapeChar = PostgresConstant.createTextConstant(
+                            Randomly.fromList(Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
+                                    "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z")));
+                }
+            }
             return new PostgresSimilarTo(generateExpression(depth + 1, PostgresDataType.TEXT),
-                    generateExpression(depth + 1, PostgresDataType.TEXT), null);
+                    generateExpression(depth + 1, PostgresDataType.TEXT), escapeChar);
+
         case POSIX_REGEX:
             assert !expectedResult;
             return new PostgresPOSIXRegularExpression(generateExpression(depth + 1, PostgresDataType.TEXT),


### PR DESCRIPTION
### Problem: 

1. In postgres v13, `SIMILAR TO .. ESCAPE NULL` explicitly returns `null` 
2. Improper implementation of `ESCAPE` in PostgresToStringVisitor.java

### Implementation
- Modified `SIMILAR TO ... ESCAPE NULL` to avoid explicit NULL returns in PostgreSQL v13
 -- In postgres v12 `ESCAPE NULL`
- Fixed usage of `SIMILAR TO` in the codebase

-- In previous version, `visit` function didn't append "ESCAPE" to the query.

`public void visit(PostgresSimilarTo op) {`
`        sb.append("(");`
 `       visit(op.getString());`
 `       sb.append(" SIMILAR TO ");`
 `       visit(op.getSimilarTo());`
 `       if (op.getEscapeCharacter() != null) {`
 `           visit(op.getEscapeCharacter());`
 `       }`
 `       sb.append(")");`
 `   }`


Partially resolves #912 

Reference : [Postgres Release Notes v13](https://www.postgresql.org/docs/13/release-13.html#id-1.11.6.26.4)
