### PR TITLE
add support for more MySQL aggregate functions and improve their handling.

### DIFF
--- a/src/sqlancer/mysql/ast/MySQLAggregate.java
+++ b/src/sqlancer/mysql/ast/MySQLAggregate.java
@@ -1,6 +1,7 @@
 package sqlancer.mysql.ast;
 
 import java.util.List;
+
 import sqlancer.Randomly;
 
 public class MySQLAggregate implements MySQLExpression {
@@ -66,7 +67,6 @@ public class MySQLAggregate implements MySQLExpression {
     public void setWindowSpecification(String windowSpec) {
         this.windowSpecification = windowSpec;
     }
-
 
     public boolean isWindowFunction() {
         return windowSpecification != null;

--- a/src/sqlancer/mysql/ast/MySQLAggregate.java
+++ b/src/sqlancer/mysql/ast/MySQLAggregate.java
@@ -1,6 +1,7 @@
 package sqlancer.mysql.ast;
 
 import java.util.List;
+import sqlancer.Randomly;
 
 public class MySQLAggregate implements MySQLExpression {
 
@@ -12,7 +13,11 @@ public class MySQLAggregate implements MySQLExpression {
         // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_min.
         MIN("MIN", null, false), MIN_DISTINCT("MIN", "DISTINCT", false),
         // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_max.
-        MAX("MAX", null, false), MAX_DISTINCT("MAX", "DISTINCT", false);
+        MAX("MAX", null, false), MAX_DISTINCT("MAX", "DISTINCT", false),
+        // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_avg.
+        AVG("AVG", null, false), AVG_DISTINCT("AVG", "DISTINCT", false),
+        // See https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_group-concat.
+        GROUP_CONCAT("GROUP_CONCAT", null, true), GROUP_CONCAT_DISTINCT("GROUP_CONCAT", "DISTINCT", true);
 
         private final String name;
         private final String option;
@@ -35,10 +40,15 @@ public class MySQLAggregate implements MySQLExpression {
         public boolean isVariadic() {
             return this.isVariadic;
         }
+
+        public static MySQLAggregateFunction getRandom() {
+            return Randomly.fromOptions(values());
+        }
     }
 
     private final List<MySQLExpression> exprs;
     private final MySQLAggregateFunction func;
+    private String windowSpecification;
 
     public MySQLAggregate(List<MySQLExpression> exprs, MySQLAggregateFunction func) {
         this.exprs = exprs;
@@ -51,5 +61,14 @@ public class MySQLAggregate implements MySQLExpression {
 
     public MySQLAggregateFunction getFunc() {
         return func;
+    }
+
+    public void setWindowSpecification(String windowSpec) {
+        this.windowSpecification = windowSpec;
+    }
+
+
+    public boolean isWindowFunction() {
+        return windowSpecification != null;
     }
 }


### PR DESCRIPTION
** I've made to improve the handling of aggregate functions in MySQL queries:**
1. Added support for window functions:
  Added a new generateWindowSpecification() method that creates window function specifications
  Window specifications can include:
  PARTITION BY clause
  ORDER BY clause
  Frame clause (ROWS or RANGE based)

2. Enhanced aggregate function handling:
  Added tracking of whether a window function has been generated
  Randomly decides whether to add a window specification to aggregate functions

 3. Improved query generation:
  Better handling of GROUP BY clauses when aggregates are present
  Proper tracking of columns for grouping
  Support for HAVING clauses with aggregate conditions

Example for generated queries now 
 Query with Both Aggregates and Window Functions
`SELECT 
    columnn1,
    COUNT(DISTINCT column2),
    GROUP_CONCAT(column3) OVER (PARTITION BY column4),
    MAX(column5) OVER (ORDER BY column6 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
FROM table1
GROUP BY column7, column8
HAVING SUM(column9) > 1000
ORDER BY column10 ASC
LIMIT 20;`
