### PR TITLE
Fix AlterTableGenerator format issue

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java
@@ -53,9 +53,7 @@ public class PostgresAlterTableGenerator {
         ALTER_VIEW_RENAME_COLUMN // RENAME COLUMN old_name TO new_name (for views)
     }
 
-    private static final List<Action> VIEW_ACTIONS = List.of(
-        Action.ALTER_VIEW_RENAME_COLUMN
-    );
+    private static final List<Action> VIEW_ACTIONS = List.of(Action.ALTER_VIEW_RENAME_COLUMN);
 
     public PostgresAlterTableGenerator(PostgresTable randomTable, PostgresGlobalState globalState,
             boolean generateOnlyKnown) {


### PR DESCRIPTION
Fixed "Failed to execute goal net.revelc.code.formatter:formatter-maven-plugin:2.20.0:validate (eclipseformat) on project sqlancer: File '/home/runner/work/sqlancer/sqlancer/src/sqlancer/postgres/gen/PostgresAlterTableGenerator.java' has not been previously formatted. Please format file (for example by invoking `mvn net.revelc.code.formatter:formatter-maven-plugin:2.20.0:format`) and commit before running validation! -> [Help 1]" 