### PR TITLE
Add support for tablespace generator in Postgres v13

### DIFF
--- a/src/sqlancer/postgres/PostgresOptions.java
+++ b/src/sqlancer/postgres/PostgresOptions.java
@@ -1,5 +1,6 @@
 package sqlancer.postgres;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
@@ -13,6 +14,7 @@ import sqlancer.DBMSSpecificOptions;
 public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactory> {
     public static final String DEFAULT_HOST = "localhost";
     public static final int DEFAULT_PORT = 5432;
+    private static final boolean DEFAULT_TEST_TABLESPACES = determineDefaultTablespaceSupport();
 
     @Parameter(names = "--bulk-insert", description = "Specifies whether INSERT statements should be issued in bulk", arity = 1)
     public boolean allowBulkInsert;
@@ -23,6 +25,12 @@ public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactor
     @Parameter(names = "--test-collations", description = "Specifies whether to test different collations", arity = 1)
     public boolean testCollations = true;
 
+    @Parameter(names = "--test-tablespaces", description = "Specifies whether to test tablespace creation (default is OS-dependent)", arity = 1)
+    public boolean testTablespaces = DEFAULT_TEST_TABLESPACES;
+
+    @Parameter(names = "--tablespace-path", description = "Base path for tablespace directories (default is OS-dependent)", arity = 1)
+    public String tablespacePath = getDefaultTablespacePath();
+
     @Parameter(names = "--connection-url", description = "Specifies the URL for connecting to the PostgreSQL server", arity = 1)
     public String connectionURL = String.format("postgresql://%s:%d/test", PostgresOptions.DEFAULT_HOST,
             PostgresOptions.DEFAULT_PORT);
@@ -30,9 +38,40 @@ public class PostgresOptions implements DBMSSpecificOptions<PostgresOracleFactor
     @Parameter(names = "--extensions", description = "Specifies a comma-separated list of extension names to be created in each test database", arity = 1)
     public String extensions = "";
 
+    private static boolean determineDefaultTablespaceSupport() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.contains("linux")) {
+            System.out.println("[INFO] Linux detected: Enabling tablespace testing by default");
+            return true;
+        } else if (osName.contains("mac") || osName.contains("darwin")) {
+            System.out.println(
+                    "[INFO] macOS detected: Disabling tablespace testing by default due to different /tmp handling. Override with --test-tablespaces=true and ensure proper directory permissions.");
+            return false;
+        } else if (osName.contains("windows")) {
+            System.out.println(
+                    "[INFO] Windows detected: Disabling tablespace testing by default due to path format differences. Override with --test-tablespaces=true and use --tablespace-path to set a valid Windows path.");
+            return false;
+        } else {
+            System.out.println(
+                    "[INFO] Unknown OS detected: Disabling tablespace testing by default for safety. Override with --test-tablespaces=true if your system supports PostgreSQL tablespaces.");
+            return false;
+        }
+    }
+
+    public static String getDefaultTablespacePath() {
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.contains("windows")) {
+            // On Windows, use a path in the temp directory
+            return new File(System.getProperty("java.io.tmpdir"), "postgresql" + File.separator + "tablespace")
+                    .getAbsolutePath();
+        } else {
+            // On Unix-like systems, use /tmp
+            return "/tmp/postgresql/tablespace";
+        }
+    }
+
     @Override
     public List<PostgresOracleFactory> getTestOracleFactory() {
         return oracle;
     }
-
 }

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -51,6 +51,7 @@ import sqlancer.postgres.gen.PostgresTruncateGenerator;
 import sqlancer.postgres.gen.PostgresUpdateGenerator;
 import sqlancer.postgres.gen.PostgresVacuumGenerator;
 import sqlancer.postgres.gen.PostgresViewGenerator;
+import sqlancer.postgres.gen.PostgresTableSpaceGenerator;
 
 // EXISTS
 // IN
@@ -125,7 +126,8 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         LISTEN((g) -> PostgresNotifyGenerator.createListen()), //
         UNLISTEN((g) -> PostgresNotifyGenerator.createUnlisten()), //
         CREATE_SEQUENCE(PostgresSequenceGenerator::createSequence), //
-        CREATE_VIEW(PostgresViewGenerator::create);
+        CREATE_VIEW(PostgresViewGenerator::create),
+        CREATE_TABLESPACE(PostgresTableSpaceGenerator::generate);
 
         private final SQLQueryProvider<PostgresGlobalState> sqlQueryProvider;
 
@@ -184,6 +186,9 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
             nrPerformed = r.getInteger(0, 2);
             break;
         case CREATE_VIEW:
+            nrPerformed = r.getInteger(0, 2);
+            break;
+        case CREATE_TABLESPACE:
             nrPerformed = r.getInteger(0, 2);
             break;
         case UPDATE:

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -46,12 +46,12 @@ import sqlancer.postgres.gen.PostgresSequenceGenerator;
 import sqlancer.postgres.gen.PostgresSetGenerator;
 import sqlancer.postgres.gen.PostgresStatisticsGenerator;
 import sqlancer.postgres.gen.PostgresTableGenerator;
+import sqlancer.postgres.gen.PostgresTableSpaceGenerator;
 import sqlancer.postgres.gen.PostgresTransactionGenerator;
 import sqlancer.postgres.gen.PostgresTruncateGenerator;
 import sqlancer.postgres.gen.PostgresUpdateGenerator;
 import sqlancer.postgres.gen.PostgresVacuumGenerator;
 import sqlancer.postgres.gen.PostgresViewGenerator;
-import sqlancer.postgres.gen.PostgresTableSpaceGenerator;
 
 // EXISTS
 // IN
@@ -126,8 +126,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         LISTEN((g) -> PostgresNotifyGenerator.createListen()), //
         UNLISTEN((g) -> PostgresNotifyGenerator.createUnlisten()), //
         CREATE_SEQUENCE(PostgresSequenceGenerator::createSequence), //
-        CREATE_VIEW(PostgresViewGenerator::create),
-        CREATE_TABLESPACE(PostgresTableSpaceGenerator::generate);
+        CREATE_VIEW(PostgresViewGenerator::create), CREATE_TABLESPACE(PostgresTableSpaceGenerator::generate);
 
         private final SQLQueryProvider<PostgresGlobalState> sqlQueryProvider;
 

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -126,7 +126,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         LISTEN((g) -> PostgresNotifyGenerator.createListen()), //
         UNLISTEN((g) -> PostgresNotifyGenerator.createUnlisten()), //
         CREATE_SEQUENCE(PostgresSequenceGenerator::createSequence), //
-        CREATE_VIEW(PostgresViewGenerator::create), 
+        CREATE_VIEW(PostgresViewGenerator::create), //
         CREATE_TABLESPACE(PostgresTableSpaceGenerator::generate);
 
         private final SQLQueryProvider<PostgresGlobalState> sqlQueryProvider;

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -126,7 +126,8 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         LISTEN((g) -> PostgresNotifyGenerator.createListen()), //
         UNLISTEN((g) -> PostgresNotifyGenerator.createUnlisten()), //
         CREATE_SEQUENCE(PostgresSequenceGenerator::createSequence), //
-        CREATE_VIEW(PostgresViewGenerator::create), CREATE_TABLESPACE(PostgresTableSpaceGenerator::generate);
+        CREATE_VIEW(PostgresViewGenerator::create), 
+        CREATE_TABLESPACE(PostgresTableSpaceGenerator::generate);
 
         private final SQLQueryProvider<PostgresGlobalState> sqlQueryProvider;
 

--- a/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
@@ -12,8 +12,7 @@ public class PostgresTableSpaceGenerator {
 
     public PostgresTableSpaceGenerator(PostgresGlobalState globalState) {
         this.globalState = globalState;
-        errors.addRegexString("ERROR: (?:tablespace )?directory \".*[\\\\/]tablespace[1-5]\" does not exist");
-        errors.add("ERROR: must be a directory");
+        errors.addRegexString("ERROR: (?:tablespace )?directory \".*[\\\\/]tablespace\\d+\" does not exist");
         errors.add("ERROR: permission denied");
         errors.add("ERROR: already exists");
         errors.add("ERROR: is not empty");
@@ -23,7 +22,7 @@ public class PostgresTableSpaceGenerator {
     public static SQLQueryAdapter generate(PostgresGlobalState globalState) {
         // Skip tablespace generation if the option is disabled
         PostgresOptions options = globalState.getDbmsSpecificOptions();
-        if (!options.testTablespaces) {
+        if (!options.isTestTablespaces()) {
             return null;
         }
         return new PostgresTableSpaceGenerator(globalState).generateTableSpace();
@@ -31,7 +30,7 @@ public class PostgresTableSpaceGenerator {
 
     private SQLQueryAdapter generateTableSpace() {
         StringBuilder sb = new StringBuilder();
-        int tableSpaceNum = globalState.getRandomly().getInteger(1, 5);
+        int tableSpaceNum = globalState.getRandomly().getInteger(1, Integer.MAX_VALUE);
 
         // CREATE TABLESPACE syntax
         sb.append("CREATE TABLESPACE ");
@@ -39,9 +38,9 @@ public class PostgresTableSpaceGenerator {
         sb.append(tableSpaceNum);
         sb.append(" LOCATION '");
 
-        // Get the base path from options and append the tablespace number
+        // Get the validated base path from options and append the tablespace number
         PostgresOptions options = globalState.getDbmsSpecificOptions();
-        String path = options.tablespacePath + tableSpaceNum;
+        String path = options.getTablespacePath() + tableSpaceNum;
 
         // Convert backslashes to forward slashes for PostgreSQL
         path = path.replace('\\', '/');

--- a/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
@@ -3,24 +3,16 @@ package sqlancer.postgres.gen;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
+import sqlancer.postgres.PostgresOptions;
 
 public class PostgresTableSpaceGenerator {
-    
+
     private final ExpectedErrors errors = new ExpectedErrors();
     private final PostgresGlobalState globalState;
 
     public PostgresTableSpaceGenerator(PostgresGlobalState globalState) {
         this.globalState = globalState;
-        errors.add("ERROR: directory \"/tmp/postgresql/tablespace1\" does not exist");
-        errors.add("ERROR: directory \"/tmp/postgresql/tablespace2\" does not exist");
-        errors.add("ERROR: directory \"/tmp/postgresql/tablespace3\" does not exist");
-        errors.add("ERROR: directory \"/tmp/postgresql/tablespace4\" does not exist");
-        errors.add("ERROR: directory \"/tmp/postgresql/tablespace5\" does not exist");
-        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace1\" does not exist");
-        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace2\" does not exist");
-        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace3\" does not exist");
-        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace4\" does not exist");
-        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace5\" does not exist");
+        errors.addRegexString("ERROR: (?:tablespace )?directory \".*[\\\\/]tablespace[1-5]\" does not exist");
         errors.add("ERROR: must be a directory");
         errors.add("ERROR: permission denied");
         errors.add("ERROR: already exists");
@@ -29,21 +21,37 @@ public class PostgresTableSpaceGenerator {
     }
 
     public static SQLQueryAdapter generate(PostgresGlobalState globalState) {
+        // Skip tablespace generation if the option is disabled
+        PostgresOptions options = globalState.getDbmsSpecificOptions();
+        if (!options.testTablespaces) {
+            return null;
+        }
         return new PostgresTableSpaceGenerator(globalState).generateTableSpace();
     }
 
     private SQLQueryAdapter generateTableSpace() {
         StringBuilder sb = new StringBuilder();
-        int tableSpaceNum = globalState.getRandomly().getInteger(1, 5); // Use the instance method
-        
+        int tableSpaceNum = globalState.getRandomly().getInteger(1, 5);
+
         // CREATE TABLESPACE syntax
         sb.append("CREATE TABLESPACE ");
         sb.append("tablespace");
         sb.append(tableSpaceNum);
-        sb.append(" LOCATION '/tmp/postgresql/tablespace");
-        sb.append(tableSpaceNum);
+        sb.append(" LOCATION '");
+
+        // Get the base path from options and append the tablespace number
+        PostgresOptions options = globalState.getDbmsSpecificOptions();
+        String path = options.tablespacePath + tableSpaceNum;
+
+        // Convert backslashes to forward slashes for PostgreSQL
+        path = path.replace('\\', '/');
+
+        // Escape single quotes in the path
+        path = path.replace("'", "''");
+
+        sb.append(path);
         sb.append("'");
-        
+
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 }

--- a/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
@@ -13,7 +13,6 @@ public class PostgresTableSpaceGenerator {
     public PostgresTableSpaceGenerator(PostgresGlobalState globalState) {
         this.globalState = globalState;
         errors.addRegexString("ERROR: (?:tablespace )?directory \".*[\\\\/]tablespace\\d+\" does not exist");
-        errors.add("ERROR: permission denied");
         errors.add("ERROR: already exists");
         errors.add("ERROR: is not empty");
         errors.add("ERROR: cannot be created because system does not support tablespaces");

--- a/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
@@ -1,0 +1,49 @@
+package sqlancer.postgres.gen;
+
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.postgres.PostgresGlobalState;
+
+public class PostgresTableSpaceGenerator {
+    
+    private final ExpectedErrors errors = new ExpectedErrors();
+    private final PostgresGlobalState globalState;
+
+    public PostgresTableSpaceGenerator(PostgresGlobalState globalState) {
+        this.globalState = globalState;
+        errors.add("ERROR: directory \"/tmp/postgresql/tablespace1\" does not exist");
+        errors.add("ERROR: directory \"/tmp/postgresql/tablespace2\" does not exist");
+        errors.add("ERROR: directory \"/tmp/postgresql/tablespace3\" does not exist");
+        errors.add("ERROR: directory \"/tmp/postgresql/tablespace4\" does not exist");
+        errors.add("ERROR: directory \"/tmp/postgresql/tablespace5\" does not exist");
+        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace1\" does not exist");
+        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace2\" does not exist");
+        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace3\" does not exist");
+        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace4\" does not exist");
+        errors.add("ERROR: tablespace directory \"/tmp/postgresql/tablespace5\" does not exist");
+        errors.add("ERROR: must be a directory");
+        errors.add("ERROR: permission denied");
+        errors.add("ERROR: already exists");
+        errors.add("ERROR: is not empty");
+        errors.add("ERROR: cannot be created because system does not support tablespaces");
+    }
+
+    public static SQLQueryAdapter generate(PostgresGlobalState globalState) {
+        return new PostgresTableSpaceGenerator(globalState).generateTableSpace();
+    }
+
+    private SQLQueryAdapter generateTableSpace() {
+        StringBuilder sb = new StringBuilder();
+        int tableSpaceNum = globalState.getRandomly().getInteger(1, 5); // Use the instance method
+        
+        // CREATE TABLESPACE syntax
+        sb.append("CREATE TABLESPACE ");
+        sb.append("tablespace");
+        sb.append(tableSpaceNum);
+        sb.append(" LOCATION '/tmp/postgresql/tablespace");
+        sb.append(tableSpaceNum);
+        sb.append("'");
+        
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+}


### PR DESCRIPTION
Currently, the location is defaulted at ```/tmp/postgresql/tablespace``` which is fine for linux users, however, the path might be different for windows users. Read more here: https://www.postgresql.org/docs/current/sql-createtablespace.html

From #912 