### PR TITLE
tidb: skip Data too long errors

### DIFF
--- a/src/sqlancer/tidb/TiDBErrors.java
+++ b/src/sqlancer/tidb/TiDBErrors.java
@@ -108,6 +108,9 @@ public final class TiDBErrors {
         errors.add("is not valid for CHARACTER SET");
         errors.add("for function inet_aton");
         errors.add("'Empty pattern is invalid' from regexp");
+        errors.add("Data too long for expression index");
+        errors.add("Data too long for column");
+        errors.add("Data Too Long");
 
         return errors;
     }


### PR DESCRIPTION
I found some errors, which seem to be caused by data generation issues rather than bugs in TiDB, so I think we can skip them.