### PR TITLE
CI: Run reducer tests in Misc Tests job instead of separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Verify
         run: mvn -B verify -DskipTests=true
       - name: Misc Tests
-        run: mvn -B '-Dtest=!sqlancer.dbms.**,!sqlancer.qpg.**,!sqlancer.reducer.**' test
+        run: mvn -B '-Dtest=!sqlancer.dbms.**,!sqlancer.qpg.**' test
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -711,21 +711,3 @@ jobs:
           DORIS_AVAILABLE=true mvn -Dtest=TestDorisNoREC test
           DORIS_AVAILABLE=true mvn -Dtest=TestDorisPQS test
           DORIS_AVAILABLE=true mvn -Dtest=TestDorisTLP test
-
-  reducer:
-    name: Reducer Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-          cache: 'maven'
-      - name: Build
-        run: mvn -B package -DskipTests=true
-      - name: Run Tests
-        run: |
-          mvn -Dtest=TestStatementReducer test


### PR DESCRIPTION
Combine the standalone reducer job into the existing Misc Tests step to reduce CI overhead. The reducer tests are lightweight and don't need their own runner.