### PR TITLE
Add DeleteGenerator for MariaDB

### DIFF
--- a/src/sqlancer/mariadb/MariaDBProvider.java
+++ b/src/sqlancer/mariadb/MariaDBProvider.java
@@ -19,13 +19,7 @@ import sqlancer.SQLProviderAdapter;
 import sqlancer.common.DBMSCommon;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.mariadb.MariaDBProvider.MariaDBGlobalState;
-import sqlancer.mariadb.gen.MariaDBIndexGenerator;
-import sqlancer.mariadb.gen.MariaDBInsertGenerator;
-import sqlancer.mariadb.gen.MariaDBSetGenerator;
-import sqlancer.mariadb.gen.MariaDBTableAdminCommandGenerator;
-import sqlancer.mariadb.gen.MariaDBTableGenerator;
-import sqlancer.mariadb.gen.MariaDBTruncateGenerator;
-import sqlancer.mariadb.gen.MariaDBUpdateGenerator;
+import sqlancer.mariadb.gen.*;
 
 @AutoService(DatabaseProvider.class)
 public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, MariaDBOptions> {
@@ -47,6 +41,7 @@ public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, Mari
         SET, //
         TRUNCATE, //
         UPDATE, //
+        DELETE,
     }
 
     @Override
@@ -76,6 +71,9 @@ public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, Mari
             case UPDATE:
             case CREATE_INDEX:
                 nrPerformed = globalState.getRandomly().getInteger(0, 2);
+                break;
+            case DELETE:
+                nrPerformed = 10;
                 break;
             case SET:
                 nrPerformed = 20;
@@ -139,6 +137,9 @@ public class MariaDBProvider extends SQLProviderAdapter<MariaDBGlobalState, Mari
                     break;
                 case SET:
                     query = MariaDBSetGenerator.set(globalState.getRandomly(), options);
+                    break;
+                case DELETE:
+                    query = MariaDBDeleteGenerator.delete(globalState.getSchema(), globalState.getRandomly());
                     break;
                 default:
                     throw new AssertionError(nextAction);

--- a/src/sqlancer/mariadb/gen/MariaDBDeleteGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBDeleteGenerator.java
@@ -1,0 +1,94 @@
+package sqlancer.mariadb.gen;
+
+import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractTables;
+import sqlancer.mariadb.MariaDBSchema;
+import sqlancer.mariadb.MariaDBSchema.MariaDBTable;
+import sqlancer.mariadb.MariaDBSchema.MariaDBColumn;
+import sqlancer.mariadb.ast.MariaDBVisitor;
+
+import java.util.Collections;
+
+public final class MariaDBDeleteGenerator {
+
+    private MariaDBDeleteGenerator() {
+    }
+
+    public static SQLQueryAdapter delete(MariaDBSchema schema, Randomly r) {
+        MariaDBTable table = schema.getRandomTable();
+
+        MariaDBExpressionGenerator expressionGenerator = new MariaDBExpressionGenerator(r);
+
+        AbstractTables<MariaDBTable, MariaDBColumn> tablesAndColumns =
+                new AbstractTables<>(Collections.singletonList(table));
+        expressionGenerator.setTablesAndColumns(tablesAndColumns);
+
+        ExpectedErrors errors = new ExpectedErrors();
+
+        errors.add("foreign key constraint fails");
+        errors.add("cannot delete or update a parent row");
+        errors.add("Data truncated");
+        errors.add("Division by 0");
+        errors.add("Incorrect value");
+
+        StringBuilder sb = new StringBuilder("DELETE");
+
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" LOW_PRIORITY");
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" QUICK");
+        }
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" IGNORE");
+        }
+
+        sb.append(" FROM ");
+        sb.append(table.getName());
+
+        if (Randomly.getBoolean()) {
+            sb.append(" WHERE ");
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                sb.append(MariaDBVisitor.asString(
+                        MariaDBExpressionGenerator.getRandomConstant(r)
+                ));
+            } else {
+                sb.append(MariaDBVisitor.asString(
+                        expressionGenerator.getRandomExpression()
+                ));
+            }
+        }
+
+        // ORDER BY + LIMIT
+        if (Randomly.getBooleanWithRatherLowProbability() && !table.getColumns().isEmpty()) {
+            sb.append(" ORDER BY ");
+            sb.append(Randomly.fromList(table.getColumns()).getName());
+            if (Randomly.getBoolean()) {
+                sb.append(Randomly.getBoolean() ? " ASC" : " DESC");
+            }
+        }
+
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" LIMIT ");
+            sb.append(Randomly.getNotCachedInteger(1, 10));
+        }
+
+        // RETURNING clause (MariaDB >= 10.5)
+        if (Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" RETURNING ");
+            if (Randomly.getBooleanWithRatherLowProbability()) {
+                sb.append(MariaDBVisitor.asString(
+                        MariaDBExpressionGenerator.getRandomConstant(r)
+                ));
+            } else {
+                sb.append(MariaDBVisitor.asString(
+                        expressionGenerator.getRandomExpression()
+                ));
+            }
+        }
+
+        return new SQLQueryAdapter(sb.toString(), errors);
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds support for generating `DELETE` statements in MariaDB.

### Changes

* Added `MariaDBDeleteGenerator` for creating random `DELETE` queries.
* Integrated the new `DELETE` action into `MariaDBProvider`.
* Simplified imports in `MariaDBProvider` (`import sqlancer.mariadb.gen.*`).