### PR TITLE
PostgreSQL: expect to_char "EEEE must be the last pattern used" error

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresCommon.java
+++ b/src/sqlancer/postgres/gen/PostgresCommon.java
@@ -122,6 +122,7 @@ public final class PostgresCommon {
         errors.add("cannot use \"S\" and \"PL\" together");
         errors.add("cannot use \"PR\" and \"S\"/\"PL\"/\"MI\"/\"SG\" together");
         errors.add("is not a number");
+        errors.add("\"EEEE\" must be the last pattern used");
 
         return errors;
     }


### PR DESCRIPTION
Random format strings fed to to_char (e.g. via md5(...)) can contain "eeee" followed by other characters, which PostgreSQL rejects with ERROR: "EEEE" must be the last pattern used. Add this to the known to_char expected errors so NoREC and similar oracles do not trip on it.