### PR TITLE
improve handling optimizer switches in MySQL

### DIFF
--- a/src/sqlancer/mysql/gen/MySQLSetGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLSetGenerator.java
@@ -164,6 +164,16 @@ public class MySQLSetGenerator {
                 }
             }
 
+            if (MySQLBugs.bug112242) {
+                selectedOptions.remove("use_invisible_indexes");
+            }
+            if (MySQLBugs.bug112243) {
+                selectedOptions.remove("subquery_to_derived");
+            }
+            if (MySQLBugs.bug112264) {
+                selectedOptions.remove("block_nested_loop");
+            }
+
             sb.append(selectedOptions.stream().map(s -> s + "=" + Randomly.fromOptions("on", "off", "default"))
                     .collect(Collectors.joining(",")));
             sb.append("'");


### PR DESCRIPTION
**I have improved Optimizer switch organization in MySQL:**
by grouping optimizer switches by category (index, join, subquery, other)
and adding systematic handling of known bugs that may occur cause of wrong configurations.

There is more handling to do in Optimizer Switch in MySQL 