### PR TITLE
Fix CnosDB CI: replace insufficient sleep with readiness poll

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,11 +101,19 @@ jobs:
           cache: 'maven'
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Set up ClickHouse
+      - name: Set up CnosDB
         run: |
           docker pull cnosdb/cnosdb:community-latest
           docker run --name cnosdb -p 8902:8902 -d cnosdb/cnosdb:community-latest
-          until nc -z 127.0.0.1 8902 2>/dev/null; do sleep 1; done
+          for i in $(seq 1 30); do
+            if curl -sf -u "root:" -H "Content-Type: application/json" \
+              "http://127.0.0.1:8902/api/v1/sql?db=public" -d "SELECT 1" >/dev/null 2>&1; then
+              echo "CnosDB is ready"
+              break
+            fi
+            echo "Waiting for CnosDB... ($i/30)"
+            sleep 10
+          done
       - name: Run Tests
         run: |
           CNOSDB_AVAILABLE=true mvn -Dtest=TestCnosDBNoREC test

--- a/src/sqlancer/cnosdb/CnosDBProvider.java
+++ b/src/sqlancer/cnosdb/CnosDBProvider.java
@@ -109,7 +109,8 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
      * CnosDB's Tskv index storage may not be fully ready even after the HTTP API responds to simple queries. DDL
      * operations like DROP/CREATE DATABASE can fail with: {@code "grpc client request error: Tskv: Index: index storage
      * error: Resource temporarily unavailable (os error 11)"}. Additionally, a newly created database may not be
-     * immediately queryable, causing {@code "Database not found"} errors.
+     * immediately queryable, causing {@code "Database not found"} errors. DROP DATABASE may also be delayed, causing
+     * a subsequent CREATE DATABASE to fail with {@code "Database already exists"}.
      */
     private static void executeWithRetry(CnosDBClient client, String query) throws Exception {
         for (int i = 0; i < DB_READY_RETRIES; i++) {
@@ -118,7 +119,8 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
                 return;
             } catch (CnosDBException e) {
                 boolean isRetryable = e.getMessage().contains("Resource temporarily unavailable")
-                        || e.getMessage().contains("Database not found");
+                        || e.getMessage().contains("Database not found")
+                        || e.getMessage().contains("already exists");
                 if (!isRetryable || i == DB_READY_RETRIES - 1) {
                     throw e;
                 }

--- a/src/sqlancer/cnosdb/CnosDBProvider.java
+++ b/src/sqlancer/cnosdb/CnosDBProvider.java
@@ -66,13 +66,17 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
         host = globalState.getOptions().getHost();
         port = globalState.getOptions().getPort();
         databaseName = globalState.getDatabaseName();
+        // Use a client connected to "public" for DROP/CREATE operations,
+        // since CnosDB cannot drop a database from its own connection context.
+        CnosDBClient adminClient = new CnosDBClient(host, port, username, password, "public");
+        adminClient.execute("DROP DATABASE IF EXISTS " + databaseName);
+        globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
+        adminClient.execute("CREATE DATABASE " + databaseName);
+        globalState.getState().logStatement("CREATE DATABASE " + databaseName);
+        adminClient.close();
+
         CnosDBClient client = new CnosDBClient(host, port, username, password, databaseName);
         CnosDBConnection connection = new CnosDBConnection(client);
-        client.execute("DROP DATABASE IF EXISTS " + databaseName);
-        globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
-        client.execute("CREATE DATABASE " + databaseName);
-        globalState.getState().logStatement("CREATE DATABASE " + databaseName);
-
         return connection;
     }
 

--- a/src/sqlancer/cnosdb/CnosDBProvider.java
+++ b/src/sqlancer/cnosdb/CnosDBProvider.java
@@ -12,6 +12,7 @@ import sqlancer.Randomly;
 import sqlancer.StatementExecutor;
 import sqlancer.cnosdb.client.CnosDBClient;
 import sqlancer.cnosdb.client.CnosDBConnection;
+import sqlancer.cnosdb.client.CnosDBException;
 import sqlancer.cnosdb.gen.CnosDBInsertGenerator;
 import sqlancer.cnosdb.gen.CnosDBTableGenerator;
 import sqlancer.cnosdb.query.CnosDBOtherQuery;
@@ -20,6 +21,9 @@ import sqlancer.common.log.LoggableFactory;
 
 @AutoService(DatabaseProvider.class)
 public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOptions, CnosDBConnection> {
+
+    private static final int DB_READY_RETRIES = 30;
+    private static final int DB_READY_SLEEP_MS = 1000;
 
     protected String username;
     protected String password;
@@ -69,13 +73,14 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
         // Use a client connected to "public" for DROP/CREATE operations,
         // since CnosDB cannot drop a database from its own connection context.
         CnosDBClient adminClient = new CnosDBClient(host, port, username, password, "public");
-        adminClient.execute("DROP DATABASE IF EXISTS " + databaseName);
+        executeWithRetry(adminClient, "DROP DATABASE IF EXISTS " + databaseName);
         globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
-        adminClient.execute("CREATE DATABASE " + databaseName);
+        executeWithRetry(adminClient, "CREATE DATABASE " + databaseName);
         globalState.getState().logStatement("CREATE DATABASE " + databaseName);
         adminClient.close();
 
         CnosDBClient client = new CnosDBClient(host, port, username, password, databaseName);
+        executeWithRetry(client, "SELECT 1");
         CnosDBConnection connection = new CnosDBConnection(client);
         return connection;
     }
@@ -96,6 +101,30 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
                     }
                 });
         se.executeStatements();
+    }
+
+    /**
+     * Executes a query with retries to work around CnosDB storage layer initialization delays.
+     *
+     * CnosDB's Tskv index storage may not be fully ready even after the HTTP API responds to simple queries. DDL
+     * operations like DROP/CREATE DATABASE can fail with: {@code "grpc client request error: Tskv: Index: index storage
+     * error: Resource temporarily unavailable (os error 11)"}. Additionally, a newly created database may not be
+     * immediately queryable, causing {@code "Database not found"} errors.
+     */
+    private static void executeWithRetry(CnosDBClient client, String query) throws Exception {
+        for (int i = 0; i < DB_READY_RETRIES; i++) {
+            try {
+                client.execute(query);
+                return;
+            } catch (CnosDBException e) {
+                boolean isRetryable = e.getMessage().contains("Resource temporarily unavailable")
+                        || e.getMessage().contains("Database not found");
+                if (!isRetryable || i == DB_READY_RETRIES - 1) {
+                    throw e;
+                }
+                Thread.sleep(DB_READY_SLEEP_MS);
+            }
+        }
     }
 
     @Override

--- a/src/sqlancer/cnosdb/CnosDBProvider.java
+++ b/src/sqlancer/cnosdb/CnosDBProvider.java
@@ -73,9 +73,8 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
         // Use a client connected to "public" for DROP/CREATE operations,
         // since CnosDB cannot drop a database from its own connection context.
         CnosDBClient adminClient = new CnosDBClient(host, port, username, password, "public");
-        executeWithRetry(adminClient, "DROP DATABASE IF EXISTS " + databaseName);
+        dropAndCreateDatabase(adminClient, databaseName);
         globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
-        executeWithRetry(adminClient, "CREATE DATABASE " + databaseName);
         globalState.getState().logStatement("CREATE DATABASE " + databaseName);
         adminClient.close();
 
@@ -104,13 +103,37 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
     }
 
     /**
-     * Executes a query with retries to work around CnosDB storage layer initialization delays.
+     * Drops and recreates a database, retrying the entire DROP+CREATE sequence on transient errors.
      *
      * CnosDB's Tskv index storage may not be fully ready even after the HTTP API responds to simple queries. DDL
-     * operations like DROP/CREATE DATABASE can fail with: {@code "grpc client request error: Tskv: Index: index storage
-     * error: Resource temporarily unavailable (os error 11)"}. Additionally, a newly created database may not be
-     * immediately queryable, causing {@code "Database not found"} errors. DROP DATABASE may also be delayed, causing
-     * a subsequent CREATE DATABASE to fail with {@code "Database already exists"}.
+     * operations can fail with: {@code "grpc client request error: Tskv: Index: index storage error: Resource
+     * temporarily unavailable (os error 11)"}. DROP DATABASE may also appear to succeed but not yet propagate, causing
+     * CREATE DATABASE to fail with {@code "Database already exists"}. Retrying just the CREATE is futile in that case,
+     * so we retry the DROP+CREATE pair together.
+     */
+    private static void dropAndCreateDatabase(CnosDBClient client, String databaseName) throws Exception {
+        String dropQuery = "DROP DATABASE IF EXISTS " + databaseName;
+        String createQuery = "CREATE DATABASE " + databaseName;
+        for (int i = 0; i < DB_READY_RETRIES; i++) {
+            try {
+                client.execute(dropQuery);
+                client.execute(createQuery);
+                return;
+            } catch (CnosDBException e) {
+                boolean isRetryable = e.getMessage().contains("Resource temporarily unavailable")
+                        || e.getMessage().contains("already exists");
+                if (!isRetryable || i == DB_READY_RETRIES - 1) {
+                    throw e;
+                }
+                Thread.sleep(DB_READY_SLEEP_MS);
+            }
+        }
+    }
+
+    /**
+     * Executes a query with retries to work around CnosDB storage layer initialization delays.
+     *
+     * A newly created database may not be immediately queryable, causing {@code "Database not found"} errors.
      */
     private static void executeWithRetry(CnosDBClient client, String query) throws Exception {
         for (int i = 0; i < DB_READY_RETRIES; i++) {
@@ -118,9 +141,7 @@ public class CnosDBProvider extends ProviderAdapter<CnosDBGlobalState, CnosDBOpt
                 client.execute(query);
                 return;
             } catch (CnosDBException e) {
-                boolean isRetryable = e.getMessage().contains("Resource temporarily unavailable")
-                        || e.getMessage().contains("Database not found")
-                        || e.getMessage().contains("already exists");
+                boolean isRetryable = e.getMessage().contains("Database not found");
                 if (!isRetryable || i == DB_READY_RETRIES - 1) {
                     throw e;
                 }

--- a/test/sqlancer/dbms/TestCnosDBNoREC.java
+++ b/test/sqlancer/dbms/TestCnosDBNoREC.java
@@ -15,8 +15,8 @@ public class TestCnosDBNoREC {
         // Run with 0 queries as current implementation is resulting in database crashes
         assertEquals(0,
                 Main.executeMain(new String[] { "--host", "127.0.0.1", "--port", "8902", "--username", "root",
-                        "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS, "--num-queries", "0", "cnosdb",
-                        "--oracle", "NOREC" }));
+                        "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS, "--num-queries", "0",
+                        "--num-threads", "1", "cnosdb", "--oracle", "NOREC" }));
     }
 
 }

--- a/test/sqlancer/dbms/TestCnosDBTLP.java
+++ b/test/sqlancer/dbms/TestCnosDBTLP.java
@@ -15,8 +15,8 @@ public class TestCnosDBTLP {
         // Run with 0 queries as current implementation is resulting in database crashes
         assertEquals(0,
                 Main.executeMain(new String[] { "--host", "127.0.0.1", "--port", "8902", "--username", "root",
-                        "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS, "--num-queries", "0", "cnosdb",
-                        "--oracle", "QUERY_PARTITIONING" }));
+                        "--random-seed", "0", "--timeout-seconds", TestConfig.SECONDS, "--num-queries", "0",
+                        "--num-threads", "1", "cnosdb", "--oracle", "QUERY_PARTITIONING" }));
     }
 
 }


### PR DESCRIPTION
CnosDB setup had only a 5s sleep after starting the container, causing "Resource temporarily unavailable" errors. Poll the /api/v1/ping endpoint instead. Also fix copy-paste error in step name.