### PR TITLE
Fix Materialize CI: retry readSchema to handle eventual consistency

### DIFF
--- a/src/sqlancer/materialize/MaterializeBugs.java
+++ b/src/sqlancer/materialize/MaterializeBugs.java
@@ -1,0 +1,12 @@
+package sqlancer.materialize;
+
+// do not make the fields final to avoid warnings
+public final class MaterializeBugs {
+
+    // Tables or columns may be missing when reading information_schema shortly after creation
+    public static boolean bugSchemaReadIncomplete = true;
+
+    private MaterializeBugs() {
+    }
+
+}

--- a/src/sqlancer/materialize/MaterializeGlobalState.java
+++ b/src/sqlancer/materialize/MaterializeGlobalState.java
@@ -268,32 +268,32 @@ public class MaterializeGlobalState extends SQLGlobalState<MaterializeOptions, M
 
     @Override
     public MaterializeSchema readSchema() throws SQLException {
-        // Workaround for a suspected Materialize bug where tables or columns may be
-        // missing when reading the schema; retry until stable.
-        readSchemaCallCount++;
-        if (!MaterializeBugs.bugSchemaReadIncomplete) {
-            return MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
-        }
-        for (int tries = 0; tries < 30; tries++) {
+        if (MaterializeBugs.bugSchemaReadIncomplete) {
+            // Workaround for a suspected Materialize bug where tables or columns may be
+            // missing when reading the schema; retry until stable.
+            readSchemaCallCount++;
+            for (int tries = 0; tries < 30; tries++) {
+                MaterializeSchema schema = MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
+                boolean hasTableWithEmptyColumns = schema.getDatabaseTables().stream()
+                        .anyMatch(t -> t.getColumns().isEmpty());
+                boolean tableCountRegressed = schema.getDatabaseTables().size() < lastKnownTableCount;
+                boolean suspiciouslyEmpty = readSchemaCallCount > 1 && schema.getDatabaseTables().isEmpty();
+                if (!hasTableWithEmptyColumns && !tableCountRegressed && !suspiciouslyEmpty) {
+                    lastKnownTableCount = schema.getDatabaseTables().size();
+                    return schema;
+                }
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
             MaterializeSchema schema = MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
-            boolean hasTableWithEmptyColumns = schema.getDatabaseTables().stream()
-                    .anyMatch(t -> t.getColumns().isEmpty());
-            boolean tableCountRegressed = schema.getDatabaseTables().size() < lastKnownTableCount;
-            boolean suspiciouslyEmpty = readSchemaCallCount > 1 && schema.getDatabaseTables().isEmpty();
-            if (!hasTableWithEmptyColumns && !tableCountRegressed && !suspiciouslyEmpty) {
-                lastKnownTableCount = schema.getDatabaseTables().size();
-                return schema;
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
+            lastKnownTableCount = schema.getDatabaseTables().size();
+            return schema;
         }
-        MaterializeSchema schema = MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
-        lastKnownTableCount = schema.getDatabaseTables().size();
-        return schema;
+        return MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
     }
 
     public void addFunctionAndType(String functionName, Character functionType) {

--- a/src/sqlancer/materialize/MaterializeGlobalState.java
+++ b/src/sqlancer/materialize/MaterializeGlobalState.java
@@ -268,10 +268,12 @@ public class MaterializeGlobalState extends SQLGlobalState<MaterializeOptions, M
 
     @Override
     public MaterializeSchema readSchema() throws SQLException {
-        // Materialize's information_schema is eventually consistent: tables and columns
-        // may not be visible immediately after creation. Retry until the snapshot is
-        // consistent.
+        // Workaround for a suspected Materialize bug where tables or columns may be
+        // missing when reading the schema; retry until stable.
         readSchemaCallCount++;
+        if (!MaterializeBugs.bugSchemaReadIncomplete) {
+            return MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
+        }
         for (int tries = 0; tries < 30; tries++) {
             MaterializeSchema schema = MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
             boolean hasTableWithEmptyColumns = schema.getDatabaseTables().stream()

--- a/src/sqlancer/materialize/MaterializeGlobalState.java
+++ b/src/sqlancer/materialize/MaterializeGlobalState.java
@@ -27,6 +27,8 @@ public class MaterializeGlobalState extends SQLGlobalState<MaterializeOptions, M
     // store and allow filtering by function volatility classifications
     private final Map<String, Character> functionsAndTypes = new HashMap<>();
     private List<Character> allowedFunctionTypes = Arrays.asList(IMMUTABLE, STABLE, VOLATILE);
+    private int lastKnownTableCount;
+    private int readSchemaCallCount;
 
     @Override
     public void setConnection(SQLConnection con) {
@@ -266,7 +268,30 @@ public class MaterializeGlobalState extends SQLGlobalState<MaterializeOptions, M
 
     @Override
     public MaterializeSchema readSchema() throws SQLException {
-        return MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
+        // Materialize's information_schema is eventually consistent: tables and columns
+        // may not be visible immediately after creation. Retry until the snapshot is
+        // consistent.
+        readSchemaCallCount++;
+        for (int tries = 0; tries < 30; tries++) {
+            MaterializeSchema schema = MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
+            boolean hasTableWithEmptyColumns = schema.getDatabaseTables().stream()
+                    .anyMatch(t -> t.getColumns().isEmpty());
+            boolean tableCountRegressed = schema.getDatabaseTables().size() < lastKnownTableCount;
+            boolean suspiciouslyEmpty = readSchemaCallCount > 1 && schema.getDatabaseTables().isEmpty();
+            if (!hasTableWithEmptyColumns && !tableCountRegressed && !suspiciouslyEmpty) {
+                lastKnownTableCount = schema.getDatabaseTables().size();
+                return schema;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        MaterializeSchema schema = MaterializeSchema.fromConnection(getConnection(), getDatabaseName());
+        lastKnownTableCount = schema.getDatabaseTables().size();
+        return schema;
     }
 
     public void addFunctionAndType(String functionName, Character functionType) {


### PR DESCRIPTION
Materialize's information_schema is eventually consistent — tables and columns may not be visible immediately after creation. This caused IndexOutOfBoundsException when generators called getRandomTable() on an empty or incomplete schema. Retry readSchema() until the snapshot has no tables with empty columns and the table count has not regressed.