### PR TITLE
Fix sqlancer#1209: UNARY_PLUS operator now converts values to DOUBLE PRECISION

### DIFF
--- a/src/sqlancer/materialize/ast/MaterializeConstant.java
+++ b/src/sqlancer/materialize/ast/MaterializeConstant.java
@@ -316,6 +316,10 @@ public abstract class MaterializeConstant implements MaterializeExpression {
             return getTextRepresentation();
         }
 
+        @Override
+        public double asDouble() {
+            return (double) val;
+        }
     }
 
     public static MaterializeConstant createNullConstant() {
@@ -363,7 +367,15 @@ public abstract class MaterializeConstant implements MaterializeExpression {
         throw new UnsupportedOperationException(this.toString());
     }
 
+    public double asDouble() {
+        throw new UnsupportedOperationException(this.toString());
+    }
+
     public boolean isBoolean() {
+        return false;
+    }
+
+    public boolean isFloat() {
         return false;
     }
 
@@ -451,6 +463,16 @@ public abstract class MaterializeConstant implements MaterializeExpression {
             return MaterializeDataType.FLOAT;
         }
 
+        @Override
+        public boolean isFloat() {
+            return true;
+        }
+
+        @Override
+        public double asDouble() {
+            return val;
+        }
+
     }
 
     public static class DoubleConstant extends MaterializeConstantBase {
@@ -473,6 +495,16 @@ public abstract class MaterializeConstant implements MaterializeExpression {
         @Override
         public MaterializeDataType getExpressionType() {
             return MaterializeDataType.FLOAT;
+        }
+
+        @Override
+        public double asDouble() {
+            return val;
+        }
+
+        @Override
+        public boolean isFloat() {
+            return true;
         }
 
     }

--- a/src/sqlancer/materialize/ast/MaterializePrefixOperation.java
+++ b/src/sqlancer/materialize/ast/MaterializePrefixOperation.java
@@ -28,13 +28,35 @@ public class MaterializePrefixOperation implements MaterializeExpression {
 
             @Override
             public MaterializeDataType getExpressionType() {
-                return MaterializeDataType.INT;
+                return MaterializeDataType.FLOAT;
             }
 
             @Override
             protected MaterializeConstant getExpectedValue(MaterializeConstant expectedValue) {
-                // TODO: actual converts to double precision
-                return expectedValue;
+                if (expectedValue.isNull()) {
+                    return MaterializeConstant.createNullConstant();
+                }
+                double doubleValue;
+                if (expectedValue.isInt()) {
+                    doubleValue = expectedValue.asDouble();
+                } else if (expectedValue.isBoolean()) {
+                    doubleValue = expectedValue.asBoolean() ? 1.0 : 0.0;
+                } else if (expectedValue.isString()) {
+                    try {
+                        doubleValue = Double.parseDouble(expectedValue.asString());
+                    } catch (NumberFormatException e) {
+                        return MaterializeConstant.createNullConstant();
+                    }
+                } else if (expectedValue.isFloat()) {
+                    doubleValue = expectedValue.asDouble();
+                } else {
+                    try {
+                        doubleValue = expectedValue.asDouble();
+                    } catch (UnsupportedOperationException e) {
+                        return MaterializeConstant.createNullConstant();
+                    }
+                }
+                return MaterializeConstant.createDoubleConstant(doubleValue);
             }
 
         },
@@ -63,8 +85,8 @@ public class MaterializePrefixOperation implements MaterializeExpression {
 
         };
 
-        private String textRepresentation;
-        private MaterializeDataType[] dataTypes;
+        private final String textRepresentation;
+        private final MaterializeDataType[] dataTypes;
 
         PrefixOperator(String textRepresentation, MaterializeDataType... dataTypes) {
             this.textRepresentation = textRepresentation;

--- a/test/sqlancer/qpg/materialize/TestMaterializeUnaryPlus.java
+++ b/test/sqlancer/qpg/materialize/TestMaterializeUnaryPlus.java
@@ -1,0 +1,53 @@
+package sqlancer.qpg.materialize;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import sqlancer.materialize.MaterializeSchema.MaterializeDataType;
+import sqlancer.materialize.ast.MaterializeConstant;
+import sqlancer.materialize.ast.MaterializeExpression;
+import sqlancer.materialize.ast.MaterializePrefixOperation;
+import sqlancer.materialize.ast.MaterializePrefixOperation.PrefixOperator;
+
+public class TestMaterializeUnaryPlus {
+
+    @Test
+    public void testUnaryPlusConvertToDouble() {
+        // Test UNARY_PLUS on int
+        MaterializeConstant intConstant = MaterializeConstant.createIntConstant(42);
+        MaterializeExpression unaryPlusInt = new MaterializePrefixOperation(intConstant, PrefixOperator.UNARY_PLUS);
+        MaterializeConstant result = unaryPlusInt.getExpectedValue();
+        
+        // Verify result type is FLOAT (double precision)
+        assertEquals(MaterializeDataType.FLOAT, unaryPlusInt.getExpressionType());
+        
+        // Verify value is converted to double
+        assertTrue(result.isFloat());
+        assertEquals(42.0, result.asDouble());
+        
+        // Test UNARY_PLUS on boolean
+        MaterializeConstant boolConstant = MaterializeConstant.createBooleanConstant(true);
+        MaterializeExpression unaryPlusBool = new MaterializePrefixOperation(boolConstant, PrefixOperator.UNARY_PLUS);
+        result = unaryPlusBool.getExpectedValue();
+        
+        // Verify result type is FLOAT
+        assertEquals(MaterializeDataType.FLOAT, unaryPlusBool.getExpressionType());
+        
+        // Verify value is converted to double (true becomes 1.0)
+        assertTrue(result.isFloat());
+        assertEquals(1.0, result.asDouble());
+        
+        // Test UNARY_PLUS on string
+        MaterializeConstant stringConstant = MaterializeConstant.createTextConstant("123.45");
+        MaterializeExpression unaryPlusString = new MaterializePrefixOperation(stringConstant, PrefixOperator.UNARY_PLUS);
+        result = unaryPlusString.getExpectedValue();
+        
+        // Verify result type is FLOAT
+        assertEquals(MaterializeDataType.FLOAT, unaryPlusString.getExpressionType());
+        
+        // Verify value is converted to double
+        assertTrue(result.isFloat());
+        assertEquals(123.45, result.asDouble());
+    }
+}


### PR DESCRIPTION
# Description
This PR addresses an issue where the UNARY_PLUS operator (+) wasn't properly handling type promotion. In SQL (including Materialize/PostgreSQL), applying the unary + operator on a numeric value should promote it to DOUBLE PRECISION. The previous implementation simply returned the input value without performing any conversion, which could lead to mismatches in expected vs. actual results during testing.

# Changes
Changed UNARY_PLUS operator's return type from INT to FLOAT (double precision). Implemented proper conversion of values to double precision. Added handling for different input types (int, boolean, string, float). Added missing asDouble() method to FloatConstant class. Added comprehensive test cases to verify the proper behavior

# Testing
Added a tests file `TestMaterializeUnaryPlus.java` to verify the changes made.

Closes #1209
