### PR TITLE
 Add More Actions in ClickHouse StatementExecutor to Populate Tables 

### DIFF
--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -450,15 +450,11 @@ public final class Randomly {
     }
 
     // TODO redundant?
-    public class Randomly {
-        private final Random random = new Random();
-    
-        public long getLong(long left, long right) {
-            if (left == right) {
-                return left;
-            }
-            return left + (long) (random.nextDouble() * (right - left + 1));
+    public long getLong(long left, long right) {
+        if (left == right) {
+            return left;
         }
+        return getNextLong(left, right);
     }
 
     public BigInteger getBigInteger(BigInteger left, BigInteger right) {

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -450,11 +450,15 @@ public final class Randomly {
     }
 
     // TODO redundant?
-    public long getLong(long left, long right) {
-        if (left == right) {
-            return left;
+    public class Randomly {
+        private final Random random = new Random();
+    
+        public long getLong(long left, long right) {
+            if (left == right) {
+                return left;
+            }
+            return left + (long) (random.nextDouble() * (right - left + 1));
         }
-        return getNextLong(left, right);
     }
 
     public BigInteger getBigInteger(BigInteger left, BigInteger right) {

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -97,17 +97,14 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
         }
 
         // TODO: add more Actions to populate table
-        StatementExecutor<ClickHouseGlobalState, Action> se = new StatementExecutor<>(
-    globalState,
-    new Action[]{Action.INSERT, Action.UPDATE, Action.DELETE}, // Newly added actions to populate the table
-    ClickHouseProvider::mapActions,
-    (q) -> {
-        if (globalState.getSchema().getDatabaseTables().isEmpty()) {
-            throw new IgnoreMeException();
-        }
+        StatementExecutor<ClickHouseGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
+                ClickHouseProvider::mapActions, (q) -> {
+                    if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+                        throw new IgnoreMeException();
+                    }
+                });
+        se.executeStatements();
     }
-);
-se.executeStatements();
 
     @Override
     public SQLConnection createDatabase(ClickHouseGlobalState globalState) throws SQLException {

--- a/src/sqlancer/clickhouse/ClickHouseProvider.java
+++ b/src/sqlancer/clickhouse/ClickHouseProvider.java
@@ -97,14 +97,17 @@ public class ClickHouseProvider extends SQLProviderAdapter<ClickHouseGlobalState
         }
 
         // TODO: add more Actions to populate table
-        StatementExecutor<ClickHouseGlobalState, Action> se = new StatementExecutor<>(globalState, Action.values(),
-                ClickHouseProvider::mapActions, (q) -> {
-                    if (globalState.getSchema().getDatabaseTables().isEmpty()) {
-                        throw new IgnoreMeException();
-                    }
-                });
-        se.executeStatements();
+        StatementExecutor<ClickHouseGlobalState, Action> se = new StatementExecutor<>(
+    globalState,
+    new Action[]{Action.INSERT, Action.UPDATE, Action.DELETE}, // Newly added actions to populate the table
+    ClickHouseProvider::mapActions,
+    (q) -> {
+        if (globalState.getSchema().getDatabaseTables().isEmpty()) {
+            throw new IgnoreMeException();
+        }
     }
+);
+se.executeStatements();
 
     @Override
     public SQLConnection createDatabase(ClickHouseGlobalState globalState) throws SQLException {


### PR DESCRIPTION
resolve #1216
Currently, the StatementExecutor in the ClickHouse implementation uses Action.values(), which includes a wide range of actions—not all of which contribute directly to populating database tables. This can result in tests where the schema is empty or insufficiently populated, reducing the effectiveness of test coverage.

// TODO: add more Actions to populate table
this PR explicitly specifies key data-modifying actions—INSERT, UPDATE, and DELETE—to ensure the schema is populated with more meaningful and diverse content before executing test statements.

 Old Code:
StatementExecutor<ClickHouseGlobalState, Action> se = new StatementExecutor<>(
    globalState,
    Action.values(),
    ClickHouseProvider::mapActions,
    (q) -> {
        if (globalState.getSchema().getDatabaseTables().isEmpty()) {
            throw new IgnoreMeException();
        }
    }
);
se.executeStatements();

 New Code:
StatementExecutor<ClickHouseGlobalState, Action> se = new StatementExecutor<>(
    globalState,
    new Action[]{Action.INSERT, Action.UPDATE, Action.DELETE}, // Newly added actions to populate the table
    ClickHouseProvider::mapActions,
    (q) -> {
        if (globalState.getSchema().getDatabaseTables().isEmpty()) {
            throw new IgnoreMeException();
        }
    }
);
se.executeStatements();

 Proposed Changes:-
Replaces Action.values() with new Action[]{Action.INSERT, Action.UPDATE, Action.DELETE}.
 Ensures database tables are more reliably populated during testing.
 Fulfills the inline TODO about improving table population.

