### PR TITLE
Fix YugabyteDB CI: use DROP DATABASE WITH (FORCE)

### DIFF
--- a/src/sqlancer/yugabyte/ysql/YSQLProvider.java
+++ b/src/sqlancer/yugabyte/ysql/YSQLProvider.java
@@ -204,11 +204,11 @@ public class YSQLProvider extends SQLProviderAdapter<YSQLGlobalState, YSQLOption
 
             Connection con = createConnectionSafely(entryURL, username, password);
             globalState.getState().logStatement(String.format("\\c %s;", entryDatabaseName));
-            globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName);
+            globalState.getState().logStatement("DROP DATABASE IF EXISTS " + databaseName + " WITH (FORCE)");
             createDatabaseCommand = getCreateDatabaseCommand(globalState);
             globalState.getState().logStatement(createDatabaseCommand);
             try (Statement s = con.createStatement()) {
-                s.execute("DROP DATABASE IF EXISTS " + databaseName);
+                s.execute("DROP DATABASE IF EXISTS " + databaseName + " WITH (FORCE)");
             }
             try (Statement s = con.createStatement()) {
                 s.execute(createDatabaseCommand);


### PR DESCRIPTION
DROP DATABASE could fail with "database is being accessed by other users" when a prior iteration's session had not yet been released, causing tests to exit with -1. Adding WITH (FORCE) terminates lingering sessions as part of the drop.