### PR TITLE
Unify INSERT/UPDATE/DELETE generators under AbstractGenerator hierarchy

### DIFF
--- a/src/sqlancer/clickhouse/gen/ClickHouseInsertGenerator.java
+++ b/src/sqlancer/clickhouse/gen/ClickHouseInsertGenerator.java
@@ -1,6 +1,5 @@
 package sqlancer.clickhouse.gen;
 
-import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,11 +28,12 @@ public class ClickHouseInsertGenerator extends AbstractInsertGenerator<ClickHous
         ClickHouseErrors.addExpectedExpressionErrors(errors);
     }
 
-    public static SQLQueryAdapter getQuery(ClickHouseGlobalState globalState) throws SQLException {
-        return new ClickHouseInsertGenerator(globalState).get();
+    public static SQLQueryAdapter getQuery(ClickHouseGlobalState globalState) {
+        return new ClickHouseInsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter get() {
+    @Override
+    public void buildStatement() {
         ClickHouseTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<ClickHouseColumn> columns = Collections.emptyList();
         while (columns.isEmpty()) {
@@ -41,7 +41,6 @@ public class ClickHouseInsertGenerator extends AbstractInsertGenerator<ClickHous
                     .collect(Collectors.toList());
         }
         buildInsertInto(table.getName(), columns);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/cockroachdb/gen/CockroachDBDeleteGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBDeleteGenerator.java
@@ -6,17 +6,23 @@ import sqlancer.cockroachdb.CockroachDBProvider.CockroachDBGlobalState;
 import sqlancer.cockroachdb.CockroachDBSchema.CockroachDBDataType;
 import sqlancer.cockroachdb.CockroachDBSchema.CockroachDBTable;
 import sqlancer.cockroachdb.CockroachDBVisitor;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 
-public final class CockroachDBDeleteGenerator {
+public final class CockroachDBDeleteGenerator extends AbstractDeleteGenerator {
 
-    private CockroachDBDeleteGenerator() {
+    private final CockroachDBGlobalState globalState;
+
+    private CockroachDBDeleteGenerator(CockroachDBGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter delete(CockroachDBGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
+        return new CockroachDBDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         CockroachDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append("DELETE FROM ");
         sb.append(table.getName());
@@ -30,7 +36,6 @@ public final class CockroachDBDeleteGenerator {
         }
         errors.add("foreign key violation");
         CockroachDBErrors.addTransactionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBIndexGenerator.java
@@ -21,7 +21,7 @@ public class CockroachDBIndexGenerator extends CockroachDBGenerator {
         if (s.getSchema().getIndexCount() >= s.getDbmsSpecificOptions().maxNumIndexes) {
             throw new IgnoreMeException();
         }
-        return new CockroachDBIndexGenerator(s).getQuery();
+        return new CockroachDBIndexGenerator(s).getStatement();
     }
 
     @Override

--- a/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBTableGenerator.java
@@ -32,7 +32,7 @@ public class CockroachDBTableGenerator extends CockroachDBGenerator {
         if (globalState.getSchema().getDatabaseTables().size() > globalState.getDbmsSpecificOptions().maxNumTables) {
             throw new IgnoreMeException();
         }
-        return new CockroachDBTableGenerator(globalState).getQuery();
+        return new CockroachDBTableGenerator(globalState).getStatement();
     }
 
     @Override

--- a/src/sqlancer/cockroachdb/gen/CockroachDBUpdateGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBUpdateGenerator.java
@@ -22,10 +22,11 @@ public final class CockroachDBUpdateGenerator extends AbstractUpdateGenerator<Co
     }
 
     public static SQLQueryAdapter gen(CockroachDBGlobalState globalState) {
-        return new CockroachDBUpdateGenerator(globalState).generate();
+        return new CockroachDBUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         CockroachDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<CockroachDBColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new CockroachDBExpressionGenerator(globalState).setColumns(columns);
@@ -51,7 +52,6 @@ public final class CockroachDBUpdateGenerator extends AbstractUpdateGenerator<Co
         errors.add("cannot write directly to computed column");
         CockroachDBErrors.addExpressionErrors(errors);
         CockroachDBErrors.addTransactionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/common/gen/AbstractDeleteGenerator.java
+++ b/src/sqlancer/common/gen/AbstractDeleteGenerator.java
@@ -2,4 +2,7 @@ package sqlancer.common.gen;
 
 public abstract class AbstractDeleteGenerator extends AbstractGenerator {
 
+    protected AbstractDeleteGenerator() {
+    }
+
 }

--- a/src/sqlancer/common/gen/AbstractDeleteGenerator.java
+++ b/src/sqlancer/common/gen/AbstractDeleteGenerator.java
@@ -1,0 +1,5 @@
+package sqlancer.common.gen;
+
+public abstract class AbstractDeleteGenerator extends AbstractGenerator {
+
+}

--- a/src/sqlancer/common/gen/AbstractGenerator.java
+++ b/src/sqlancer/common/gen/AbstractGenerator.java
@@ -8,10 +8,11 @@ public abstract class AbstractGenerator {
     protected final ExpectedErrors errors = new ExpectedErrors();
     protected final StringBuilder sb = new StringBuilder();
     protected boolean canAffectSchema;
+    protected boolean canonicalizeString = true;
 
-    public SQLQueryAdapter getQuery() {
+    public SQLQueryAdapter getStatement() {
         buildStatement();
-        return new SQLQueryAdapter(sb.toString(), errors, canAffectSchema);
+        return new SQLQueryAdapter(sb.toString(), errors, canAffectSchema, canonicalizeString);
     }
 
     public abstract void buildStatement();

--- a/src/sqlancer/common/gen/AbstractInsertGenerator.java
+++ b/src/sqlancer/common/gen/AbstractInsertGenerator.java
@@ -4,13 +4,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.schema.AbstractTableColumn;
 
-public abstract class AbstractInsertGenerator<C extends AbstractTableColumn<?, ?>> {
-
-    protected StringBuilder sb = new StringBuilder();
-    protected ExpectedErrors errors = new ExpectedErrors();
+public abstract class AbstractInsertGenerator<C extends AbstractTableColumn<?, ?>> extends AbstractGenerator {
 
     protected void appendColumnList(List<C> columns) {
         sb.append("(");

--- a/src/sqlancer/common/gen/AbstractUpdateGenerator.java
+++ b/src/sqlancer/common/gen/AbstractUpdateGenerator.java
@@ -2,13 +2,9 @@ package sqlancer.common.gen;
 
 import java.util.List;
 
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.schema.AbstractTableColumn;
 
-public abstract class AbstractUpdateGenerator<C extends AbstractTableColumn<?, ?>> {
-
-    protected final ExpectedErrors errors = new ExpectedErrors();
-    protected StringBuilder sb = new StringBuilder();
+public abstract class AbstractUpdateGenerator<C extends AbstractTableColumn<?, ?>> extends AbstractGenerator {
 
     protected void updateColumns(List<C> columns) {
         for (int nrColumn = 0; nrColumn < columns.size(); nrColumn++) {

--- a/src/sqlancer/databend/gen/DatabendDeleteGenerator.java
+++ b/src/sqlancer/databend/gen/DatabendDeleteGenerator.java
@@ -1,21 +1,28 @@
 package sqlancer.databend.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.databend.DatabendErrors;
 import sqlancer.databend.DatabendProvider.DatabendGlobalState;
 import sqlancer.databend.DatabendSchema.DatabendDataType;
 import sqlancer.databend.DatabendToStringVisitor;
 
-public final class DatabendDeleteGenerator {
+public final class DatabendDeleteGenerator extends AbstractDeleteGenerator {
 
-    private DatabendDeleteGenerator() {
+    private final DatabendGlobalState globalState;
+
+    private DatabendDeleteGenerator(DatabendGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter generate(DatabendGlobalState globalState) {
-        StringBuilder sb = new StringBuilder("DELETE FROM ");
-        ExpectedErrors errors = new ExpectedErrors();
+        return new DatabendDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        sb.append("DELETE FROM ");
         sb.append(globalState.getSchema().getRandomTable(t -> !t.isView()).getName());
         if (Randomly.getBoolean()) {
             sb.append(" WHERE ");
@@ -23,7 +30,6 @@ public final class DatabendDeleteGenerator {
                     new DatabendNewExpressionGenerator(globalState).generateExpression(DatabendDataType.BOOLEAN)));
             DatabendErrors.addExpressionErrors(errors);
         }
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/databend/gen/DatabendInsertGenerator.java
+++ b/src/sqlancer/databend/gen/DatabendInsertGenerator.java
@@ -19,15 +19,15 @@ public class DatabendInsertGenerator extends AbstractInsertGenerator<DatabendCol
     }
 
     public static SQLQueryAdapter getQuery(DatabendGlobalState globalState) {
-        return new DatabendInsertGenerator(globalState).generate();
+        return new DatabendInsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         DatabendTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<DatabendColumn> columns = table.getRandomNonEmptyColumnSubset();
         buildInsertInto(table.getName(), columns);
         DatabendErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/datafusion/gen/DataFusionInsertGenerator.java
+++ b/src/sqlancer/datafusion/gen/DataFusionInsertGenerator.java
@@ -13,22 +13,24 @@ import sqlancer.datafusion.DataFusionToStringVisitor;
 public class DataFusionInsertGenerator extends AbstractInsertGenerator<DataFusionColumn> {
 
     private final DataFusionGlobalState globalState;
+    private final DataFusionTable targetTable;
 
-    public DataFusionInsertGenerator(DataFusionGlobalState globalState) {
+    public DataFusionInsertGenerator(DataFusionGlobalState globalState, DataFusionTable targetTable) {
         this.globalState = globalState;
+        this.targetTable = targetTable;
     }
 
     public static SQLQueryAdapter getQuery(DataFusionGlobalState globalState, DataFusionTable targetTable) {
-        return new DataFusionInsertGenerator(globalState).generate(targetTable);
+        return new DataFusionInsertGenerator(globalState, targetTable).getStatement();
     }
 
-    private SQLQueryAdapter generate(DataFusionTable targetTable) {
+    @Override
+    public void buildStatement() {
         if (targetTable.getColumns().isEmpty()) {
             throw new IgnoreMeException();
         }
         List<DataFusionColumn> columns = targetTable.getRandomNonEmptyColumnSubset();
         buildInsertInto(targetTable.getName(), columns);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/doris/gen/DorisDeleteGenerator.java
+++ b/src/sqlancer/doris/gen/DorisDeleteGenerator.java
@@ -1,7 +1,7 @@
 package sqlancer.doris.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.doris.DorisErrors;
 import sqlancer.doris.DorisProvider.DorisGlobalState;
@@ -9,14 +9,21 @@ import sqlancer.doris.DorisSchema;
 import sqlancer.doris.DorisSchema.DorisTable;
 import sqlancer.doris.visitor.DorisToStringVisitor;
 
-public final class DorisDeleteGenerator {
+public final class DorisDeleteGenerator extends AbstractDeleteGenerator {
 
-    private DorisDeleteGenerator() {
+    private final DorisGlobalState globalState;
+
+    private DorisDeleteGenerator(DorisGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter generate(DorisGlobalState globalState) {
-        StringBuilder sb = new StringBuilder("DELETE FROM ");
-        ExpectedErrors errors = new ExpectedErrors();
+        return new DorisDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        sb.append("DELETE FROM ");
         DorisTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
         if (Randomly.getBoolean()) {
@@ -25,7 +32,6 @@ public final class DorisDeleteGenerator {
                     .setColumns(table.getColumns()).generateExpression(DorisSchema.DorisDataType.BOOLEAN)));
             DorisErrors.addExpressionErrors(errors);
         }
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/doris/gen/DorisInsertGenerator.java
+++ b/src/sqlancer/doris/gen/DorisInsertGenerator.java
@@ -20,15 +20,15 @@ public class DorisInsertGenerator extends AbstractInsertGenerator<DorisColumn> {
     }
 
     public static SQLQueryAdapter getQuery(DorisGlobalState globalState) {
-        return new DorisInsertGenerator(globalState).generate();
+        return new DorisInsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         DorisTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        List<DorisColumn> columns = table.getRandomNonEmptyInsertColumns();
+        List<DorisColumn> columns = table.getRandomNonEmptyColumnSubset();
         buildInsertInto(table.getName(), columns);
         DorisErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/doris/gen/DorisUpdateGenerator.java
+++ b/src/sqlancer/doris/gen/DorisUpdateGenerator.java
@@ -23,10 +23,11 @@ public final class DorisUpdateGenerator extends AbstractUpdateGenerator<DorisCol
     }
 
     public static SQLQueryAdapter getQuery(DorisGlobalState globalState) {
-        return new DorisUpdateGenerator(globalState).generate();
+        return new DorisUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         DorisTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<DorisColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new DorisNewExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -37,7 +38,6 @@ public final class DorisUpdateGenerator extends AbstractUpdateGenerator<DorisCol
         sb.append(" WHERE ");
         sb.append(DorisToStringVisitor.asString(gen.generateExpression(DorisSchema.DorisDataType.BOOLEAN)));
         DorisErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/duckdb/gen/DuckDBDeleteGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBDeleteGenerator.java
@@ -1,21 +1,28 @@
 package sqlancer.duckdb.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.duckdb.DuckDBErrors;
 import sqlancer.duckdb.DuckDBProvider.DuckDBGlobalState;
 import sqlancer.duckdb.DuckDBSchema.DuckDBTable;
 import sqlancer.duckdb.DuckDBToStringVisitor;
 
-public final class DuckDBDeleteGenerator {
+public final class DuckDBDeleteGenerator extends AbstractDeleteGenerator {
 
-    private DuckDBDeleteGenerator() {
+    private final DuckDBGlobalState globalState;
+
+    private DuckDBDeleteGenerator(DuckDBGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter generate(DuckDBGlobalState globalState) {
-        StringBuilder sb = new StringBuilder("DELETE FROM ");
-        ExpectedErrors errors = new ExpectedErrors();
+        return new DuckDBDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        sb.append("DELETE FROM ");
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
         if (Randomly.getBoolean()) {
@@ -24,7 +31,6 @@ public final class DuckDBDeleteGenerator {
                     new DuckDBExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
         }
         DuckDBErrors.addExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/duckdb/gen/DuckDBInsertGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBInsertGenerator.java
@@ -20,15 +20,15 @@ public class DuckDBInsertGenerator extends AbstractInsertGenerator<DuckDBColumn>
     }
 
     public static SQLQueryAdapter getQuery(DuckDBGlobalState globalState) {
-        return new DuckDBInsertGenerator(globalState).generate();
+        return new DuckDBInsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<DuckDBColumn> columns = table.getRandomNonEmptyColumnSubsetFilter(p -> !p.getName().equals("rowid"));
         buildInsertInto(table.getName(), columns);
         DuckDBErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/duckdb/gen/DuckDBUpdateGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBUpdateGenerator.java
@@ -22,10 +22,11 @@ public final class DuckDBUpdateGenerator extends AbstractUpdateGenerator<DuckDBC
     }
 
     public static SQLQueryAdapter getQuery(DuckDBGlobalState globalState) {
-        return new DuckDBUpdateGenerator(globalState).generate();
+        return new DuckDBUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<DuckDBColumn> columns = table.getRandomNonEmptyColumnSubsetFilter(p -> !p.getName().equals("rowid"));
         gen = new DuckDBExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -34,7 +35,6 @@ public final class DuckDBUpdateGenerator extends AbstractUpdateGenerator<DuckDBC
         sb.append(" SET ");
         updateColumns(columns);
         DuckDBErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/h2/H2DeleteGenerator.java
+++ b/src/sqlancer/h2/H2DeleteGenerator.java
@@ -1,19 +1,26 @@
 package sqlancer.h2;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.h2.H2Provider.H2GlobalState;
 import sqlancer.h2.H2Schema.H2Table;
 
-public final class H2DeleteGenerator {
+public final class H2DeleteGenerator extends AbstractDeleteGenerator {
 
-    private H2DeleteGenerator() {
+    private final H2GlobalState globalState;
+
+    private H2DeleteGenerator(H2GlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter getQuery(H2GlobalState globalState) {
-        StringBuilder sb = new StringBuilder("DELETE FROM ");
-        ExpectedErrors errors = new ExpectedErrors();
+        return new H2DeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        sb.append("DELETE FROM ");
         H2Table table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
         if (Randomly.getBoolean()) {
@@ -27,7 +34,6 @@ public final class H2DeleteGenerator {
         }
         H2Errors.addExpressionErrors(errors);
         H2Errors.addDeleteErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/h2/H2InsertGenerator.java
+++ b/src/sqlancer/h2/H2InsertGenerator.java
@@ -21,10 +21,11 @@ public class H2InsertGenerator extends AbstractInsertGenerator<H2Column> {
     }
 
     public static SQLQueryAdapter getQuery(H2GlobalState globalState) {
-        return new H2InsertGenerator(globalState).generate();
+        return new H2InsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         boolean mergeInto = false; // Randomly.getBooleanWithRatherLowProbability();
         if (mergeInto) {
             sb.append("MERGE INTO ");
@@ -48,7 +49,6 @@ public class H2InsertGenerator extends AbstractInsertGenerator<H2Column> {
         insertColumns(columns);
         H2Errors.addInsertErrors(errors);
         H2Errors.addExpressionErrors(errors); // generated columns
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/h2/H2UpdateGenerator.java
+++ b/src/sqlancer/h2/H2UpdateGenerator.java
@@ -19,10 +19,11 @@ public final class H2UpdateGenerator extends AbstractUpdateGenerator<H2Column> {
     }
 
     public static SQLQueryAdapter getQuery(H2GlobalState globalState) {
-        return new H2UpdateGenerator(globalState).generate();
+        return new H2UpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         H2Table table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<H2Column> columns = table.getRandomNonEmptyColumnSubset();
         gen = new H2ExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -37,7 +38,6 @@ public final class H2UpdateGenerator extends AbstractUpdateGenerator<H2Column> {
             sb.append(H2ToStringVisitor.asString(gen.generateExpression()));
         }
         H2Errors.addExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/hive/gen/HiveInsertGenerator.java
+++ b/src/sqlancer/hive/gen/HiveInsertGenerator.java
@@ -18,10 +18,11 @@ public class HiveInsertGenerator extends AbstractInsertGenerator<HiveColumn> {
     public HiveInsertGenerator(HiveGlobalState globalState) {
         this.globalState = globalState;
         this.gen = new HiveExpressionGenerator(globalState);
+        this.canonicalizeString = false;
     }
 
     public static SQLQueryAdapter getQuery(HiveGlobalState globalState) {
-        return new HiveInsertGenerator(globalState).generate();
+        return new HiveInsertGenerator(globalState).getStatement();
     }
 
     @Override
@@ -29,7 +30,8 @@ public class HiveInsertGenerator extends AbstractInsertGenerator<HiveColumn> {
         sb.append(HiveToStringVisitor.asString(gen.generateConstant()));
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         // Inserting values into tables from SQL.
         sb.append("INSERT INTO ");
         HiveTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
@@ -45,6 +47,5 @@ public class HiveInsertGenerator extends AbstractInsertGenerator<HiveColumn> {
         insertColumns(columns);
 
         HiveErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, false, false);
     }
 }

--- a/src/sqlancer/hsqldb/gen/HSQLDBInsertGenerator.java
+++ b/src/sqlancer/hsqldb/gen/HSQLDBInsertGenerator.java
@@ -18,14 +18,14 @@ public class HSQLDBInsertGenerator extends AbstractInsertGenerator<HSQLDBSchema.
     }
 
     public static SQLQueryAdapter getQuery(HSQLDBProvider.HSQLDBGlobalState globalState) {
-        return new HSQLDBInsertGenerator(globalState).generate();
+        return new HSQLDBInsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         HSQLDBSchema.HSQLDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<HSQLDBSchema.HSQLDBColumn> columns = table.getRandomNonEmptyColumnSubset();
         buildInsertInto(table.getName(), columns);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/hsqldb/gen/HSQLDBUpdateGenerator.java
+++ b/src/sqlancer/hsqldb/gen/HSQLDBUpdateGenerator.java
@@ -24,10 +24,11 @@ public final class HSQLDBUpdateGenerator extends AbstractUpdateGenerator<HSQLDBC
     }
 
     public static SQLQueryAdapter getQuery(HSQLDBProvider.HSQLDBGlobalState globalState) {
-        return new HSQLDBUpdateGenerator(globalState).generate();
+        return new HSQLDBUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         HSQLDBSchema.HSQLDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<HSQLDBSchema.HSQLDBColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new HSQLDBExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -42,7 +43,6 @@ public final class HSQLDBUpdateGenerator extends AbstractUpdateGenerator<HSQLDBC
             errors.add("data type of expression is not boolean");
             HSQLDBErrors.addExpressionErrors(errors);
         }
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/mariadb/gen/MariaDBDeleteGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBDeleteGenerator.java
@@ -3,7 +3,7 @@ package sqlancer.mariadb.gen;
 import java.util.Collections;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.schema.AbstractTables;
 import sqlancer.mariadb.MariaDBSchema;
@@ -11,12 +11,22 @@ import sqlancer.mariadb.MariaDBSchema.MariaDBColumn;
 import sqlancer.mariadb.MariaDBSchema.MariaDBTable;
 import sqlancer.mariadb.ast.MariaDBVisitor;
 
-public final class MariaDBDeleteGenerator {
+public final class MariaDBDeleteGenerator extends AbstractDeleteGenerator {
 
-    private MariaDBDeleteGenerator() {
+    private final MariaDBSchema schema;
+    private final Randomly r;
+
+    private MariaDBDeleteGenerator(MariaDBSchema schema, Randomly r) {
+        this.schema = schema;
+        this.r = r;
     }
 
     public static SQLQueryAdapter delete(MariaDBSchema schema, Randomly r) {
+        return new MariaDBDeleteGenerator(schema, r).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         MariaDBTable table = schema.getRandomTable();
 
         MariaDBExpressionGenerator expressionGenerator = new MariaDBExpressionGenerator(r);
@@ -25,15 +35,13 @@ public final class MariaDBDeleteGenerator {
                 Collections.singletonList(table));
         expressionGenerator.setTablesAndColumns(tablesAndColumns);
 
-        ExpectedErrors errors = new ExpectedErrors();
-
         errors.add("foreign key constraint fails");
         errors.add("cannot delete or update a parent row");
         errors.add("Data truncated");
         errors.add("Division by 0");
         errors.add("Incorrect value");
 
-        StringBuilder sb = new StringBuilder("DELETE");
+        sb.append("DELETE");
 
         if (Randomly.getBooleanWithRatherLowProbability()) {
             sb.append(" LOW_PRIORITY");
@@ -81,13 +89,10 @@ public final class MariaDBDeleteGenerator {
             }
         }
 
-        String query = sb.toString();
-        if (query.contains("RLIKE") || query.contains("REGEXP")) {
+        if (sb.toString().contains("RLIKE") || sb.toString().contains("REGEXP")) {
             errors.add("Regex error");
             errors.add("quantifier does not follow a repeatable item");
             errors.add("Got error");
         }
-
-        return new SQLQueryAdapter(query, errors);
     }
 }

--- a/src/sqlancer/materialize/gen/MaterializeDeleteGenerator.java
+++ b/src/sqlancer/materialize/gen/MaterializeDeleteGenerator.java
@@ -1,25 +1,32 @@
 package sqlancer.materialize.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.materialize.MaterializeGlobalState;
 import sqlancer.materialize.MaterializeSchema.MaterializeDataType;
 import sqlancer.materialize.MaterializeSchema.MaterializeTable;
 import sqlancer.materialize.MaterializeVisitor;
 
-public final class MaterializeDeleteGenerator {
+public final class MaterializeDeleteGenerator extends AbstractDeleteGenerator {
 
-    private MaterializeDeleteGenerator() {
+    private final MaterializeGlobalState globalState;
+
+    private MaterializeDeleteGenerator(MaterializeGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter create(MaterializeGlobalState globalState) {
+        return new MaterializeDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         MaterializeTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        ExpectedErrors errors = new ExpectedErrors();
         errors.add("violates foreign key constraint");
         errors.add("violates not-null constraint");
         errors.add("could not determine which collation to use for string comparison");
-        StringBuilder sb = new StringBuilder("DELETE FROM");
+        sb.append("DELETE FROM");
         sb.append(" ");
         sb.append(table.getName());
         if (Randomly.getBoolean()) {
@@ -32,7 +39,6 @@ public final class MaterializeDeleteGenerator {
         errors.add("does not support casting");
         errors.add("invalid input syntax for");
         errors.add("division by zero");
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/materialize/gen/MaterializeUpdateGenerator.java
+++ b/src/sqlancer/materialize/gen/MaterializeUpdateGenerator.java
@@ -20,6 +20,7 @@ public final class MaterializeUpdateGenerator extends AbstractUpdateGenerator<Ma
 
     private MaterializeUpdateGenerator(MaterializeGlobalState globalState) {
         this.globalState = globalState;
+        this.canAffectSchema = true;
         errors.addAll(Arrays.asList("conflicting key value violates exclusion constraint",
                 "reached maximum value of sequence", "violates foreign key constraint", "violates not-null constraint",
                 "violates unique constraint", "out of range", "does not support casting", "must be type boolean",
@@ -29,10 +30,11 @@ public final class MaterializeUpdateGenerator extends AbstractUpdateGenerator<Ma
     }
 
     public static SQLQueryAdapter create(MaterializeGlobalState globalState) {
-        return new MaterializeUpdateGenerator(globalState).generate();
+        return new MaterializeUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         randomTable = globalState.getSchema().getRandomTable(t -> t.isInsertable());
         List<MaterializeColumn> columns = randomTable.getRandomNonEmptyColumnSubset();
         sb.append("UPDATE ");
@@ -55,8 +57,6 @@ public final class MaterializeUpdateGenerator extends AbstractUpdateGenerator<Ma
                     randomTable.getColumns(), MaterializeDataType.BOOLEAN);
             sb.append(MaterializeVisitor.asString(where));
         }
-
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
     @Override

--- a/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
@@ -3,16 +3,15 @@ package sqlancer.mysql.gen;
 import java.util.Arrays;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.mysql.MySQLErrors;
 import sqlancer.mysql.MySQLGlobalState;
 import sqlancer.mysql.MySQLSchema.MySQLTable;
 import sqlancer.mysql.MySQLVisitor;
 
-public class MySQLDeleteGenerator {
+public class MySQLDeleteGenerator extends AbstractDeleteGenerator {
 
-    private final StringBuilder sb = new StringBuilder();
     private final MySQLGlobalState globalState;
 
     public MySQLDeleteGenerator(MySQLGlobalState globalState) {
@@ -20,13 +19,13 @@ public class MySQLDeleteGenerator {
     }
 
     public static SQLQueryAdapter delete(MySQLGlobalState globalState) {
-        return new MySQLDeleteGenerator(globalState).generate();
+        return new MySQLDeleteGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         MySQLTable randomTable = globalState.getSchema().getRandomTable();
         MySQLExpressionGenerator gen = new MySQLExpressionGenerator(globalState).setColumns(randomTable.getColumns());
-        ExpectedErrors errors = new ExpectedErrors();
         sb.append("DELETE");
         if (Randomly.getBoolean()) {
             sb.append(" LOW_PRIORITY");
@@ -51,7 +50,6 @@ public class MySQLDeleteGenerator {
                                                     */, "Truncated incorrect INTEGER value",
                 "Truncated incorrect DECIMAL value", "Data truncated for functional index"));
         // TODO: support ORDER BY
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/mysql/gen/MySQLUpdateGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLUpdateGenerator.java
@@ -1,6 +1,5 @@
 package sqlancer.mysql.gen;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import sqlancer.Randomly;
@@ -21,11 +20,12 @@ public class MySQLUpdateGenerator extends AbstractUpdateGenerator<MySQLColumn> {
         this.globalState = globalState;
     }
 
-    public static SQLQueryAdapter create(MySQLGlobalState globalState) throws SQLException {
-        return new MySQLUpdateGenerator(globalState).generate();
+    public static SQLQueryAdapter create(MySQLGlobalState globalState) {
+        return new MySQLUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() throws SQLException {
+    @Override
+    public void buildStatement() {
         MySQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<MySQLColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new MySQLExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -40,8 +40,6 @@ public class MySQLUpdateGenerator extends AbstractUpdateGenerator<MySQLColumn> {
         }
         MySQLErrors.addInsertUpdateErrors(errors);
         errors.add("doesn't have this option");
-
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/oceanbase/gen/OceanBaseDeleteGenerator.java
+++ b/src/sqlancer/oceanbase/gen/OceanBaseDeleteGenerator.java
@@ -3,16 +3,15 @@ package sqlancer.oceanbase.gen;
 import java.util.Arrays;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.oceanbase.OceanBaseErrors;
 import sqlancer.oceanbase.OceanBaseGlobalState;
 import sqlancer.oceanbase.OceanBaseSchema.OceanBaseTable;
 import sqlancer.oceanbase.OceanBaseVisitor;
 
-public class OceanBaseDeleteGenerator {
+public class OceanBaseDeleteGenerator extends AbstractDeleteGenerator {
 
-    private final StringBuilder sb = new StringBuilder();
     private final OceanBaseGlobalState globalState;
     private final Randomly r;
 
@@ -22,14 +21,14 @@ public class OceanBaseDeleteGenerator {
     }
 
     public static SQLQueryAdapter delete(OceanBaseGlobalState globalState) {
-        return new OceanBaseDeleteGenerator(globalState).generate();
+        return new OceanBaseDeleteGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         OceanBaseTable randomTable = globalState.getSchema().getRandomTable();
         OceanBaseExpressionGenerator gen = new OceanBaseExpressionGenerator(globalState)
                 .setColumns(randomTable.getColumns());
-        ExpectedErrors errors = new ExpectedErrors();
         sb.append("DELETE");
         if (Randomly.getBoolean()) {
             sb.append(" /*+parallel(" + r.getLong(0, 10) + ") enable_parallel_dml*/ ");
@@ -45,7 +44,6 @@ public class OceanBaseDeleteGenerator {
                 "Truncated incorrect INTEGER value", "Truncated incorrect DECIMAL value",
                 "Data truncated for functional index", "Incorrect value", "Out of range value for column",
                 "Data truncation:"));
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/oceanbase/gen/OceanBaseUpdateGenerator.java
+++ b/src/sqlancer/oceanbase/gen/OceanBaseUpdateGenerator.java
@@ -23,10 +23,11 @@ public class OceanBaseUpdateGenerator extends AbstractUpdateGenerator<OceanBaseC
     }
 
     public static SQLQueryAdapter update(OceanBaseGlobalState globalState) {
-        return new OceanBaseUpdateGenerator(globalState).generate();
+        return new OceanBaseUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         OceanBaseSchema.OceanBaseTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<OceanBaseSchema.OceanBaseColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new OceanBaseExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -45,8 +46,6 @@ public class OceanBaseUpdateGenerator extends AbstractUpdateGenerator<OceanBaseC
         }
         errors.add("Duplicated primary key");
         OceanBaseErrors.addInsertErrors(errors);
-
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/postgres/gen/PostgresDeleteGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDeleteGenerator.java
@@ -1,25 +1,32 @@
 package sqlancer.postgres.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresDataType;
 import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.PostgresVisitor;
 
-public final class PostgresDeleteGenerator {
+public final class PostgresDeleteGenerator extends AbstractDeleteGenerator {
 
-    private PostgresDeleteGenerator() {
+    private final PostgresGlobalState globalState;
+
+    private PostgresDeleteGenerator(PostgresGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter create(PostgresGlobalState globalState) {
+        return new PostgresDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         PostgresTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        ExpectedErrors errors = new ExpectedErrors();
         errors.add("violates foreign key constraint");
         errors.add("violates not-null constraint");
         errors.add("could not determine which collation to use for string comparison");
-        StringBuilder sb = new StringBuilder("DELETE FROM");
+        sb.append("DELETE FROM");
         if (Randomly.getBoolean()) {
             sb.append(" ONLY");
         }
@@ -40,7 +47,6 @@ public final class PostgresDeleteGenerator {
         errors.add("cannot cast");
         errors.add("invalid input syntax for");
         errors.add("division by zero");
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/postgres/gen/PostgresUpdateGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresUpdateGenerator.java
@@ -20,6 +20,7 @@ public final class PostgresUpdateGenerator extends AbstractUpdateGenerator<Postg
 
     private PostgresUpdateGenerator(PostgresGlobalState globalState) {
         this.globalState = globalState;
+        this.canAffectSchema = true;
         errors.addAll(Arrays.asList("conflicting key value violates exclusion constraint",
                 "reached maximum value of sequence", "violates foreign key constraint", "violates not-null constraint",
                 "violates unique constraint", "out of range", "cannot cast", "must be type boolean", "is not unique",
@@ -29,10 +30,11 @@ public final class PostgresUpdateGenerator extends AbstractUpdateGenerator<Postg
     }
 
     public static SQLQueryAdapter create(PostgresGlobalState globalState) {
-        return new PostgresUpdateGenerator(globalState).generate();
+        return new PostgresUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         randomTable = globalState.getSchema().getRandomTable(t -> t.isInsertable());
         List<PostgresColumn> columns = randomTable.getRandomNonEmptyColumnSubset();
         sb.append("UPDATE ");
@@ -55,8 +57,6 @@ public final class PostgresUpdateGenerator extends AbstractUpdateGenerator<Postg
                     randomTable.getColumns(), PostgresDataType.BOOLEAN);
             sb.append(PostgresVisitor.asString(where));
         }
-
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
     @Override

--- a/src/sqlancer/presto/gen/PrestoDeleteGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoDeleteGenerator.java
@@ -1,7 +1,7 @@
 package sqlancer.presto.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.presto.PrestoErrors;
 import sqlancer.presto.PrestoGlobalState;
@@ -9,14 +9,22 @@ import sqlancer.presto.PrestoSchema;
 import sqlancer.presto.PrestoSchema.PrestoTable;
 import sqlancer.presto.PrestoToStringVisitor;
 
-public final class PrestoDeleteGenerator {
+public final class PrestoDeleteGenerator extends AbstractDeleteGenerator {
 
-    private PrestoDeleteGenerator() {
+    private final PrestoGlobalState globalState;
+
+    private PrestoDeleteGenerator(PrestoGlobalState globalState) {
+        this.globalState = globalState;
+        this.canonicalizeString = false;
     }
 
     public static SQLQueryAdapter generate(PrestoGlobalState globalState) {
-        StringBuilder sb = new StringBuilder("DELETE FROM ");
-        ExpectedErrors errors = new ExpectedErrors();
+        return new PrestoDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        sb.append("DELETE FROM ");
         PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
         if (Randomly.getBoolean()) {
@@ -26,7 +34,6 @@ public final class PrestoDeleteGenerator {
                             .generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull())));
         }
         PrestoErrors.addExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, false, false);
     }
 
 }

--- a/src/sqlancer/presto/gen/PrestoInsertGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoInsertGenerator.java
@@ -17,18 +17,19 @@ public class PrestoInsertGenerator extends AbstractInsertGenerator<PrestoColumn>
 
     public PrestoInsertGenerator(PrestoGlobalState globalState) {
         this.globalState = globalState;
+        this.canonicalizeString = false;
     }
 
     public static SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
-        return new PrestoInsertGenerator(globalState).generate();
+        return new PrestoInsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<PrestoColumn> columns = table.getRandomNonEmptyColumnSubset();
         buildInsertInto(table.getName(), columns);
         PrestoErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, false, false);
     }
 
     @Override

--- a/src/sqlancer/presto/gen/PrestoUpdateGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoUpdateGenerator.java
@@ -19,13 +19,15 @@ public final class PrestoUpdateGenerator extends AbstractUpdateGenerator<PrestoC
 
     private PrestoUpdateGenerator(PrestoGlobalState globalState) {
         this.globalState = globalState;
+        this.canonicalizeString = false;
     }
 
     public static SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
-        return new PrestoUpdateGenerator(globalState).generate();
+        return new PrestoUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<PrestoColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new PrestoTypedExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -34,7 +36,6 @@ public final class PrestoUpdateGenerator extends AbstractUpdateGenerator<PrestoC
         sb.append(" SET ");
         updateColumns(columns);
         PrestoErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, false, false);
     }
 
     @Override

--- a/src/sqlancer/questdb/gen/QuestDBInsertGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBInsertGenerator.java
@@ -18,16 +18,16 @@ public class QuestDBInsertGenerator extends AbstractInsertGenerator<QuestDBColum
         this.globalState = globalState;
     }
 
-    private SQLQueryAdapter generate() {
+    public static SQLQueryAdapter getQuery(QuestDBGlobalState globalState) {
+        return new QuestDBInsertGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         QuestDBTable table = globalState.getSchema().getRandomTable();
         List<QuestDBColumn> columns = table.getRandomNonEmptyColumnSubset();
         buildInsertInto(table.getName(), columns);
         QuestDBErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
-    }
-
-    public static SQLQueryAdapter getQuery(QuestDBGlobalState globalState) {
-        return new QuestDBInsertGenerator(globalState).generate();
     }
 
     @Override

--- a/src/sqlancer/spark/gen/SparkInsertGenerator.java
+++ b/src/sqlancer/spark/gen/SparkInsertGenerator.java
@@ -18,10 +18,11 @@ public class SparkInsertGenerator extends AbstractInsertGenerator<SparkColumn> {
     public SparkInsertGenerator(SparkGlobalState globalState) {
         this.globalState = globalState;
         this.gen = new SparkExpressionGenerator(globalState);
+        this.canonicalizeString = false;
     }
 
     public static SQLQueryAdapter getQuery(SparkGlobalState globalState) {
-        return new SparkInsertGenerator(globalState).generate();
+        return new SparkInsertGenerator(globalState).getStatement();
     }
 
     @Override
@@ -29,7 +30,8 @@ public class SparkInsertGenerator extends AbstractInsertGenerator<SparkColumn> {
         sb.append(SparkToStringVisitor.asString(gen.generateConstant()));
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         sb.append("INSERT INTO ");
         SparkTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
@@ -40,6 +42,5 @@ public class SparkInsertGenerator extends AbstractInsertGenerator<SparkColumn> {
         insertColumns(columns);
 
         SparkErrors.addInsertErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, false, false);
     }
 }

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3DeleteGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3DeleteGenerator.java
@@ -3,7 +3,7 @@ package sqlancer.sqlite3.gen.dml;
 import java.util.Arrays;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.sqlite3.SQLite3Errors;
 import sqlancer.sqlite3.SQLite3GlobalState;
@@ -11,26 +11,35 @@ import sqlancer.sqlite3.SQLite3Visitor;
 import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
-public final class SQLite3DeleteGenerator {
+public final class SQLite3DeleteGenerator extends AbstractDeleteGenerator {
 
-    private SQLite3DeleteGenerator() {
+    private final SQLite3GlobalState globalState;
+    private final SQLite3Table table;
+
+    private SQLite3DeleteGenerator(SQLite3GlobalState globalState, SQLite3Table table) {
+        this.globalState = globalState;
+        this.table = table;
+        this.canAffectSchema = true;
     }
 
     public static SQLQueryAdapter deleteContent(SQLite3GlobalState globalState) {
-        SQLite3Table tableName = globalState.getSchema().getRandomTable(t -> !t.isView() && !t.isReadOnly());
-        return deleteContent(globalState, tableName);
+        SQLite3Table table = globalState.getSchema().getRandomTable(t -> !t.isView() && !t.isReadOnly());
+        return deleteContent(globalState, table);
     }
 
-    public static SQLQueryAdapter deleteContent(SQLite3GlobalState globalState, SQLite3Table tableName) {
-        StringBuilder sb = new StringBuilder();
+    public static SQLQueryAdapter deleteContent(SQLite3GlobalState globalState, SQLite3Table table) {
+        return new SQLite3DeleteGenerator(globalState, table).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         sb.append("DELETE FROM ");
-        sb.append(tableName.getName());
+        sb.append(table.getName());
         if (Randomly.getBoolean()) {
             sb.append(" WHERE ");
-            sb.append(SQLite3Visitor.asString(new SQLite3ExpressionGenerator(globalState)
-                    .setColumns(tableName.getColumns()).generateExpression()));
+            sb.append(SQLite3Visitor.asString(
+                    new SQLite3ExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
         }
-        ExpectedErrors errors = new ExpectedErrors();
         SQLite3Errors.addExpectedExpressionErrors(errors);
         errors.addAll(Arrays.asList("[SQLITE_ERROR] SQL error or missing database (foreign key mismatch",
                 "[SQLITE_CONSTRAINT]  Abort due to constraint violation ",
@@ -40,7 +49,6 @@ public final class SQLite3DeleteGenerator {
                 "cannot INSERT into generated column", "A table in the database is locked",
                 "load_extension() prohibited in triggers and views", "The database file is locked"));
         SQLite3Errors.addDeleteErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
 }

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
@@ -14,7 +14,7 @@ import sqlancer.sqlite3.gen.SQLite3ExpressionGenerator;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Column;
 import sqlancer.sqlite3.schema.SQLite3Schema.SQLite3Table;
 
-public class SQLite3UpdateGenerator extends AbstractUpdateGenerator<SQLite3Column> {
+public final class SQLite3UpdateGenerator extends AbstractUpdateGenerator<SQLite3Column> {
 
     private final SQLite3GlobalState globalState;
     private final Randomly r;

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
@@ -18,10 +18,13 @@ public class SQLite3UpdateGenerator extends AbstractUpdateGenerator<SQLite3Colum
 
     private final SQLite3GlobalState globalState;
     private final Randomly r;
+    private final SQLite3Table table;
 
-    public SQLite3UpdateGenerator(SQLite3GlobalState globalState, Randomly r) {
+    private SQLite3UpdateGenerator(SQLite3GlobalState globalState, SQLite3Table table) {
         this.globalState = globalState;
-        this.r = r;
+        this.r = globalState.getRandomly();
+        this.table = table;
+        this.canAffectSchema = true;
     }
 
     public static SQLQueryAdapter updateRow(SQLite3GlobalState globalState) {
@@ -31,11 +34,11 @@ public class SQLite3UpdateGenerator extends AbstractUpdateGenerator<SQLite3Colum
     }
 
     public static SQLQueryAdapter updateRow(SQLite3GlobalState globalState, SQLite3Table table) {
-        SQLite3UpdateGenerator generator = new SQLite3UpdateGenerator(globalState, globalState.getRandomly());
-        return generator.generate(table);
+        return new SQLite3UpdateGenerator(globalState, table).getStatement();
     }
 
-    private SQLQueryAdapter generate(SQLite3Table table) {
+    @Override
+    public void buildStatement() {
         List<SQLite3Column> columnsToUpdate = Randomly.nonEmptySubsetPotentialDuplicates(table.getColumns());
         sb.append("UPDATE ");
         if (Randomly.getBoolean()) {
@@ -98,8 +101,6 @@ public class SQLite3UpdateGenerator extends AbstractUpdateGenerator<SQLite3Colum
         SQLite3Errors.addInsertNowErrors(errors);
         SQLite3Errors.addExpectedExpressionErrors(errors);
         SQLite3Errors.addDeleteErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, true /* column could have an ON UPDATE clause */);
-
     }
 
     @Override

--- a/src/sqlancer/tidb/gen/TiDBDeleteGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBDeleteGenerator.java
@@ -1,10 +1,9 @@
 package sqlancer.tidb.gen;
 
-import java.sql.SQLException;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.tidb.TiDBErrors;
 import sqlancer.tidb.TiDBExpressionGenerator;
@@ -12,16 +11,24 @@ import sqlancer.tidb.TiDBProvider.TiDBGlobalState;
 import sqlancer.tidb.TiDBSchema.TiDBTable;
 import sqlancer.tidb.visitor.TiDBVisitor;
 
-public final class TiDBDeleteGenerator {
+public final class TiDBDeleteGenerator extends AbstractDeleteGenerator {
 
-    private TiDBDeleteGenerator() {
+    private final TiDBGlobalState globalState;
+
+    private TiDBDeleteGenerator(TiDBGlobalState globalState) {
+        this.globalState = globalState;
     }
 
-    public static SQLQueryAdapter getQuery(TiDBGlobalState globalState) throws SQLException {
-        ExpectedErrors errors = ExpectedErrors.newErrors().with(TiDBErrors.getExpressionErrors()).build();
+    public static SQLQueryAdapter getQuery(TiDBGlobalState globalState) {
+        return new TiDBDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        errors.addAll(TiDBErrors.getExpressionErrors());
         TiDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         TiDBExpressionGenerator gen = new TiDBExpressionGenerator(globalState).setColumns(table.getColumns());
-        StringBuilder sb = new StringBuilder("DELETE ");
+        sb.append("DELETE ");
         if (Randomly.getBooleanWithSmallProbability()) {
             sb.append("LOW_PRIORITY ");
         }
@@ -55,8 +62,6 @@ public final class TiDBDeleteGenerator {
         errors.add("is not valid for CHARACTER SET");
         errors.add("Division by 0");
         errors.add("error parsing regexp");
-        return new SQLQueryAdapter(sb.toString(), errors);
-
     }
 
 }

--- a/src/sqlancer/tidb/gen/TiDBUpdateGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBUpdateGenerator.java
@@ -1,6 +1,5 @@
 package sqlancer.tidb.gen;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import sqlancer.Randomly;
@@ -22,11 +21,12 @@ public final class TiDBUpdateGenerator extends AbstractUpdateGenerator<TiDBColum
         this.globalState = globalState;
     }
 
-    public static SQLQueryAdapter getQuery(TiDBGlobalState globalState) throws SQLException {
-        return new TiDBUpdateGenerator(globalState).generate();
+    public static SQLQueryAdapter getQuery(TiDBGlobalState globalState) {
+        return new TiDBUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() throws SQLException {
+    @Override
+    public void buildStatement() {
         TiDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<TiDBColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new TiDBExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -40,8 +40,6 @@ public final class TiDBUpdateGenerator extends AbstractUpdateGenerator<TiDBColum
             sb.append(TiDBVisitor.asString(gen.generateExpression()));
         }
         TiDBErrors.addInsertErrors(errors);
-
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLDeleteGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLDeleteGenerator.java
@@ -1,31 +1,36 @@
 package sqlancer.yugabyte.ycql.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.yugabyte.ycql.YCQLErrors;
 import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
 import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
 import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
 
-public final class YCQLDeleteGenerator {
+public final class YCQLDeleteGenerator extends AbstractDeleteGenerator {
 
-    private YCQLDeleteGenerator() {
+    private final YCQLGlobalState globalState;
+
+    private YCQLDeleteGenerator(YCQLGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter generate(YCQLGlobalState globalState) {
-        StringBuilder sb = new StringBuilder("DELETE FROM ");
-        ExpectedErrors errors = new ExpectedErrors();
+        return new YCQLDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
+        sb.append("DELETE FROM ");
         sb.append(table.getName());
         if (Randomly.getBoolean()) {
             sb.append(" WHERE ");
             sb.append(YCQLToStringVisitor.asString(
                     new YCQLExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
         }
-
         YCQLErrors.addExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLInsertGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLInsertGenerator.java
@@ -19,10 +19,11 @@ public class YCQLInsertGenerator extends AbstractInsertGenerator<YCQLColumn> {
     }
 
     public static SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
-        return new YCQLInsertGenerator(globalState).generate();
+        return new YCQLInsertGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<YCQLColumn> columns = table.getColumns();
         buildInsertInto(globalState.getDatabaseName() + "." + table.getName(), columns);
@@ -31,7 +32,6 @@ public class YCQLInsertGenerator extends AbstractInsertGenerator<YCQLColumn> {
         errors.add("Null Argument for Primary Key");
 
         YCQLErrors.addExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLUpdateGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLUpdateGenerator.java
@@ -22,10 +22,11 @@ public final class YCQLUpdateGenerator extends AbstractUpdateGenerator<YCQLColum
     }
 
     public static SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
-        return new YCQLUpdateGenerator(globalState).generate();
+        return new YCQLUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         List<YCQLColumn> columns = table.getRandomNonEmptyColumnSubset();
         gen = new YCQLExpressionGenerator(globalState).setColumns(table.getColumns());
@@ -41,7 +42,6 @@ public final class YCQLUpdateGenerator extends AbstractUpdateGenerator<YCQLColum
         errors.add("Missing Argument for Primary Key");
 
         YCQLErrors.addExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     @Override

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDeleteGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDeleteGenerator.java
@@ -1,7 +1,7 @@
 package sqlancer.yugabyte.ysql.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractDeleteGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.yugabyte.ysql.YSQLErrors;
 import sqlancer.yugabyte.ysql.YSQLGlobalState;
@@ -9,18 +9,25 @@ import sqlancer.yugabyte.ysql.YSQLSchema.YSQLDataType;
 import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
 import sqlancer.yugabyte.ysql.YSQLVisitor;
 
-public final class YSQLDeleteGenerator {
+public final class YSQLDeleteGenerator extends AbstractDeleteGenerator {
 
-    private YSQLDeleteGenerator() {
+    private final YSQLGlobalState globalState;
+
+    private YSQLDeleteGenerator(YSQLGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter create(YSQLGlobalState globalState) {
+        return new YSQLDeleteGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         YSQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        ExpectedErrors errors = new ExpectedErrors();
         errors.add("violates foreign key constraint");
         errors.add("violates not-null constraint");
         errors.add("could not determine which collation to use for string comparison");
-        StringBuilder sb = new StringBuilder("DELETE FROM");
+        sb.append("DELETE FROM");
         if (Randomly.getBoolean()) {
             sb.append(" ONLY");
         }
@@ -41,7 +48,6 @@ public final class YSQLDeleteGenerator {
         errors.add("cannot cast");
         errors.add("invalid input syntax for");
         errors.add("division by zero");
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
 }

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLUpdateGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLUpdateGenerator.java
@@ -21,6 +21,7 @@ public final class YSQLUpdateGenerator extends AbstractUpdateGenerator<YSQLColum
 
     private YSQLUpdateGenerator(YSQLGlobalState globalState) {
         this.globalState = globalState;
+        this.canAffectSchema = true;
         errors.addAll(Arrays.asList("conflicting key value violates exclusion constraint",
                 "reached maximum value of sequence", "violates foreign key constraint", "violates not-null constraint",
                 "violates unique constraint", "out of range", "cannot cast", "must be type boolean", "is not unique",
@@ -30,10 +31,11 @@ public final class YSQLUpdateGenerator extends AbstractUpdateGenerator<YSQLColum
     }
 
     public static SQLQueryAdapter create(YSQLGlobalState globalState) {
-        return new YSQLUpdateGenerator(globalState).generate();
+        return new YSQLUpdateGenerator(globalState).getStatement();
     }
 
-    private SQLQueryAdapter generate() {
+    @Override
+    public void buildStatement() {
         randomTable = globalState.getSchema().getRandomTable(YSQLTable::isInsertable);
         List<YSQLColumn> columns = randomTable.getRandomNonEmptyColumnSubset();
         sb.append("UPDATE ");
@@ -57,8 +59,6 @@ public final class YSQLUpdateGenerator extends AbstractUpdateGenerator<YSQLColum
                     YSQLDataType.BOOLEAN);
             sb.append(YSQLVisitor.asString(where));
         }
-
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
     @Override


### PR DESCRIPTION
Introduce AbstractDeleteGenerator extending AbstractGenerator, and make AbstractInsertGenerator and AbstractUpdateGenerator also extend it, eliminating duplicate sb/errors field declarations across all generator classes.

Convert all 15 DELETE generators (CockroachDB, Databend, Doris, DuckDB, H2, MariaDB, Materialize, MySQL, OceanBase, Postgres, Presto, SQLite3, TiDB, YCQL, YSQL) from static-utility classes to the instance-based buildStatement() pattern. Add canonicalizeString field to AbstractGenerator (defaulting to true) so generators like Presto/Hive/Spark can opt out of semicolon canonicalization.