### PR TITLE
CI: upgrade Citus to PostgreSQL 17 + Citus 13.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,9 +59,11 @@ jobs:
         run: |
           echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | sudo tee  /etc/apt/sources.list.d/pgdg.list
           curl https://install.citusdata.com/community/deb.sh | sudo bash
-          sudo apt-get -y install  postgresql-15-citus-11.1
+          sudo sed -i 's/noble/jammy/g' /etc/apt/sources.list.d/citusdata_community.list # https://github.com/citusdata/citus/issues/7692
+          sudo apt-get update
+          sudo apt-get -y install  postgresql-17-citus-13.0
           sudo chown -R $USER:$USER /var/run/postgresql
-          export PATH=/usr/lib/postgresql/15/bin:$PATH
+          export PATH=/usr/lib/postgresql/17/bin:$PATH
           cd ~
           mkdir -p citus/coordinator citus/worker1 citus/worker2
           initdb -D citus/coordinator


### PR DESCRIPTION
## Summary

Upgrade the Citus version, with the plan to fix the other issues (e.g., expected errors) later.

Fixes: https://github.com/citusdata/citus/issues/7692

Split from #1301 — this PR contains only the CI version bump. The Java-side fixes for Citus 13.0 compatibility will follow in a separate PR.

## Test plan
- [ ] Citus CI job passes with PostgreSQL 17 + Citus 13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)