### PR TITLE
Add the SQLQueryError class for DQE and its test

### DIFF
--- a/src/sqlancer/common/query/SQLQueryError.java
+++ b/src/sqlancer/common/query/SQLQueryError.java
@@ -1,0 +1,116 @@
+package sqlancer.common.query;
+
+public class SQLQueryError implements Comparable<SQLQueryError> {
+
+    public enum ErrorLevel {
+        WARNING, ERROR
+    }
+
+    private ErrorLevel level;
+    private int code;
+    private String message;
+
+    public void setLevel(String level) {
+        // value of is case-sensitive
+        this.level = ErrorLevel.valueOf(level.toUpperCase());
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public ErrorLevel getLevel() {
+        return level;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean hasSameLevel(SQLQueryError that) {
+        if (level == null && that.getLevel() == null) {
+            return true;
+        } else if (level != null && level.equals(that.getLevel())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public boolean hasSameCodeAndMessage(SQLQueryError that) {
+        if (code != that.getCode()) {
+            return false;
+        }
+        if (message == null && that.getMessage() == null) {
+            return true;
+        } else if (message != null && message.equals(that.getMessage())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (that == null) {
+            return false;
+        }
+        if (that instanceof SQLQueryError) {
+            SQLQueryError thatError = (SQLQueryError) that;
+            if (hasSameLevel(thatError) && hasSameCodeAndMessage(thatError)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Level: %s; Code: %d; Message: %s.", level, code, message);
+    }
+
+    @Override
+    public int compareTo(SQLQueryError that) {
+        if (code < that.getCode()) {
+            return -1;
+        } else if (code > that.getCode()) {
+            return 1;
+        }
+
+        if (level == null && that.getLevel() != null) {
+            return -1;
+        }
+        if (level != null && that.getLevel() == null) {
+            return 1;
+        }
+        if (level != null && that.getLevel() != null) {
+            int res = level.compareTo(that.getLevel());
+            if (res != 0) {
+                return res;
+            }
+        }
+
+        if (message == null && that.getMessage() != null) {
+            return -1;
+        }
+        if (message != null && that.getMessage() == null) {
+            return 1;
+        }
+        if (message != null && that.getMessage() != null) {
+            int res = message.compareTo(that.getMessage());
+            if (res != 0) {
+                return res;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/sqlancer/common/query/SQLQueryError.java
+++ b/src/sqlancer/common/query/SQLQueryError.java
@@ -1,5 +1,7 @@
 package sqlancer.common.query;
 
+import java.util.Objects;
+
 public class SQLQueryError implements Comparable<SQLQueryError> {
 
     public enum ErrorLevel {
@@ -63,6 +65,11 @@ public class SQLQueryError implements Comparable<SQLQueryError> {
             return hasSameLevel(thatError) && hasSameCodeAndMessage(thatError);
         }
         return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(level, code, message);
     }
 
     @Override

--- a/src/sqlancer/common/query/SQLQueryError.java
+++ b/src/sqlancer/common/query/SQLQueryError.java
@@ -10,9 +10,8 @@ public class SQLQueryError implements Comparable<SQLQueryError> {
     private int code;
     private String message;
 
-    public void setLevel(String level) {
-        // value of is case-sensitive
-        this.level = ErrorLevel.valueOf(level.toUpperCase());
+    public void setLevel(ErrorLevel level) {
+        this.level = level;
     }
 
     public void setCode(int code) {
@@ -36,12 +35,10 @@ public class SQLQueryError implements Comparable<SQLQueryError> {
     }
 
     public boolean hasSameLevel(SQLQueryError that) {
-        if (level == null && that.getLevel() == null) {
-            return true;
-        } else if (level != null && level.equals(that.getLevel())) {
-            return true;
+        if (level == null) {
+            return that.getLevel() == null;
         } else {
-            return false;
+            return level.equals(that.getLevel());
         }
     }
 
@@ -49,12 +46,10 @@ public class SQLQueryError implements Comparable<SQLQueryError> {
         if (code != that.getCode()) {
             return false;
         }
-        if (message == null && that.getMessage() == null) {
-            return true;
-        } else if (message != null && message.equals(that.getMessage())) {
-            return true;
+        if (message == null) {
+            return that.getMessage() == null;
         } else {
-            return false;
+            return message.equals(that.getMessage());
         }
     }
 
@@ -65,9 +60,7 @@ public class SQLQueryError implements Comparable<SQLQueryError> {
         }
         if (that instanceof SQLQueryError) {
             SQLQueryError thatError = (SQLQueryError) that;
-            if (hasSameLevel(thatError) && hasSameCodeAndMessage(thatError)) {
-                return true;
-            }
+            return hasSameLevel(thatError) && hasSameCodeAndMessage(thatError);
         }
         return false;
     }
@@ -87,27 +80,27 @@ public class SQLQueryError implements Comparable<SQLQueryError> {
 
         if (level == null && that.getLevel() != null) {
             return -1;
-        }
-        if (level != null && that.getLevel() == null) {
-            return 1;
-        }
-        if (level != null && that.getLevel() != null) {
-            int res = level.compareTo(that.getLevel());
-            if (res != 0) {
-                return res;
+        } else {
+            if (that.getLevel() == null) {
+                return 1;
+            } else {
+                int res = level.compareTo(that.getLevel());
+                if (res != 0) {
+                    return res;
+                }
             }
         }
 
         if (message == null && that.getMessage() != null) {
             return -1;
-        }
-        if (message != null && that.getMessage() == null) {
-            return 1;
-        }
-        if (message != null && that.getMessage() != null) {
-            int res = message.compareTo(that.getMessage());
-            if (res != 0) {
-                return res;
+        } else {
+            if (that.getMessage() == null) {
+                return 1;
+            } else {
+                int res = message.compareTo(that.getMessage());
+                if (res != 0) {
+                    return res;
+                }
             }
         }
 

--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -279,14 +279,14 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
         }
         Connection con = DriverManager.getConnection("jdbc:" + entryURL, username, password);
         globalState.getState().logStatement(String.format("\\c %s;", entryDatabaseName));
-        
+
         String dropCommand = "DROP DATABASE";
         boolean forceDrop = Randomly.getBoolean();
         if (forceDrop) {
             dropCommand += " FORCE";
         }
         dropCommand += " IF EXISTS " + databaseName;
-        
+
         globalState.getState().logStatement(dropCommand + ";");
         try (Statement s = con.createStatement()) {
             s.execute(dropCommand);
@@ -302,7 +302,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
                 throw e;
             }
         }
-        
+
         // Create database section
         createDatabaseCommand = getCreateDatabaseCommand(globalState);
         globalState.getState().logStatement(createDatabaseCommand + ";");

--- a/test/sqlancer/common/query/SQLQueryErrorTest.java
+++ b/test/sqlancer/common/query/SQLQueryErrorTest.java
@@ -90,4 +90,3 @@ public class SQLQueryErrorTest {
         assertTrue(e1.compareTo(e2) < 0);
     }
 }
-

--- a/test/sqlancer/common/query/SQLQueryErrorTest.java
+++ b/test/sqlancer/common/query/SQLQueryErrorTest.java
@@ -1,0 +1,93 @@
+package sqlancer.common.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SQLQueryErrorTest {
+    @Test
+    public void testSettersAndGetters() {
+        SQLQueryError error = new SQLQueryError();
+        error.setLevel("error");
+        error.setCode(123);
+        error.setMessage("Test message");
+        assertEquals(SQLQueryError.ErrorLevel.ERROR, error.getLevel());
+        assertEquals(123, error.getCode());
+        assertEquals("Test message", error.getMessage());
+    }
+
+    @Test
+    public void testHasSameLevel() {
+        SQLQueryError e1 = new SQLQueryError();
+        SQLQueryError e2 = new SQLQueryError();
+        e1.setLevel("warning");
+        e2.setLevel("warning");
+        assertTrue(e1.hasSameLevel(e2));
+        e2.setLevel("error");
+        assertFalse(e1.hasSameLevel(e2));
+    }
+
+    @Test
+    public void testHasSameCodeAndMessage() {
+        SQLQueryError e1 = new SQLQueryError();
+        SQLQueryError e2 = new SQLQueryError();
+        e1.setCode(1);
+        e2.setCode(1);
+        e1.setMessage("msg");
+        e2.setMessage("msg");
+        assertTrue(e1.hasSameCodeAndMessage(e2));
+        e2.setCode(2);
+        assertFalse(e1.hasSameCodeAndMessage(e2));
+        e2.setCode(1);
+        e2.setMessage("other");
+        assertFalse(e1.hasSameCodeAndMessage(e2));
+    }
+
+    @Test
+    public void testEquals() {
+        SQLQueryError e1 = new SQLQueryError();
+        SQLQueryError e2 = new SQLQueryError();
+        e1.setLevel("error");
+        e1.setCode(1);
+        e1.setMessage("msg");
+        e2.setLevel("error");
+        e2.setCode(1);
+        e2.setMessage("msg");
+        assertEquals(e1, e2);
+        e2.setLevel("warning");
+        assertNotEquals(e1, e2);
+    }
+
+    @Test
+    public void testToString() {
+        SQLQueryError e = new SQLQueryError();
+        e.setLevel("error");
+        e.setCode(1);
+        e.setMessage("msg");
+        String str = e.toString();
+        assertTrue(str.contains("Level: ERROR"));
+        assertTrue(str.contains("Code: 1"));
+        assertTrue(str.contains("Message: msg"));
+    }
+
+    @Test
+    public void testCompareTo() {
+        SQLQueryError e1 = new SQLQueryError();
+        SQLQueryError e2 = new SQLQueryError();
+        e1.setCode(1);
+        e2.setCode(2);
+        assertTrue(e1.compareTo(e2) < 0);
+        e2.setCode(1);
+        e1.setLevel("error");
+        e2.setLevel("warning");
+        assertTrue(e1.compareTo(e2) > 0 || e1.compareTo(e2) < 0);
+        e2.setLevel("error");
+        e1.setMessage("a");
+        e2.setMessage("b");
+        assertTrue(e1.compareTo(e2) < 0);
+    }
+}
+

--- a/test/sqlancer/common/query/SQLQueryErrorTest.java
+++ b/test/sqlancer/common/query/SQLQueryErrorTest.java
@@ -11,7 +11,7 @@ public class SQLQueryErrorTest {
     @Test
     public void testSettersAndGetters() {
         SQLQueryError error = new SQLQueryError();
-        error.setLevel("error");
+        error.setLevel(SQLQueryError.ErrorLevel.ERROR);
         error.setCode(123);
         error.setMessage("Test message");
         assertEquals(SQLQueryError.ErrorLevel.ERROR, error.getLevel());
@@ -23,10 +23,10 @@ public class SQLQueryErrorTest {
     public void testHasSameLevel() {
         SQLQueryError e1 = new SQLQueryError();
         SQLQueryError e2 = new SQLQueryError();
-        e1.setLevel("warning");
-        e2.setLevel("warning");
+        e1.setLevel(SQLQueryError.ErrorLevel.WARNING);
+        e2.setLevel(SQLQueryError.ErrorLevel.WARNING);
         assertTrue(e1.hasSameLevel(e2));
-        e2.setLevel("error");
+        e2.setLevel(SQLQueryError.ErrorLevel.ERROR);
         assertFalse(e1.hasSameLevel(e2));
     }
 
@@ -50,21 +50,21 @@ public class SQLQueryErrorTest {
     public void testEquals() {
         SQLQueryError e1 = new SQLQueryError();
         SQLQueryError e2 = new SQLQueryError();
-        e1.setLevel("error");
+        e1.setLevel(SQLQueryError.ErrorLevel.ERROR);
         e1.setCode(1);
         e1.setMessage("msg");
-        e2.setLevel("error");
+        e2.setLevel(SQLQueryError.ErrorLevel.ERROR);
         e2.setCode(1);
         e2.setMessage("msg");
         assertEquals(e1, e2);
-        e2.setLevel("warning");
+        e2.setLevel(SQLQueryError.ErrorLevel.WARNING);
         assertNotEquals(e1, e2);
     }
 
     @Test
     public void testToString() {
         SQLQueryError e = new SQLQueryError();
-        e.setLevel("error");
+        e.setLevel(SQLQueryError.ErrorLevel.ERROR);
         e.setCode(1);
         e.setMessage("msg");
         String str = e.toString();
@@ -81,10 +81,10 @@ public class SQLQueryErrorTest {
         e2.setCode(2);
         assertTrue(e1.compareTo(e2) < 0);
         e2.setCode(1);
-        e1.setLevel("error");
-        e2.setLevel("warning");
+        e1.setLevel(SQLQueryError.ErrorLevel.ERROR);
+        e2.setLevel(SQLQueryError.ErrorLevel.WARNING);
         assertTrue(e1.compareTo(e2) > 0 || e1.compareTo(e2) < 0);
-        e2.setLevel("error");
+        e2.setLevel(SQLQueryError.ErrorLevel.ERROR);
         e1.setMessage("a");
         e2.setMessage("b");
         assertTrue(e1.compareTo(e2) < 0);


### PR DESCRIPTION
This PR is used to split #1251 into small pieces.

The core idea of DQE is that the SELECT, UPDATE and DELETE queries with the same predicate φ should access the same rows. If these queries access different rows, DQE reveals a potential logic bug in the target DBMS. SQLQueryError class is used to compare the errors @mrigger @JensonSung 