### PR TITLE
Bump SQLite from 3.47.2.0 to 3.49.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.47.2.0</version>
+      <version>3.49.1.0</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
All sqlite-related tests were executed successfully with no assertion failures.
<img width="776" alt="test" src="https://github.com/user-attachments/assets/ebe5ff9a-4429-4f4e-867d-7f789cf5528c" />
