### PR TITLE
Add support for Alter Statistics and Set Statistics

### DIFF
--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -99,6 +99,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         }), //
         CREATE_STATISTICS(PostgresStatisticsGenerator::insert), //
         DROP_STATISTICS(PostgresStatisticsGenerator::remove), //
+        ALTER_STATISTICS(PostgresStatisticsGenerator::alter), //
         DELETE(PostgresDeleteGenerator::create), //
         DISCARD(PostgresDiscardGenerator::create), //
         DROP_INDEX(PostgresDropIndexGenerator::create), //
@@ -149,6 +150,9 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
             break;
         case CREATE_STATISTICS:
             nrPerformed = r.getInteger(0, 5);
+            break;
+        case ALTER_STATISTICS:
+            nrPerformed = r.getInteger(0, 2);
             break;
         case DISCARD:
         case DROP_INDEX:

--- a/src/sqlancer/postgres/gen/PostgresCommon.java
+++ b/src/sqlancer/postgres/gen/PostgresCommon.java
@@ -434,6 +434,8 @@ public final class PostgresCommon {
             }
             break;
         case EXCLUDE:
+            errors.add("exclusion constraints are not supported on partitioned tables");
+            errors.add("unsupported EXCLUDE constraint with partition key definition");
             sb.append("EXCLUDE ");
             sb.append("(");
             // TODO [USING index_method ]
@@ -454,7 +456,6 @@ public final class PostgresCommon {
             errors.add("exclusion constraints are not supported on partitioned tables");
             errors.add("The exclusion operator must be related to the index operator class for the constraint");
             errors.add("could not create exclusion constraint");
-            // TODO: index parameters
             if (Randomly.getBoolean()) {
                 sb.append(" WHERE ");
                 sb.append("(");

--- a/src/sqlancer/postgres/gen/PostgresSetGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresSetGenerator.java
@@ -112,7 +112,7 @@ public final class PostgresSetGenerator {
         JIT("jit", (r) -> Randomly.fromOptions(1, 0)),
         JOIN_COLLAPSE_LIMIT("join_collapse_limit", (r) -> r.getInteger(1, Integer.MAX_VALUE)),
         PARALLEL_LEADER_PARTICIPATION("parallel_leader_participation", (r) -> Randomly.fromOptions(1, 0)),
-        FORCE_PARALLEL_MODE("force_parallel_mode", (r) -> Randomly.fromOptions("off", "on", "regress")),
+        // FORCE_PARALLEL_MODE("force_parallel_mode", (r) -> Randomly.fromOptions("off", "on", "regress")),
         PLAN_CACHE_MODE("plan_cache_mode",
                 (r) -> Randomly.fromOptions("auto", "force_generic_plan", "force_custom_plan"));
 

--- a/src/sqlancer/postgres/gen/PostgresStatisticsGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresStatisticsGenerator.java
@@ -58,6 +58,20 @@ public final class PostgresStatisticsGenerator {
         return new SQLQueryAdapter(sb.toString(), true);
     }
 
+    public static SQLQueryAdapter alter(PostgresGlobalState globalState) {
+        StringBuilder sb = new StringBuilder("ALTER STATISTICS ");
+        PostgresTable randomTable = globalState.getSchema().getRandomTable();
+        List<PostgresStatisticsObject> statistics = randomTable.getStatistics();
+        if (statistics.isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        PostgresStatisticsObject randomStatistic = Randomly.fromList(statistics);
+        sb.append(randomStatistic.getName());
+        sb.append(" SET STATISTICS ");
+        sb.append(Randomly.getNotCachedInteger(-1, 10000)); // -1 means default
+        return new SQLQueryAdapter(sb.toString(), true);
+    }
+
     private static String getNewStatisticsName(PostgresTable randomTable) {
         List<PostgresStatisticsObject> statistics = randomTable.getStatistics();
         int i = 0;


### PR DESCRIPTION
Add support for altering and setting statistics.
Force_parallel_mode is deprecated and has been renamed to debug_parallel_query, therefore, I commented it out. 
Read more: https://www.postgresql.org/docs/16/release-16.html
I think postgres has a limitation where "exclude" constraints cannot be used together with partition keys that include expressions, therefore I added some errors handling in the ```PostgresCommon``` 

Apologize for putting all these in a single issue. Will make sure other issues are separated in the future.

Thanks!