### PR TITLE
Fix StateToReproduce serialization

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -691,6 +691,7 @@ public final class Main {
                         executor.getLogger().logFileWriter = null;
                         executor.getLogger().logException(reduce, executor.getStateToReproduce());
                         if (options.serializeReproduceState()) {
+                            executor.getStateToReproduce().logStatement(reduce.getMessage()); // add the error statement
                             executor.getStateToReproduce().serialize(executor.getLogger().getReproduceFilePath());
                         }
                         return false;

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -28,7 +28,7 @@ public class StateToReproduce implements Serializable {
 
     String exception;
 
-    public OracleRunReproductionState localState;
+    public transient OracleRunReproductionState localState;
 
     public StateToReproduce(String databaseName, DatabaseProvider<?, ?, ?> databaseProvider) {
         this.databaseName = databaseName;


### PR DESCRIPTION
- Marked `OracleRunReproductionState localState` as `transient` to avoid serialization issues.
- Included the error-causing statement when serializing statements.