### PR TITLE
[PostgreSQL] Optionally append "ONLY" to TRUNCATE statements

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresTruncateGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTruncateGenerator.java
@@ -18,10 +18,11 @@ public final class PostgresTruncateGenerator {
         if (Randomly.getBoolean()) {
             sb.append(" TABLE");
         }
-        // TODO partitions
-        // if (Randomly.getBoolean()) {
-        // sb.append(" ONLY");
-        // }
+
+        if (Randomly.getBoolean()) {
+            sb.append(" ONLY");
+        }
+
         sb.append(" ");
         sb.append(globalState.getSchema().getDatabaseTablesRandomSubsetNotEmpty().stream().map(t -> t.getName())
                 .collect(Collectors.joining(", ")));


### PR DESCRIPTION
#  Description

This PR updates the `PostgresTruncateGenerator` by adding an option to include the `ONLY` keyword in the generated TRUNCATE queries. With this change, the generator can now produce queries that truncate only the specified parent tables without affecting any inherited child tables. This enhancement ensures that the generator covers a wider range of PostgreSQL syntax variations.

# Proposed Changes

- **Keyword Addition:**  
  Introduced a new conditional branch that appends `ONLY` after `TRUNCATE`.

# Impact

- **Enhanced Test Coverage:**  
  By generating queries with the `ONLY` keyword, tests can now simulate scenarios where only the parent table is truncated, leaving inherited child tables unaffected.