### PR TITLE
Fixes a Bug in sqlancer

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -792,7 +792,6 @@ public final class Main {
                 lastNrQueries = currentNrQueries;
                 lastNrDbs = currentNrDbs;
             }
-        }, 5, 5, TimeUnit.SECONDS);
+        }, 10, 10, TimeUnit.SECONDS);
     }
-
 }

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -167,7 +167,7 @@ public final class Main {
 
         public FileWriter getCurrentFileWriter() {
             if (!logEachSelect) {
-                throw new UnsupportedOperationException();
+                return null; // Instead of throwing an exception
             }
             if (currentFileWriter == null) {
                 try {
@@ -177,7 +177,7 @@ public final class Main {
                 }
             }
             return currentFileWriter;
-        }
+        }        
 
         public FileWriter getQueryPlanFileWriter() {
             if (!logQueryPlan) {
@@ -209,16 +209,18 @@ public final class Main {
 
         public void writeCurrent(StateToReproduce state) {
             if (!logEachSelect) {
-                throw new UnsupportedOperationException();
+                return; // Skip logging if logEachSelect is false
             }
-            printState(getCurrentFileWriter(), state);
-            try {
-                currentFileWriter.flush();
-
-            } catch (IOException e) {
-                e.printStackTrace();
+            FileWriter writer = getCurrentFileWriter();
+            if (writer != null) {
+                printState(writer, state);
+                try {
+                    writer.flush();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
-        }
+        }        
 
         public void writeCurrent(String input) {
             write(databaseProvider.getLoggableFactory().createLoggable(input));
@@ -230,16 +232,18 @@ public final class Main {
 
         private void write(Loggable loggable) {
             if (!logEachSelect) {
-                throw new UnsupportedOperationException();
+                return; // Skip writing if logging is disabled
             }
-            try {
-                getCurrentFileWriter().write(loggable.getLogString());
-
-                currentFileWriter.flush();
-            } catch (IOException e) {
-                throw new AssertionError();
+            FileWriter writer = getCurrentFileWriter();
+            if (writer != null) {
+                try {
+                    writer.write(loggable.getLogString());
+                    writer.flush();
+                } catch (IOException e) {
+                    throw new AssertionError(e);
+                }
             }
-        }
+        }        
 
         public void writeQueryPlan(String queryPlan) {
             if (!logQueryPlan) {
@@ -792,6 +796,7 @@ public final class Main {
                 lastNrQueries = currentNrQueries;
                 lastNrDbs = currentNrDbs;
             }
-        }, 10, 10, TimeUnit.SECONDS);
+        }, 5, 5, TimeUnit.SECONDS);
     }
+
 }


### PR DESCRIPTION
 fixes a bug in sqlancer that will always throw AssertionError if --log-each-select is set to false. The issue was identified in main.java and has been resolved by updating the logic and improving error handling. The fix has been tested to ensure correct execution and prevent regressions. This improves sqlancer’s stability and accuracy for database testing. 🚀