### PR TITLE
Update: Add "Float" and "Real" data type support for Postgres BinaryArithmeticOperation

### DIFF
--- a/src/sqlancer/postgres/ast/PostgresBinaryArithmeticOperation.java
+++ b/src/sqlancer/postgres/ast/PostgresBinaryArithmeticOperation.java
@@ -16,35 +16,58 @@ public class PostgresBinaryArithmeticOperation extends BinaryOperatorNode<Postgr
         ADDITION("+") {
             @Override
             public PostgresConstant apply(PostgresConstant left, PostgresConstant right) {
-                return applyBitOperation(left, right, (l, r) -> l + r);
+                if (left.isReal() && right.isReal()) {
+                    return applyRealOperation(left, right, (l, r) -> l + r);
+                } else if (left.isFloat() && right.isFloat()) {
+                    return applyFloatOperation(left, right, (l, r) -> l + r);
+                } else {
+                    return applyIntOperation(left, right, (l, r) -> l + r);
+                }
             }
 
         },
         SUBTRACTION("-") {
             @Override
             public PostgresConstant apply(PostgresConstant left, PostgresConstant right) {
-                return applyBitOperation(left, right, (l, r) -> l - r);
+                if (left.isReal() && right.isReal()) {
+                    return applyRealOperation(left, right, (l, r) -> l - r);
+                } else if (left.isFloat() && right.isFloat()) {
+                    return applyFloatOperation(left, right, (l, r) -> l - r);
+                } else {
+                    return applyIntOperation(left, right, (l, r) -> l - r);
+                }
             }
         },
         MULTIPLICATION("*") {
             @Override
             public PostgresConstant apply(PostgresConstant left, PostgresConstant right) {
-                return applyBitOperation(left, right, (l, r) -> l * r);
+                if (left.isReal() && right.isReal()) {
+                    return applyRealOperation(left, right, (l, r) -> l * r);
+                } else if (left.isFloat() && right.isFloat()) {
+                    return applyFloatOperation(left, right, (l, r) -> l * r);
+                } else {
+                    return applyIntOperation(left, right, (l, r) -> l * r);
+                }
             }
         },
         DIVISION("/") {
 
             @Override
             public PostgresConstant apply(PostgresConstant left, PostgresConstant right) {
-                return applyBitOperation(left, right, (l, r) -> r == 0 ? -1 : l / r);
-
+                if (left.isReal() && right.isReal()) {
+                    return applyRealOperation(left, right, (l, r) -> r == 0 ? -1 : l / r);
+                } else if (left.isFloat() && right.isFloat()) {
+                    return applyFloatOperation(left, right, (l, r) -> r == 0 ? -1 : l / r);
+                } else {
+                    return applyIntOperation(left, right, (l, r) -> r == 0 ? -1 : l / r);
+                }
             }
 
         },
         MODULO("%") {
             @Override
             public PostgresConstant apply(PostgresConstant left, PostgresConstant right) {
-                return applyBitOperation(left, right, (l, r) -> r == 0 ? -1 : l % r);
+                return applyIntOperation(left, right, (l, r) -> r == 0 ? -1 : l % r);
 
             }
         },
@@ -57,7 +80,7 @@ public class PostgresBinaryArithmeticOperation extends BinaryOperatorNode<Postgr
 
         private String textRepresentation;
 
-        private static PostgresConstant applyBitOperation(PostgresConstant left, PostgresConstant right,
+        private static PostgresConstant applyIntOperation(PostgresConstant left, PostgresConstant right,
                 BinaryOperator<Long> op) {
             if (left.isNull() || right.isNull()) {
                 return PostgresConstant.createNullConstant();
@@ -66,6 +89,30 @@ public class PostgresBinaryArithmeticOperation extends BinaryOperatorNode<Postgr
                 long rightVal = right.cast(PostgresDataType.INT).asInt();
                 long value = op.apply(leftVal, rightVal);
                 return PostgresConstant.createIntConstant(value);
+            }
+        }
+
+        private static PostgresConstant applyFloatOperation(PostgresConstant left, PostgresConstant right,
+                BinaryOperator<Float> op) {
+            if (left.isNull() || right.isNull()) {
+                return PostgresConstant.createNullConstant();
+            } else {
+                float leftVal = left.cast(PostgresDataType.FLOAT).asFloat();
+                float rightVal = right.cast(PostgresDataType.FLOAT).asFloat();
+                float value = op.apply(leftVal, rightVal);
+                return PostgresConstant.createFloatConstant(value);
+            }
+        }
+
+        private static PostgresConstant applyRealOperation(PostgresConstant left, PostgresConstant right,
+                BinaryOperator<Double> op) {
+            if (left.isNull() || right.isNull()) {
+                return PostgresConstant.createNullConstant();
+            } else {
+                double leftVal = left.cast(PostgresDataType.REAL).asReal();
+                double rightVal = right.cast(PostgresDataType.REAL).asReal();
+                double value = op.apply(leftVal, rightVal);
+                return PostgresConstant.createDoubleConstant(value);
             }
         }
 

--- a/src/sqlancer/postgres/ast/PostgresConstant.java
+++ b/src/sqlancer/postgres/ast/PostgresConstant.java
@@ -74,6 +74,11 @@ public abstract class PostgresConstant implements PostgresExpression {
                 return PostgresConstant.createIntConstant(value ? 1 : 0);
             case TEXT:
                 return PostgresConstant.createTextConstant(value ? "true" : "false");
+            case REAL:
+                return PostgresConstant.createDoubleConstant(value ? 1 : 0);
+            case FLOAT:
+                return PostgresConstant.createFloatConstant(value ? 1 : 0);
+
             default:
                 return null;
             }
@@ -211,6 +216,18 @@ public abstract class PostgresConstant implements PostgresExpression {
                 }
             case TEXT:
                 return this;
+            case REAL:
+                try {
+                    return PostgresConstant.createDoubleConstant(Double.parseDouble(s));
+                } catch (NumberFormatException e) {
+                    return PostgresConstant.createDoubleConstant(-1);
+                }
+            case FLOAT:
+                try {
+                    return PostgresConstant.createFloatConstant(Float.parseFloat(s));
+                } catch (NumberFormatException e) {
+                    return PostgresConstant.createFloatConstant(-1);
+                }
             default:
                 return null;
             }
@@ -306,6 +323,11 @@ public abstract class PostgresConstant implements PostgresExpression {
                 return this;
             case TEXT:
                 return PostgresConstant.createTextConstant(String.valueOf(val));
+            case FLOAT:
+                return PostgresConstant.createFloatConstant(val);
+            case REAL:
+                return PostgresConstant.createDoubleConstant(val);
+
             default:
                 return null;
             }
@@ -363,6 +385,18 @@ public abstract class PostgresConstant implements PostgresExpression {
         throw new UnsupportedOperationException(this.toString());
     }
 
+    public double asReal() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
+    public boolean isReal() {
+        return false;
+    }
+
+    public float asFloat() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
     public boolean isBoolean() {
         return false;
     }
@@ -370,6 +404,10 @@ public abstract class PostgresConstant implements PostgresExpression {
     public abstract PostgresConstant isEquals(PostgresConstant rightVal);
 
     public boolean isInt() {
+        return false;
+    }
+
+    public boolean isFloat() {
         return false;
     }
 
@@ -458,6 +496,16 @@ public abstract class PostgresConstant implements PostgresExpression {
         }
 
         @Override
+        public float asFloat() {
+            return val;
+        }
+
+        @Override
+        public boolean isFloat() {
+            return true;
+        }
+
+        @Override
         public String getTextRepresentation() {
             if (Double.isFinite(val)) {
                 return String.valueOf(val);
@@ -471,6 +519,25 @@ public abstract class PostgresConstant implements PostgresExpression {
             return PostgresDataType.FLOAT;
         }
 
+        @Override
+        public PostgresConstant cast(PostgresDataType type) {
+            switch (type) {
+            case BOOLEAN:
+                return PostgresConstant.createBooleanConstant(val != 0f);
+            case INT:
+                return PostgresConstant.createIntConstant((int) val);
+            case TEXT:
+                return PostgresConstant.createTextConstant(String.valueOf(val));
+            case FLOAT:
+                return this;
+            case REAL:
+                return PostgresConstant.createDoubleConstant(val);
+
+            default:
+                return null;
+            }
+
+        }
     }
 
     public static class DoubleConstant extends PostgresConstantBase {
@@ -482,6 +549,16 @@ public abstract class PostgresConstant implements PostgresExpression {
         }
 
         @Override
+        public double asReal() {
+            return val;
+        }
+
+        @Override
+        public boolean isReal() {
+            return true;
+        }
+
+        @Override
         public String getTextRepresentation() {
             if (Double.isFinite(val)) {
                 return String.valueOf(val);
@@ -495,6 +572,24 @@ public abstract class PostgresConstant implements PostgresExpression {
             return PostgresDataType.FLOAT;
         }
 
+        @Override
+        public PostgresConstant cast(PostgresDataType type) {
+            switch (type) {
+            case BOOLEAN:
+                return PostgresConstant.createBooleanConstant(val != 0.0);
+            case INT:
+                return PostgresConstant.createIntConstant((int) val);
+            case TEXT:
+                return PostgresConstant.createTextConstant(String.valueOf(val));
+            case FLOAT:
+                return this;
+            case REAL:
+                return PostgresConstant.createDoubleConstant(val);
+
+            default:
+                return null;
+            }
+        }
     }
 
     public static class BitConstant extends PostgresConstantBase {

--- a/src/sqlancer/postgres/ast/PostgresFunction.java
+++ b/src/sqlancer/postgres/ast/PostgresFunction.java
@@ -210,6 +210,66 @@ public class PostgresFunction implements PostgresExpression {
                 return true;
             }
 
+        },
+        CEIL(1, "ceil") {
+            @Override
+            public PostgresConstant apply(PostgresConstant[] evaluatedArgs, PostgresExpression... args) {
+                if (evaluatedArgs[0].isNull()) {
+                    return PostgresConstant.createNullConstant();
+                }
+                double value = evaluatedArgs[0].cast(PostgresDataType.REAL).asReal();
+                return PostgresConstant.createDoubleConstant(Math.ceil(value));
+            }
+
+            @Override
+            public boolean supportsReturnType(PostgresDataType type) {
+                return type == PostgresDataType.REAL;
+            }
+
+            @Override
+            public PostgresDataType[] getInputTypesForReturnType(PostgresDataType returnType, int nrArguments) {
+                return new PostgresDataType[] { PostgresDataType.REAL };
+            }
+        },
+        FLOOR(1, "floor") {
+            @Override
+            public PostgresConstant apply(PostgresConstant[] evaluatedArgs, PostgresExpression... args) {
+                if (evaluatedArgs[0].isNull()) {
+                    return PostgresConstant.createNullConstant();
+                }
+                double value = evaluatedArgs[0].cast(PostgresDataType.REAL).asReal();
+                return PostgresConstant.createDoubleConstant(Math.floor(value));
+            }
+
+            @Override
+            public boolean supportsReturnType(PostgresDataType type) {
+                return type == PostgresDataType.REAL;
+            }
+
+            @Override
+            public PostgresDataType[] getInputTypesForReturnType(PostgresDataType returnType, int nrArguments) {
+                return new PostgresDataType[] { PostgresDataType.REAL };
+            }
+        },
+        ROUND(1, "round") {
+            @Override
+            public PostgresConstant apply(PostgresConstant[] evaluatedArgs, PostgresExpression... args) {
+                if (evaluatedArgs[0].isNull()) {
+                    return PostgresConstant.createNullConstant();
+                }
+                double value = evaluatedArgs[0].cast(PostgresDataType.REAL).asReal();
+                return PostgresConstant.createDoubleConstant(Math.round(value));
+            }
+
+            @Override
+            public boolean supportsReturnType(PostgresDataType type) {
+                return type == PostgresDataType.REAL;
+            }
+
+            @Override
+            public PostgresDataType[] getInputTypesForReturnType(PostgresDataType returnType, int nrArguments) {
+                return new PostgresDataType[] { PostgresDataType.REAL };
+            }
         };
 
         private String functionName;

--- a/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresExpressionGenerator.java
@@ -333,6 +333,7 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
                 return generateTextExpression(depth);
             case DECIMAL:
             case REAL:
+                return generateDoubleExpression(depth);
             case FLOAT:
             case MONEY:
             case INET:
@@ -526,6 +527,30 @@ public class PostgresExpressionGenerator implements ExpressionGenerator<Postgres
         case BINARY_ARITHMETIC_EXPRESSION:
             return new PostgresBinaryArithmeticOperation(generateExpression(depth + 1, PostgresDataType.INT),
                     generateExpression(depth + 1, PostgresDataType.INT), PostgresBinaryOperator.getRandom());
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    private enum DoubleExpression {
+        UNARY_OPERATION, FUNCTION, CAST, BINARY_ARITHMETIC_EXPRESSION
+    }
+
+    private PostgresExpression generateDoubleExpression(int depth) {
+        DoubleExpression option;
+        option = Randomly.fromOptions(DoubleExpression.values());
+        switch (option) {
+        case CAST:
+            return new PostgresCastOperation(generateExpression(depth + 1), getCompoundDataType(PostgresDataType.REAL));
+        case UNARY_OPERATION:
+            PostgresExpression floatExpression = generateExpression(depth + 1, PostgresDataType.FLOAT);
+            return new PostgresPrefixOperation(floatExpression,
+                    Randomly.getBoolean() ? PrefixOperator.UNARY_PLUS : PrefixOperator.UNARY_MINUS);
+        case FUNCTION:
+            return generateFunction(depth + 1, PostgresDataType.REAL);
+        case BINARY_ARITHMETIC_EXPRESSION:
+            return new PostgresBinaryArithmeticOperation(generateExpression(depth + 1, PostgresDataType.REAL),
+                    generateExpression(depth + 1, PostgresDataType.REAL), PostgresBinaryOperator.getRandom());
         default:
             throw new AssertionError();
         }


### PR DESCRIPTION
Hi @mrigger 
Previously, Only Integer data type is supported as discussed in issue #630 

I have added the support for
- Real data type
- Float data type

Resolves #630