### PR TITLE
Renaming force_parallel_mode in PostgreSQL V16 Upgrade

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresSetGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresSetGenerator.java
@@ -112,7 +112,7 @@ public final class PostgresSetGenerator {
         JIT("jit", (r) -> Randomly.fromOptions(1, 0)),
         JOIN_COLLAPSE_LIMIT("join_collapse_limit", (r) -> r.getInteger(1, Integer.MAX_VALUE)),
         PARALLEL_LEADER_PARTICIPATION("parallel_leader_participation", (r) -> Randomly.fromOptions(1, 0)),
-        // FORCE_PARALLEL_MODE("force_parallel_mode", (r) -> Randomly.fromOptions("off", "on", "regress")),
+        DEBUG_PARALLEL_QUERY("debug_parallel_query", (r) -> Randomly.fromOptions("off", "on", "regress")),
         PLAN_CACHE_MODE("plan_cache_mode",
                 (r) -> Randomly.fromOptions("auto", "force_generic_plan", "force_custom_plan"));
 


### PR DESCRIPTION
Renaming force_parallel_mode to debug_parallel_query
Closes #1044 point 7