### PR TITLE
Serialize StateToReproduce to JSON

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@
           <target>11</target>
           <compilerArguments>
             <properties>${project.basedir}/.settings/org.eclipse.jdt.core.prefs</properties>
-            <arg>-Xlint:-serial</arg>
           </compilerArguments>
           <compilerId>eclipse</compilerId>
           <showWarnings>true</showWarnings>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
           <target>11</target>
           <compilerArguments>
             <properties>${project.basedir}/.settings/org.eclipse.jdt.core.prefs</properties>
+            <arg>-Xlint:-serial</arg>
           </compilerArguments>
           <compilerId>eclipse</compilerId>
           <showWarnings>true</showWarnings>

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -123,6 +123,9 @@ public class MainOptions {
     @Parameter(names = "--database-prefix", description = "The prefix used for each database created")
     private String databasePrefix = "database"; // NOPMD
 
+    @Parameter(names = "--serialize-reproduce-state", description = "Serialize the state to reproduce")
+    private boolean serializeReproduceState = false; // NOPMD
+
     @Parameter(names = "--use-reducer", description = "EXPERIMENTAL Attempt to reduce queries using a simple reducer")
     private boolean useReducer = false; // NOPMD
 
@@ -302,6 +305,10 @@ public class MainOptions {
 
     public boolean performConnectionTest() {
         return useConnectionTest;
+    }
+
+    public boolean serializeReproduceState() {
+        return serializeReproduceState;
     }
 
     public boolean useReducer() {

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -16,7 +16,7 @@ import sqlancer.common.query.Query;
 public class StateToReproduce implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private transient List<Query<?>> statements = new ArrayList<>();
+    private List<Query<?>> statements = new ArrayList<>();
 
     private final String databaseName;
 
@@ -157,19 +157,11 @@ public class StateToReproduce implements Serializable {
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
 
-        List<String> statementStrings = new ArrayList<>();
-        for (Query<?> q : this.statements) {
-            statementStrings.add(q.getLogString());
-        }
-        out.writeObject(statementStrings);
         out.writeObject(this.databaseProvider != null ? this.databaseProvider.getDBMSName() : null);
     }
 
-    @SuppressWarnings("unchecked")
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        this.statements = new ArrayList<>();
-        List<String> statementStrings = (List<String>) in.readObject();
         String dbmsName = (String) in.readObject();
 
         DatabaseProvider<?, ?, ?> provider = null;
@@ -182,14 +174,7 @@ public class StateToReproduce implements Serializable {
                 }
             }
         }
-
-        if (provider == null || statementStrings == null) {
-            throw new AssertionError("Database provider or statement is null");
-        }
         this.databaseProvider = provider;
-        for (String s : statementStrings) {
-            this.statements.add(provider.getLoggableFactory().getQueryForStateToReproduce(s));
-        }
     }
 
     public void setStatements(List<Query<?>> statements) {

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -1,19 +1,26 @@
 package sqlancer;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import sqlancer.common.query.Query;
 
-public class StateToReproduce {
+public class StateToReproduce implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private List<Query<?>> statements = new ArrayList<>();
+    private transient List<Query<?>> statements = new ArrayList<>();
 
     private final String databaseName;
 
-    private final DatabaseProvider<?, ?, ?> databaseProvider;
+    private transient DatabaseProvider<?, ?, ?> databaseProvider;
 
     public String databaseVersion;
 
@@ -129,6 +136,60 @@ public class StateToReproduce {
 
     public OracleRunReproductionState createLocalState() {
         return new OracleRunReproductionState();
+    }
+
+    public void serialize(Path path) {
+        try (ObjectOutputStream oos = new ObjectOutputStream(Files.newOutputStream(path))) {
+            oos.writeObject(this);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public static StateToReproduce deserialize(Path path) {
+        try (ObjectInputStream ois = new ObjectInputStream(Files.newInputStream(path))) {
+            return (StateToReproduce) ois.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+
+        List<String> statementStrings = new ArrayList<>();
+        for (Query<?> q : this.statements) {
+            statementStrings.add(q.getLogString());
+        }
+        out.writeObject(statementStrings);
+        out.writeObject(this.databaseProvider != null ? this.databaseProvider.getDBMSName() : null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        this.statements = new ArrayList<>();
+        List<String> statementStrings = (List<String>) in.readObject();
+        String dbmsName = (String) in.readObject();
+
+        DatabaseProvider<?, ?, ?> provider = null;
+        if (dbmsName != null) {
+            List<DatabaseProvider<?, ?, ?>> providers = Main.getDBMSProviders();
+            for (DatabaseProvider<?, ?, ?> p : providers) {
+                if (p.getDBMSName().equals(dbmsName)) {
+                    provider = p;
+                    break;
+                }
+            }
+        }
+
+        if (provider == null || statementStrings == null) {
+            throw new AssertionError("Database provider or statement is null");
+        }
+        this.databaseProvider = provider;
+        for (String s : statementStrings) {
+            this.statements.add(provider.getLoggableFactory().getQueryForStateToReproduce(s));
+        }
     }
 
     public void setStatements(List<Query<?>> statements) {

--- a/src/sqlancer/cnosdb/query/CnosDBOtherQuery.java
+++ b/src/sqlancer/cnosdb/query/CnosDBOtherQuery.java
@@ -6,6 +6,8 @@ import sqlancer.cnosdb.client.CnosDBConnection;
 import sqlancer.common.query.ExpectedErrors;
 
 public class CnosDBOtherQuery extends CnosDBQueryAdapter {
+    private static final long serialVersionUID = 1L;
+
     public CnosDBOtherQuery(String query, ExpectedErrors errors) {
         super(query, errors);
     }

--- a/src/sqlancer/cnosdb/query/CnosDBQueryAdapter.java
+++ b/src/sqlancer/cnosdb/query/CnosDBQueryAdapter.java
@@ -5,6 +5,7 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.Query;
 
 public abstract class CnosDBQueryAdapter extends Query<CnosDBConnection> {
+    private static final long serialVersionUID = 1L;
 
     String query;
     ExpectedErrors errors;

--- a/src/sqlancer/cnosdb/query/CnosDBSelectQuery.java
+++ b/src/sqlancer/cnosdb/query/CnosDBSelectQuery.java
@@ -7,6 +7,7 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLancerResultSet;
 
 public class CnosDBSelectQuery extends CnosDBQueryAdapter {
+    private static final long serialVersionUID = 1L;
     CnosDBResultSet resultSet;
 
     public CnosDBSelectQuery(String query, ExpectedErrors errors) {

--- a/src/sqlancer/common/log/Loggable.java
+++ b/src/sqlancer/common/log/Loggable.java
@@ -1,5 +1,7 @@
 package sqlancer.common.log;
 
-public interface Loggable {
+import java.io.Serializable;
+
+public interface Loggable extends Serializable {
     String getLogString();
 }

--- a/src/sqlancer/common/log/LoggedString.java
+++ b/src/sqlancer/common/log/LoggedString.java
@@ -1,6 +1,7 @@
 package sqlancer.common.log;
 
 public class LoggedString implements Loggable {
+    private static final long serialVersionUID = 1L;
 
     private final String loggedString;
 

--- a/src/sqlancer/common/query/ExpectedErrors.java
+++ b/src/sqlancer/common/query/ExpectedErrors.java
@@ -1,5 +1,6 @@
 package sqlancer.common.query;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -11,7 +12,8 @@ import java.util.regex.Pattern;
  * result in an error "UNIQUE constraint violated" when it attempts to insert a duplicate value in a column declared as
  * UNIQUE.
  */
-public class ExpectedErrors {
+public class ExpectedErrors implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final Set<String> errors;
     private final Set<Pattern> regexes;

--- a/src/sqlancer/common/query/Query.java
+++ b/src/sqlancer/common/query/Query.java
@@ -5,6 +5,7 @@ import sqlancer.SQLancerDBConnection;
 import sqlancer.common.log.Loggable;
 
 public abstract class Query<C extends SQLancerDBConnection> implements Loggable {
+    private static final long serialVersionUID = 1L;
 
     /**
      * Gets the query string, which is guaranteed to be terminated with a semicolon.

--- a/src/sqlancer/common/query/SQLQueryAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryAdapter.java
@@ -1,5 +1,6 @@
 package sqlancer.common.query;
 
+import java.io.Serializable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -9,7 +10,8 @@ import sqlancer.GlobalState;
 import sqlancer.Main;
 import sqlancer.SQLConnection;
 
-public class SQLQueryAdapter extends Query<SQLConnection> {
+public class SQLQueryAdapter extends Query<SQLConnection> implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final String query;
     private final ExpectedErrors expectedErrors;

--- a/src/sqlancer/common/query/SQLQueryResultCheckAdapter.java
+++ b/src/sqlancer/common/query/SQLQueryResultCheckAdapter.java
@@ -9,6 +9,7 @@ import sqlancer.GlobalState;
 import sqlancer.SQLConnection;
 
 public class SQLQueryResultCheckAdapter extends SQLQueryAdapter {
+    private static final long serialVersionUID = 1L;
 
     private final Consumer<ResultSet> rsChecker;
 

--- a/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDiscardGenerator.java
@@ -25,6 +25,7 @@ public final class PostgresDiscardGenerator {
         }
         sb.append(what);
         return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("cannot run inside a transaction block")) {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public boolean couldAffectSchema() {

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDiscardGenerator.java
@@ -25,6 +25,7 @@ public final class YSQLDiscardGenerator {
         }
         sb.append(what);
         return new SQLQueryAdapter(sb.toString(), ExpectedErrors.from("cannot run inside a transaction block")) {
+            private static final long serialVersionUID = 1L;
 
             @Override
             public boolean couldAffectSchema() {

--- a/test/sqlancer/reducer/VirtualDB/VirtualDBQuery.java
+++ b/test/sqlancer/reducer/VirtualDB/VirtualDBQuery.java
@@ -7,6 +7,7 @@ import sqlancer.common.query.SQLQueryAdapter;
 import java.sql.SQLException;
 
 public class VirtualDBQuery extends SQLQueryAdapter {
+    private static final long serialVersionUID = 1L;
 
     public VirtualDBQuery(String query) {
         // Since the base class must check the format


### PR DESCRIPTION
### Motivation

To support a standalone reducer in SQLancer, we need a way to serialize the `StateToReproduce` object, which encapsulates all the information needed to reproduce a bug.

### Solution

- This PR introduces a mechanism to serialize `StateToReproduce` into a JSON file when a bug is found.
- The serialization captures all essential fields: `statements`, `errorType` (EXCEPTION, NOREC, TLP_WHERE), `databaseName`, `databaseProvider`, `reproducerData`, `exception`
- Serialization is controlled via a new command-line option: `--serialize-reproduce-state`, and serialized `.json` files are written to `logs/<dbms>/reproduce/`.
- A private static inner class `StateToReproduceSerializor` is introduced to control which fields are included in the output.

### Example Output

```json
{
  "statements": [
    "CREATE VIRTUAL TABLE rt0 USING rtree(c0, c1, c2, c3, c4);",
    ...
  ],
  "databaseName": "database6",
  "databaseProvider": "sqlancer.sqlite3.SQLite3Provider",
  "errorType": "NOREC",
  "expectedErrorsMap": {
    "INSERT OR FAIL INTO rt0 VALUES (NULL, 0.9105867290640974, \u0027\u0027, x\u00270a74\u0027, NULL), (x\u0027\u0027, NULL, 0x3cef0261, NULL, NULL), (\u0027280862872\u0027, \u00271022296673\u0027, \u0027n\u0027, x\u0027c9c3f71d\u0027, NULL);": [
      "[SQLITE_CONSTRAINT]  Abort due to constraint violation (rtree constraint failed: rt0.(c1\u003c\u003dc2))"
    ],
    ...
  },
  "reproducerData": {
    "optimizedQueryString": "SELECT COUNT(*) FROM rt0 WHERE (((SQLITE_SOURCE_ID())\u003c\u003d(rt0.c4)))",
    "unoptimizedQueryString": "SELECT SUM(count) FROM (SELECT ((((SQLITE_SOURCE_ID())\u003c\u003d(rt0.c4))) IS TRUE)  as count FROM rt0)",
    "shouldUseAggregate": "true"
  }
}
```