### PR TITLE
Added PostgreSQL v13 VACUUM PARALLEL option support

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresVacuumGenerator.java
@@ -10,6 +10,12 @@ import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
 
+/**
+ * Generates VACUUM commands for PostgreSQL.
+ * This implementation supports PostgreSQL 13 features including the PARALLEL option.
+ * The PARALLEL option specifies the number of parallel worker processes to use when running
+ * a parallel vacuum (only applies to the collection of table data, not indexes).
+ */
 public final class PostgresVacuumGenerator {
 
     private PostgresVacuumGenerator() {
@@ -25,12 +31,27 @@ public final class PostgresVacuumGenerator {
             for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
                 ArrayList<String> opts = new ArrayList<>(Arrays.asList("FULL", "FREEZE", "ANALYZE", "VERBOSE",
                         "DISABLE_PAGE_SKIPPING", "SKIP_LOCKED", "INDEX_CLEANUP", "TRUNCATE"));
+
+                // Add PARALLEL option if PostgreSQL version is 13 or higher
+                int majorVersion = globalState.getMajorVersion();
+                if (majorVersion >= 13) {
+                    opts.add("PARALLEL");
+                }
+                
                 String option = Randomly.fromList(opts);
                 if (i != 0) {
                     sb.append(", ");
                 }
                 sb.append(option);
-                if (Randomly.getBoolean()) {
+                
+                // For PostgreSQL v13+, PARALLEL always needs a value
+                if (option.equals("PARALLEL") && majorVersion >= 13) {
+                    // PARALLEL takes integer value between 0 and 1024
+                    sb.append(" ");
+                    sb.append(Randomly.getNotCachedInteger(0, 4)); // Use reasonable value for testing
+                } 
+                // For other options, randomly decide whether to append a value
+                else if (Randomly.getBoolean()) {
                     sb.append(" ");
                     sb.append(Randomly.fromOptions(1, 0));
                 }
@@ -60,6 +81,12 @@ public final class PostgresVacuumGenerator {
                                  */
         errors.add("ERROR: ANALYZE option must be specified when a column list is provided");
         errors.add("VACUUM option DISABLE_PAGE_SKIPPING cannot be used with FULL");
+        
+        // Add error specific to PostgreSQL v13's PARALLEL option
+        if (globalState.getMajorVersion() >= 13) {
+            errors.add("VACUUM option PARALLEL cannot be used with FULL");
+        }
+        
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 


### PR DESCRIPTION
Here's a PR draft for the PostgreSQL v13 VACUUM PARALLEL implementation:

# PostgreSQL v13 VACUUM PARALLEL option support

## Description
This PR adds support for the PARALLEL option of VACUUM commands in PostgreSQL 13+. The PARALLEL option was introduced in PostgreSQL 13 and allows specifying number of parallel worker processes to use when running a parallel vacuum operation.

## Changes made
1. Added PostgreSQL version detection in `PostgresGlobalState.java` -
 Added a `majorVersion` field to store the server's major version, implemented `getMajorVersion()` method that extracts the major version from `server_version_num`and updated `setConnection()` to initialize the major version when connecting

2. Enhanced `PostgresVacuumGenerator.java` to support the PARALLEL option -
 Added PARALLEL option to the list of vacuum options when PostgreSQL version is 13 or higher , ensured PARALLEL option always has valid integer value (between 0-4 for testing) and added error handling for the "VACUUM option PARALLEL cannot be used with FULL" error

## Testing
Tested with PostgreSQL 13.20 to verify:
- Version detection works correctly
- VACUUM commands with PARALLEL option are properly generated
- The PARALLEL option always receives a valid integer value
- Error handling is appropriate for VACUUM PARALLEL constraints

## Related Issues
Resolves one of the pending items from #912
Related to #1040 "[Postgres][v13] Add PARALLEL option for VACUUM"

<img width="918" alt="Screenshot 2025-04-06 at 3 54 19 AM" src="https://github.com/user-attachments/assets/07ac4da6-7115-41b2-b97e-9deb1a53ed33" />