### PR TITLE
Remove Databend bug19738 workaround after upstream fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       databend:
-        image: datafuselabs/databend:v1.2.896-nightly
+        image: datafuselabs/databend:v1.2.900-nightly
         env:
           QUERY_DEFAULT_USER: sqlancer
           QUERY_DEFAULT_PASSWORD: sqlancer

--- a/src/sqlancer/databend/DatabendBugs.java
+++ b/src/sqlancer/databend/DatabendBugs.java
@@ -19,6 +19,7 @@ public final class DatabendBugs {
     public static boolean bug15569 = true; // https://github.com/datafuselabs/databend/issues/15569
     public static boolean bug15570 = true; // https://github.com/datafuselabs/databend/issues/15570
     public static boolean bug15572 = true; // https://github.com/datafuselabs/databend/issues/15572
+    public static boolean bug19773 = true; // https://github.com/databendlabs/databend/issues/19773
 
     private DatabendBugs() {
     }

--- a/src/sqlancer/databend/DatabendBugs.java
+++ b/src/sqlancer/databend/DatabendBugs.java
@@ -19,7 +19,6 @@ public final class DatabendBugs {
     public static boolean bug15569 = true; // https://github.com/datafuselabs/databend/issues/15569
     public static boolean bug15570 = true; // https://github.com/datafuselabs/databend/issues/15570
     public static boolean bug15572 = true; // https://github.com/datafuselabs/databend/issues/15572
-    public static boolean bug19738 = true; // https://github.com/databendlabs/databend/issues/19738
 
     private DatabendBugs() {
     }

--- a/src/sqlancer/databend/DatabendErrors.java
+++ b/src/sqlancer/databend/DatabendErrors.java
@@ -47,10 +47,6 @@ public final class DatabendErrors {
         if (DatabendBugs.bug15568) {
             errors.add("Decimal overflow at line : 723 while evaluating function `to_decimal");
         }
-        if (DatabendBugs.bug19738) {
-            errors.add("UnwindError");
-            errors.add("unable to cast `NULL`");
-        }
 
         /*
          * TODO column为not null 时，注意default不能为null DROP DATABASE IF EXISTS databend2; CREATE DATABASE databend2; USE

--- a/src/sqlancer/databend/DatabendErrors.java
+++ b/src/sqlancer/databend/DatabendErrors.java
@@ -47,6 +47,11 @@ public final class DatabendErrors {
         if (DatabendBugs.bug15568) {
             errors.add("Decimal overflow at line : 723 while evaluating function `to_decimal");
         }
+        if (DatabendBugs.bug19773) {
+            errors.add("failed to downcast column Decimal128");
+            errors.add("Decimal(DecimalSize { precision: 38");
+            errors.add("_eager_final_count");
+        }
 
         /*
          * TODO column为not null 时，注意default不能为null DROP DATABASE IF EXISTS databend2; CREATE DATABASE databend2; USE

--- a/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningAggregateTester.java
+++ b/src/sqlancer/databend/test/tlp/DatabendQueryPartitioningAggregateTester.java
@@ -10,7 +10,6 @@ import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.query.SQLancerResultSet;
-import sqlancer.databend.DatabendBugs;
 import sqlancer.databend.DatabendErrors;
 import sqlancer.databend.DatabendProvider.DatabendGlobalState;
 import sqlancer.databend.DatabendSchema.DatabendCompositeDataType;
@@ -45,12 +44,10 @@ public class DatabendQueryPartitioningAggregateTester extends DatabendQueryParti
     @Override
     public void check() throws SQLException {
         super.check();
-        List<DatabendAggregateFunction> aggregateFunctions = new ArrayList<>(List.of(DatabendAggregateFunction.MAX,
-                DatabendAggregateFunction.MIN, DatabendAggregateFunction.SUM, DatabendAggregateFunction.COUNT
-        /* , DatabendAggregateFunction.STDDEV_POP */));
-        if (!DatabendBugs.bug19738) {
-            aggregateFunctions.add(DatabendAggregateFunction.AVG);
-        }
+        List<DatabendAggregateFunction> aggregateFunctions = new ArrayList<>(
+                List.of(DatabendAggregateFunction.MAX, DatabendAggregateFunction.MIN, DatabendAggregateFunction.SUM,
+                        DatabendAggregateFunction.COUNT, DatabendAggregateFunction.AVG
+                /* , DatabendAggregateFunction.STDDEV_POP */));
         DatabendAggregateFunction aggregateFunction = Randomly.fromList(aggregateFunctions);
         DatabendFunctionOperation<DatabendAggregateFunction> aggregate = (DatabendAggregateOperation) gen
                 .generateArgsForAggregate(aggregateFunction);


### PR DESCRIPTION
The issue (databendlabs/databend#19738) was fixed in databendlabs/databend#19740 — re-enable AVG in aggregate testing and stop suppressing the related error messages.