### PR TITLE
Fix sqlancer#1249: Postgres REINDEX now generate only one index name per statement

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresReindexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresReindexGenerator.java
@@ -1,7 +1,6 @@
 package sqlancer.postgres.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
@@ -39,7 +38,7 @@ public final class PostgresReindexGenerator {
             if (indexes.isEmpty()) {
                 throw new IgnoreMeException();
             }
-            sb.append(indexes.stream().map(i -> i.getIndexName()).collect(Collectors.joining()));
+            sb.append(indexes.stream().skip(Randomly.getNotCachedInteger(0, indexes.size())).findFirst().map(i -> i.getIndexName()).orElse(""));
             break;
         case TABLE:
             sb.append("TABLE ");


### PR DESCRIPTION
In Postgres, each REINDEX statement can only work on one index, as can be seen [here](https://www.postgresql.org/docs/devel/sql-reindex.html). 

The previous edition will instead generate all index names, concatenated without delimiter.