### PR TITLE
Fix Presto CI: handle bytecode compiler bugs #27608 and #27609

### DIFF
--- a/src/sqlancer/ComparatorHelper.java
+++ b/src/sqlancer/ComparatorHelper.java
@@ -70,11 +70,12 @@ public final class ComparatorHelper {
                 throw e;
             }
 
-            if (e.getMessage() == null) {
-                throw new AssertionError(queryString, e);
-            }
-            if (errors.errorIsExpected(e.getMessage())) {
-                throw new IgnoreMeException();
+            Throwable current = e;
+            while (current != null) {
+                if (current.getMessage() != null && errors.errorIsExpected(current.getMessage())) {
+                    throw new IgnoreMeException();
+                }
+                current = current.getCause();
             }
             throw new AssertionError(queryString, e);
         } finally {

--- a/src/sqlancer/presto/PrestoBugs.java
+++ b/src/sqlancer/presto/PrestoBugs.java
@@ -8,6 +8,12 @@ public final class PrestoBugs {
     // https://github.com/prestodb/presto/issues/23613
     public static boolean bug23613 = true;
 
+    // https://github.com/prestodb/presto/issues/27608
+    public static boolean bugVerifyError = true;
+
+    // https://github.com/prestodb/presto/issues/27609
+    public static boolean bugCompilerFailed = true;
+
     private PrestoBugs() {
     }
 

--- a/src/sqlancer/presto/PrestoErrors.java
+++ b/src/sqlancer/presto/PrestoErrors.java
@@ -47,6 +47,13 @@ public final class PrestoErrors {
         }
         errors.add("Cannot cast java.lang.String to java.util.List");
         errors.add("Unexpected subquery expression in logical plan");
+        if (PrestoBugs.bugVerifyError) {
+            errors.add("VerifyError");
+        }
+        if (PrestoBugs.bugCompilerFailed) {
+            errors.add("Compiler failed");
+            errors.add("Error processing class definition");
+        }
 
         // 9223372036854775808
         errors.add("Invalid numeric literal");


### PR DESCRIPTION
Walk the exception cause chain in ComparatorHelper (consistent with SQLQueryAdapter.checkException) so wrapped errors like the JDBC driver's RuntimeException are matched against expected errors.

Add VerifyError (#27608) and Compiler failed (#27609) as expected Presto bugs triggered by complex CASE expressions on Presto 0.297.