### PR TITLE
Shut down executor threads after timeout to prevent JaCoCo EOFException

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -716,6 +716,7 @@ public final class Main {
                 execService.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
             } else {
                 execService.awaitTermination(options.getTimeoutSeconds(), TimeUnit.SECONDS);
+                execService.shutdownNow();
             }
         } catch (InterruptedException e) {
             e.printStackTrace();

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -626,7 +626,11 @@ public final class Main {
             }
         }
 
-        ExecutorService execService = Executors.newFixedThreadPool(options.getNumberConcurrentThreads());
+        ExecutorService execService = Executors.newFixedThreadPool(options.getNumberConcurrentThreads(), r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            return t;
+        });
         DBMSExecutorFactory<?, ?, ?> executorFactory = nameToProvider.get(jc.getParsedCommand());
 
         if (options.performConnectionTest()) {
@@ -784,7 +788,11 @@ public final class Main {
         } else {
             progressMonitorStarted = true;
         }
-        final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+        final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, r -> {
+            Thread t = new Thread(r, "SQLancer-progress-monitor");
+            t.setDaemon(true);
+            return t;
+        });
         scheduler.scheduleAtFixedRate(new Runnable() {
 
             private long timeMillis = System.currentTimeMillis();


### PR DESCRIPTION
When executeMain times out, awaitTermination returns but worker threads remain running (non-daemon). For remote DBs like Materialize, threads blocked on network I/O prevent the JVM from exiting cleanly, causing surefire to forcibly kill the process before JaCoCo can flush jacoco.exec, resulting in an EOFException during report generation.

Calling shutdownNow() after the timeout interrupts threads (PostgreSQL JDBC socket reads respond to Thread.interrupt()), allowing them to exit and JaCoCo to write complete coverage data.