### PR TITLE
Refactor: extract common INSERT generation logic into AbstractInsertG…

### DIFF
--- a/src/sqlancer/clickhouse/gen/ClickHouseInsertGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseInsertGenerator.java
@@ -11,13 +11,11 @@ import sqlancer.clickhouse.ClickHouseSchema.ClickHouseColumn;
 import sqlancer.clickhouse.ClickHouseSchema.ClickHouseTable;
 import sqlancer.clickhouse.ClickHouseToStringVisitor;
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 
 public class ClickHouseInsertGenerator extends AbstractInsertGenerator<ClickHouseColumn> {
 
     private final ClickHouseGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
     private final ClickHouseExpressionGenerator gen;
 
     public ClickHouseInsertGenerator(ClickHouseGlobalState globalState) {
@@ -42,13 +40,7 @@ public class ClickHouseInsertGenerator extends AbstractInsertGenerator<ClickHous
             columns = table.getRandomNonEmptyColumnSubset().stream().filter(c -> !c.isAlias() && !c.isMaterialized())
                     .collect(Collectors.toList());
         }
-        sb.append("INSERT INTO ");
-        sb.append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
+        buildInsertInto(table.getName(), columns);
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 

--- a/src/sqlancer/common/gen/AbstractInsertGenerator.java
+++ b/src/sqlancer/common/gen/AbstractInsertGenerator.java
@@ -1,12 +1,30 @@
 package sqlancer.common.gen;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.schema.AbstractTableColumn;
 
-public abstract class AbstractInsertGenerator<C> {
+public abstract class AbstractInsertGenerator<C extends AbstractTableColumn<?, ?>> {
 
     protected StringBuilder sb = new StringBuilder();
+    protected ExpectedErrors errors = new ExpectedErrors();
+
+    protected void appendColumnList(List<C> columns) {
+        sb.append("(");
+        sb.append(columns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
+        sb.append(")");
+    }
+
+    protected void buildInsertInto(String tableName, List<C> columns) {
+        sb.append("INSERT INTO ");
+        sb.append(tableName);
+        appendColumnList(columns);
+        sb.append(" VALUES ");
+        insertColumns(columns);
+    }
 
     protected void insertColumns(List<C> columns) {
         for (int nrRows = 0; nrRows < Randomly.smallNumber() + 1; nrRows++) {

--- a/src/sqlancer/databend/gen/DatabendInsertGenerator.java
+++ b/src/sqlancer/databend/gen/DatabendInsertGenerator.java
@@ -1,12 +1,9 @@
 package sqlancer.databend.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.databend.DatabendErrors;
 import sqlancer.databend.DatabendProvider.DatabendGlobalState;
 import sqlancer.databend.DatabendSchema.DatabendColumn;
@@ -16,7 +13,6 @@ import sqlancer.databend.DatabendToStringVisitor;
 public class DatabendInsertGenerator extends AbstractInsertGenerator<DatabendColumn> {
 
     private final DatabendGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
 
     public DatabendInsertGenerator(DatabendGlobalState globalState) {
         this.globalState = globalState;
@@ -27,15 +23,9 @@ public class DatabendInsertGenerator extends AbstractInsertGenerator<DatabendCol
     }
 
     private SQLQueryAdapter generate() {
-        sb.append("INSERT INTO ");
         DatabendTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<DatabendColumn> columns = table.getRandomNonEmptyColumnSubset();
-        sb.append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
+        buildInsertInto(table.getName(), columns);
         DatabendErrors.addInsertErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/datafusion/gen/DataFusionInsertGenerator.java
+++ b/src/sqlancer/datafusion/gen/DataFusionInsertGenerator.java
@@ -1,11 +1,9 @@
 package sqlancer.datafusion.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.datafusion.DataFusionProvider.DataFusionGlobalState;
 import sqlancer.datafusion.DataFusionSchema.DataFusionColumn;
@@ -15,7 +13,6 @@ import sqlancer.datafusion.DataFusionToStringVisitor;
 public class DataFusionInsertGenerator extends AbstractInsertGenerator<DataFusionColumn> {
 
     private final DataFusionGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
 
     public DataFusionInsertGenerator(DataFusionGlobalState globalState) {
         this.globalState = globalState;
@@ -26,21 +23,11 @@ public class DataFusionInsertGenerator extends AbstractInsertGenerator<DataFusio
     }
 
     private SQLQueryAdapter generate(DataFusionTable targetTable) {
-        // `sb` is a global `StringBuilder` for current insert query
-        sb.append("INSERT INTO ");
-
         if (targetTable.getColumns().isEmpty()) {
             throw new IgnoreMeException();
         }
         List<DataFusionColumn> columns = targetTable.getRandomNonEmptyColumnSubset();
-
-        sb.append(targetTable.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns); // will finally call `insertValue()` to generate random value
-
+        buildInsertInto(targetTable.getName(), columns);
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 

--- a/src/sqlancer/doris/gen/DorisInsertGenerator.java
+++ b/src/sqlancer/doris/gen/DorisInsertGenerator.java
@@ -1,11 +1,9 @@
 package sqlancer.doris.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.doris.DorisErrors;
 import sqlancer.doris.DorisProvider.DorisGlobalState;
@@ -16,7 +14,6 @@ import sqlancer.doris.visitor.DorisToStringVisitor;
 public class DorisInsertGenerator extends AbstractInsertGenerator<DorisColumn> {
 
     private final DorisGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
 
     public DorisInsertGenerator(DorisGlobalState globalState) {
         this.globalState = globalState;
@@ -27,15 +24,9 @@ public class DorisInsertGenerator extends AbstractInsertGenerator<DorisColumn> {
     }
 
     private SQLQueryAdapter generate() {
-        sb.append("INSERT INTO ");
         DorisTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<DorisColumn> columns = table.getRandomNonEmptyInsertColumns();
-        sb.append(table.getName());
-        sb.append(" (");
-        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
+        buildInsertInto(table.getName(), columns);
         DorisErrors.addInsertErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/duckdb/gen/DuckDBInsertGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBInsertGenerator.java
@@ -1,11 +1,9 @@
 package sqlancer.duckdb.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.duckdb.DuckDBErrors;
 import sqlancer.duckdb.DuckDBProvider.DuckDBGlobalState;
@@ -16,7 +14,6 @@ import sqlancer.duckdb.DuckDBToStringVisitor;
 public class DuckDBInsertGenerator extends AbstractInsertGenerator<DuckDBColumn> {
 
     private final DuckDBGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
 
     public DuckDBInsertGenerator(DuckDBGlobalState globalState) {
         this.globalState = globalState;
@@ -27,15 +24,9 @@ public class DuckDBInsertGenerator extends AbstractInsertGenerator<DuckDBColumn>
     }
 
     private SQLQueryAdapter generate() {
-        sb.append("INSERT INTO ");
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<DuckDBColumn> columns = table.getRandomNonEmptyColumnSubsetFilter(p -> !p.getName().equals("rowid"));
-        sb.append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
+        buildInsertInto(table.getName(), columns);
         DuckDBErrors.addInsertErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/h2/H2InsertGenerator.java
+++ b/src/sqlancer/h2/H2InsertGenerator.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.h2.H2Provider.H2GlobalState;
 import sqlancer.h2.H2Schema.H2Column;
@@ -14,7 +13,6 @@ import sqlancer.h2.H2Schema.H2Table;
 public class H2InsertGenerator extends AbstractInsertGenerator<H2Column> {
 
     private final H2GlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
     private final H2ExpressionGenerator gen;
 
     public H2InsertGenerator(H2GlobalState globalState) {
@@ -39,9 +37,7 @@ public class H2InsertGenerator extends AbstractInsertGenerator<H2Column> {
         H2Table table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<H2Column> columns = table.getRandomNonEmptyColumnSubset();
         sb.append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
+        appendColumnList(columns);
         if (mergeInto && Randomly.getBoolean()) {
             sb.append(" KEY(");
             sb.append(table.getRandomNonEmptyColumnSubset().stream().map(c -> c.getName())

--- a/src/sqlancer/hive/gen/HiveInsertGenerator.java
+++ b/src/sqlancer/hive/gen/HiveInsertGenerator.java
@@ -3,7 +3,6 @@ package sqlancer.hive.gen;
 import java.util.List;
 
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.hive.HiveErrors;
 import sqlancer.hive.HiveGlobalState;
@@ -14,7 +13,6 @@ import sqlancer.hive.HiveToStringVisitor;
 public class HiveInsertGenerator extends AbstractInsertGenerator<HiveColumn> {
 
     private final HiveGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
     private final HiveExpressionGenerator gen;
 
     public HiveInsertGenerator(HiveGlobalState globalState) {

--- a/src/sqlancer/hsqldb/gen/HSQLDBInsertGenerator.java
+++ b/src/sqlancer/hsqldb/gen/HSQLDBInsertGenerator.java
@@ -1,10 +1,8 @@
 package sqlancer.hsqldb.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.hsqldb.HSQLDBProvider;
 import sqlancer.hsqldb.HSQLDBSchema;
@@ -14,7 +12,6 @@ import sqlancer.hsqldb.ast.HSQLDBExpression;
 public class HSQLDBInsertGenerator extends AbstractInsertGenerator<HSQLDBSchema.HSQLDBColumn> {
 
     private final HSQLDBProvider.HSQLDBGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
 
     public HSQLDBInsertGenerator(HSQLDBProvider.HSQLDBGlobalState globalState) {
         this.globalState = globalState;
@@ -25,16 +22,9 @@ public class HSQLDBInsertGenerator extends AbstractInsertGenerator<HSQLDBSchema.
     }
 
     private SQLQueryAdapter generate() {
-        sb.append("INSERT INTO ");
         HSQLDBSchema.HSQLDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<HSQLDBSchema.HSQLDBColumn> columns = table.getRandomNonEmptyColumnSubset();
-        sb.append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
-        // HSQLDBErrors.addInsertErrors(errors);
+        buildInsertInto(table.getName(), columns);
         return new SQLQueryAdapter(sb.toString(), errors);
     }
 

--- a/src/sqlancer/presto/gen/PrestoInsertGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoInsertGenerator.java
@@ -1,10 +1,8 @@
 package sqlancer.presto.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.presto.PrestoErrors;
 import sqlancer.presto.PrestoGlobalState;
@@ -26,16 +24,9 @@ public class PrestoInsertGenerator extends AbstractInsertGenerator<PrestoColumn>
     }
 
     private SQLQueryAdapter generate() {
-        sb.append("INSERT INTO ");
         PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<PrestoColumn> columns = table.getRandomNonEmptyColumnSubset();
-        sb.append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
-        ExpectedErrors errors = new ExpectedErrors();
+        buildInsertInto(table.getName(), columns);
         PrestoErrors.addInsertErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors, false, false);
     }

--- a/src/sqlancer/questdb/gen/QuestDBInsertGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBInsertGenerator.java
@@ -1,12 +1,9 @@
 package sqlancer.questdb.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.questdb.QuestDBErrors;
 import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
 import sqlancer.questdb.QuestDBSchema.QuestDBColumn;
@@ -17,22 +14,14 @@ public class QuestDBInsertGenerator extends AbstractInsertGenerator<QuestDBColum
 
     private final QuestDBGlobalState globalState;
 
-    private final ExpectedErrors errors = new ExpectedErrors();
-
     public QuestDBInsertGenerator(QuestDBGlobalState globalState) {
         this.globalState = globalState;
     }
 
     private SQLQueryAdapter generate() {
-        sb.append("INSERT INTO ");
         QuestDBTable table = globalState.getSchema().getRandomTable();
         List<QuestDBColumn> columns = table.getRandomNonEmptyColumnSubset();
-        sb.append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
+        buildInsertInto(table.getName(), columns);
         QuestDBErrors.addInsertErrors(errors);
         return new SQLQueryAdapter(sb.toString(), errors);
     }

--- a/src/sqlancer/spark/gen/SparkInsertGenerator.java
+++ b/src/sqlancer/spark/gen/SparkInsertGenerator.java
@@ -3,7 +3,6 @@ package sqlancer.spark.gen;
 import java.util.List;
 
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.spark.SparkErrors;
 import sqlancer.spark.SparkGlobalState;
@@ -14,7 +13,6 @@ import sqlancer.spark.SparkToStringVisitor;
 public class SparkInsertGenerator extends AbstractInsertGenerator<SparkColumn> {
 
     private final SparkGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
     private final SparkExpressionGenerator gen;
 
     public SparkInsertGenerator(SparkGlobalState globalState) {

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLInsertGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLInsertGenerator.java
@@ -1,12 +1,9 @@
 package sqlancer.yugabyte.ycql.gen;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import sqlancer.common.gen.AbstractInsertGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.yugabyte.ycql.YCQLErrors;
 import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
 import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
@@ -16,7 +13,6 @@ import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
 public class YCQLInsertGenerator extends AbstractInsertGenerator<YCQLColumn> {
 
     private final YCQLGlobalState globalState;
-    private final ExpectedErrors errors = new ExpectedErrors();
 
     public YCQLInsertGenerator(YCQLGlobalState globalState) {
         this.globalState = globalState;
@@ -27,15 +23,9 @@ public class YCQLInsertGenerator extends AbstractInsertGenerator<YCQLColumn> {
     }
 
     private SQLQueryAdapter generate() {
-        sb.append("INSERT INTO ");
         YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<YCQLColumn> columns = table.getColumns();
-        sb.append(globalState.getDatabaseName()).append(".").append(table.getName());
-        sb.append("(");
-        sb.append(columns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
-        sb.append(")");
-        sb.append(" VALUES ");
-        insertColumns(columns);
+        buildInsertInto(globalState.getDatabaseName() + "." + table.getName(), columns);
 
         errors.add("Invalid Arguments");
         errors.add("Null Argument for Primary Key");


### PR DESCRIPTION
…enerator

Move shared boilerplate (INSERT INTO, column list, ExpectedErrors field) from 12 concrete InsertGenerator subclasses into AbstractInsertGenerator, reducing ~79 lines of duplicated code.