### PR TITLE
Remove cannot insert into column in Postgres v13

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresInsertGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresInsertGenerator.java
@@ -25,7 +25,7 @@ public final class PostgresInsertGenerator {
 
     public static SQLQueryAdapter insertRows(PostgresGlobalState globalState, PostgresSchema.PostgresTable table) {
         ExpectedErrors errors = new ExpectedErrors();
-        errors.add("cannot insert into column");
+        // errors.add("cannot insert into column");
         PostgresCommon.addCommonExpressionErrors(errors);
         PostgresCommon.addCommonInsertUpdateErrors(errors);
         PostgresCommon.addCommonExpressionErrors(errors);

--- a/src/sqlancer/postgres/gen/PostgresInsertGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresInsertGenerator.java
@@ -25,7 +25,6 @@ public final class PostgresInsertGenerator {
 
     public static SQLQueryAdapter insertRows(PostgresGlobalState globalState, PostgresSchema.PostgresTable table) {
         ExpectedErrors errors = new ExpectedErrors();
-        // errors.add("cannot insert into column");
         PostgresCommon.addCommonExpressionErrors(errors);
         PostgresCommon.addCommonInsertUpdateErrors(errors);
         PostgresCommon.addCommonExpressionErrors(errors);


### PR DESCRIPTION
Closes 13. INSERT - Remove "Cannot insert intocolumn" from #912 