### PR TITLE
[PostgreSQL]TODO: Add Char and Text for "TEXT" datatype

### DIFF
--- a/src/sqlancer/postgres/PostgresToStringVisitor.java
+++ b/src/sqlancer/postgres/PostgresToStringVisitor.java
@@ -237,7 +237,7 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
             break;
         case TEXT:
             String opt = Randomly.fromOptions("VARCHAR", "TEXT", "CHAR");
-            if(opt.equals("TEXT")){
+            if (opt.equals("TEXT")) {
                 typeModifierAllowed = false;
             }
             sb.append(opt);

--- a/src/sqlancer/postgres/PostgresToStringVisitor.java
+++ b/src/sqlancer/postgres/PostgresToStringVisitor.java
@@ -227,16 +227,20 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
 
     private void appendType(PostgresCastOperation cast) {
         PostgresCompoundDataType compoundType = cast.getCompoundType();
+        boolean typeModifierAllowed = true;
         switch (compoundType.getDataType()) {
         case BOOLEAN:
             sb.append("BOOLEAN");
             break;
-        case INT: // TODO support also other int types
-            sb.append("INT");
+        case INT:
+            sb.append(Randomly.fromOptions("INT", "SMALLINT", "BIGINT"));
             break;
         case TEXT:
-            // TODO: append TEXT, CHAR
-            sb.append(Randomly.fromOptions("VARCHAR"));
+            String opt = Randomly.fromOptions("VARCHAR", "TEXT", "CHAR");
+            if(opt.equals("TEXT")){
+                typeModifierAllowed = false;
+            }
+            sb.append(opt);
             break;
         case REAL:
             sb.append("FLOAT");
@@ -268,7 +272,7 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
             throw new AssertionError(cast.getType());
         }
         Optional<Integer> size = compoundType.getSize();
-        if (size.isPresent()) {
+        if (size.isPresent() && typeModifierAllowed) {
             sb.append("(");
             sb.append(size.get());
             sb.append(")");

--- a/src/sqlancer/postgres/PostgresToStringVisitor.java
+++ b/src/sqlancer/postgres/PostgresToStringVisitor.java
@@ -233,7 +233,7 @@ public final class PostgresToStringVisitor extends ToStringVisitor<PostgresExpre
             sb.append("BOOLEAN");
             break;
         case INT:
-            sb.append(Randomly.fromOptions("INT", "SMALLINT", "BIGINT"));
+            sb.append(Randomly.fromOptions("INT", "BIGINT"));
             break;
         case TEXT:
             String opt = Randomly.fromOptions("VARCHAR", "TEXT", "CHAR");


### PR DESCRIPTION
- Completed a TODO task for adding `CHAR` and `TEXT` to postgres.
- Added a flag to handle because `TEXT` doesn't support type modifier