### PR TITLE
Refactor: extract common CREATE INDEX logic into AbstractIndexGenerator

### DIFF
--- a/src/sqlancer/common/gen/AbstractIndexGenerator.java
+++ b/src/sqlancer/common/gen/AbstractIndexGenerator.java
@@ -1,0 +1,33 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+
+import sqlancer.Randomly;
+import sqlancer.common.schema.AbstractTableColumn;
+
+public abstract class AbstractIndexGenerator<C extends AbstractTableColumn<?, ?>> extends AbstractGenerator {
+
+    protected void appendCreateIndex(boolean unique) {
+        sb.append("CREATE ");
+        if (unique) {
+            sb.append("UNIQUE ");
+        }
+        sb.append("INDEX ");
+    }
+
+    protected void appendIndexColumnList(List<C> columns, boolean allowOrdering) {
+        sb.append("(");
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append(columns.get(i).getName());
+            if (allowOrdering && Randomly.getBoolean()) {
+                sb.append(" ");
+                sb.append(Randomly.fromOptions("ASC", "DESC"));
+            }
+        }
+        sb.append(")");
+    }
+
+}

--- a/src/sqlancer/doris/gen/DorisIndexGenerator.java
+++ b/src/sqlancer/doris/gen/DorisIndexGenerator.java
@@ -5,42 +5,45 @@ import java.util.List;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.doris.DorisProvider.DorisGlobalState;
 import sqlancer.doris.DorisSchema.DorisColumn;
 import sqlancer.doris.DorisSchema.DorisTable;
 
-public final class DorisIndexGenerator {
+public class DorisIndexGenerator extends AbstractIndexGenerator<DorisColumn> {
 
-    private DorisIndexGenerator() {
+    private final DorisGlobalState globalState;
+
+    public DorisIndexGenerator(DorisGlobalState globalState) {
+        this.globalState = globalState;
+        this.canAffectSchema = true;
     }
 
     public static SQLQueryAdapter getQuery(DorisGlobalState globalState) throws SQLException {
         if (globalState.getSchema().getIndexCount() > globalState.getDbmsSpecificOptions().maxNumIndexes) {
             throw new IgnoreMeException();
         }
-        ExpectedErrors errors = new ExpectedErrors();
+        return new DorisIndexGenerator(globalState).getStatement();
+    }
 
+    @Override
+    public void buildStatement() {
         DorisTable randomTable = globalState.getSchema().getRandomTable(t -> !t.isView());
-        String indexName = globalState.getSchema().getFreeIndexName();
-        StringBuilder sb = new StringBuilder("CREATE ");
-        sb.append("INDEX ");
+        appendCreateIndex(false);
         if (Randomly.getBoolean()) {
             sb.append("IF NOT EXISTS ");
         }
-        sb.append(indexName);
+        sb.append(globalState.getSchema().getFreeIndexName());
         sb.append(" ON ");
         sb.append(randomTable.getName());
-        sb.append("(");
-        int nr = 1; // Doris Only support CREATE_INDEX on single column and index type is BITMAP;
-        List<DorisColumn> subset = Randomly.extractNrRandomColumns(randomTable.getColumns(), nr);
-        sb.append(subset.get(0).getName());
-        sb.append(") ");
+        // Doris only supports CREATE INDEX on a single column; index type is BITMAP
+        List<DorisColumn> subset = Randomly.extractNrRandomColumns(randomTable.getColumns(), 1);
+        appendIndexColumnList(subset, false);
+        sb.append(" ");
         if (Randomly.getBoolean()) {
             sb.append("USING BITMAP ");
         }
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
 }

--- a/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBIndexGenerator.java
@@ -3,26 +3,32 @@ package sqlancer.duckdb.gen;
 import java.util.List;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.duckdb.DuckDBProvider.DuckDBGlobalState;
 import sqlancer.duckdb.DuckDBSchema.DuckDBColumn;
 import sqlancer.duckdb.DuckDBSchema.DuckDBTable;
 
-public final class DuckDBIndexGenerator {
+public class DuckDBIndexGenerator extends AbstractIndexGenerator<DuckDBColumn> {
 
-    private DuckDBIndexGenerator() {
+    private final DuckDBGlobalState globalState;
+
+    public DuckDBIndexGenerator(DuckDBGlobalState globalState) {
+        this.globalState = globalState;
+        this.canAffectSchema = true;
     }
 
     public static SQLQueryAdapter getQuery(DuckDBGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE ");
-        if (Randomly.getBoolean()) {
+        return new DuckDBIndexGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        boolean unique = Randomly.getBoolean();
+        if (unique) {
             errors.add("Data contains duplicates on indexed column(s)");
-            sb.append("UNIQUE ");
         }
-        sb.append("INDEX ");
+        appendCreateIndex(unique);
         sb.append(globalState.getSchema().getFreeIndexName());
         sb.append(" ON ");
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
@@ -43,7 +49,6 @@ public final class DuckDBIndexGenerator {
         if (globalState.getDbmsSpecificOptions().testRowid) {
             errors.add("cannot create an index on the rowid");
         }
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
 }

--- a/src/sqlancer/mariadb/gen/MariaDBIndexGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBIndexGenerator.java
@@ -1,31 +1,36 @@
 package sqlancer.mariadb.gen;
 
-import java.util.List;
-
 import sqlancer.Randomly;
 import sqlancer.common.DBMSCommon;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.mariadb.MariaDBSchema;
 import sqlancer.mariadb.MariaDBSchema.MariaDBColumn;
 import sqlancer.mariadb.MariaDBSchema.MariaDBTable;
 
-public final class MariaDBIndexGenerator {
+public class MariaDBIndexGenerator extends AbstractIndexGenerator<MariaDBColumn> {
 
-    private MariaDBIndexGenerator() {
+    private final MariaDBSchema schema;
+
+    public MariaDBIndexGenerator(MariaDBSchema schema) {
+        this.schema = schema;
+        this.canAffectSchema = true;
     }
 
     public static SQLQueryAdapter generate(MariaDBSchema s) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder("CREATE ");
+        return new MariaDBIndexGenerator(s).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         errors.add("Key/Index cannot be defined on a virtual generated column");
         errors.add("Specified key was too long");
-        if (Randomly.getBoolean()) {
+        boolean unique = Randomly.getBoolean();
+        if (unique) {
             errors.add("Duplicate entry");
             errors.add("Key/Index cannot be defined on a virtual generated column");
-            sb.append("UNIQUE ");
         }
-        sb.append("INDEX ");
+        appendCreateIndex(unique);
         sb.append("i");
         sb.append(DBMSCommon.createColumnName(Randomly.smallNumber()));
         if (Randomly.getBoolean()) {
@@ -34,28 +39,9 @@ public final class MariaDBIndexGenerator {
         }
 
         sb.append(" ON ");
-        MariaDBTable randomTable = s.getRandomTable();
+        MariaDBTable randomTable = schema.getRandomTable();
         sb.append(randomTable.getName());
-        sb.append("(");
-        List<MariaDBColumn> columns = Randomly.nonEmptySubset(randomTable.getColumns());
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(columns.get(i).getName());
-            if (Randomly.getBoolean()) {
-                sb.append(" ");
-                sb.append(Randomly.fromOptions("ASC", "DESC"));
-            }
-        }
-        sb.append(")");
-        // if (Randomly.getBoolean()) {
-        // sb.append(" ALGORITHM=");
-        // sb.append(Randomly.fromOptions("DEFAULT", "INPLACE", "COPY", "NOCOPY", "INSTANT"));
-        // errors.add("is not supported for this operation");
-        // }
-
-        return new SQLQueryAdapter(sb.toString(), errors, true);
+        appendIndexColumnList(Randomly.nonEmptySubset(randomTable.getColumns()), true);
     }
 
 }

--- a/src/sqlancer/materialize/gen/MaterializeIndexGenerator.java
+++ b/src/sqlancer/materialize/gen/MaterializeIndexGenerator.java
@@ -1,14 +1,18 @@
 package sqlancer.materialize.gen;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.materialize.MaterializeGlobalState;
+import sqlancer.materialize.MaterializeSchema.MaterializeColumn;
 import sqlancer.materialize.MaterializeSchema.MaterializeTable;
 
-public final class MaterializeIndexGenerator {
+public class MaterializeIndexGenerator extends AbstractIndexGenerator<MaterializeColumn> {
 
-    private MaterializeIndexGenerator() {
+    private final MaterializeGlobalState globalState;
+
+    public MaterializeIndexGenerator(MaterializeGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public enum IndexType {
@@ -16,17 +20,18 @@ public final class MaterializeIndexGenerator {
     }
 
     public static SQLQueryAdapter generate(MaterializeGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE");
-        sb.append(" INDEX ");
+        return new MaterializeIndexGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        appendCreateIndex(false);
         MaterializeTable randomTable = globalState.getSchema().getRandomTable(t -> !t.isView()); // TODO: materialized
                                                                                                  // views
         sb.append(MaterializeCommon.getFreeIndexName(globalState.getSchema()));
         sb.append(" ON ");
         sb.append(randomTable.getName());
-        IndexType method;
-        method = IndexType.BTREE;
+        IndexType method = IndexType.BTREE;
 
         sb.append("(");
         if (method == IndexType.HASH) {
@@ -75,6 +80,5 @@ public final class MaterializeIndexGenerator {
         errors.add("result of range difference would not be contiguous");
         errors.add("which is part of the partition key");
         MaterializeCommon.addCommonExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 }

--- a/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
 import sqlancer.common.DBMSCommon;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema.PostgresColumn;
@@ -15,9 +15,12 @@ import sqlancer.postgres.PostgresSchema.PostgresTable;
 import sqlancer.postgres.PostgresVisitor;
 import sqlancer.postgres.ast.PostgresExpression;
 
-public final class PostgresIndexGenerator {
+public class PostgresIndexGenerator extends AbstractIndexGenerator<PostgresColumn> {
 
-    private PostgresIndexGenerator() {
+    private final PostgresGlobalState globalState;
+
+    public PostgresIndexGenerator(PostgresGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public enum IndexType {
@@ -25,13 +28,12 @@ public final class PostgresIndexGenerator {
     }
 
     public static SQLQueryAdapter generate(PostgresGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE");
-        if (Randomly.getBoolean()) {
-            sb.append(" UNIQUE");
-        }
-        sb.append(" INDEX ");
+        return new PostgresIndexGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        appendCreateIndex(Randomly.getBoolean());
         /*
          * Commented out as a workaround for https://www.postgresql.org/message-id/CA%2Bu7OA4XYhc-
          * qyCgJqwwgMGZDWAyeH821oa5oMzm_HEifZ4BeA%40mail.gmail.com
@@ -136,7 +138,6 @@ public final class PostgresIndexGenerator {
         errors.add("result of range difference would not be contiguous");
         errors.add("which is part of the partition key");
         PostgresCommon.addCommonExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     private static String getNewIndexName(PostgresTable randomTable) {

--- a/src/sqlancer/presto/gen/PrestoIndexGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoIndexGenerator.java
@@ -3,7 +3,7 @@ package sqlancer.presto.gen;
 import java.util.List;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.presto.PrestoGlobalState;
 import sqlancer.presto.PrestoSchema;
@@ -12,20 +12,27 @@ import sqlancer.presto.PrestoSchema.PrestoTable;
 import sqlancer.presto.PrestoToStringVisitor;
 import sqlancer.presto.ast.PrestoExpression;
 
-public final class PrestoIndexGenerator {
+public class PrestoIndexGenerator extends AbstractIndexGenerator<PrestoColumn> {
 
-    private PrestoIndexGenerator() {
+    private final PrestoGlobalState globalState;
+
+    public PrestoIndexGenerator(PrestoGlobalState globalState) {
+        this.globalState = globalState;
+        this.canAffectSchema = true;
+        this.canonicalizeString = false;
     }
 
     public static SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE ");
-        if (Randomly.getBoolean()) {
+        return new PrestoIndexGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        boolean unique = Randomly.getBoolean();
+        if (unique) {
             errors.add("Cant create unique index, table contains duplicate data on indexed column(s)");
-            sb.append("UNIQUE ");
         }
-        sb.append("INDEX ");
+        appendCreateIndex(unique);
         sb.append(Randomly.fromOptions("i0", "i1", "i2", "i3", "i4")); // cannot query this information
         sb.append(" ON ");
         PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
@@ -50,7 +57,6 @@ public final class PrestoIndexGenerator {
             sb.append(PrestoToStringVisitor.asString(expr));
         }
         errors.add("already exists!");
-        return new SQLQueryAdapter(sb.toString(), errors, true, false);
     }
 
 }

--- a/src/sqlancer/tidb/gen/TiDBIndexGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBIndexGenerator.java
@@ -5,34 +5,39 @@ import java.util.List;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.tidb.TiDBProvider.TiDBGlobalState;
 import sqlancer.tidb.TiDBSchema.TiDBColumn;
 import sqlancer.tidb.TiDBSchema.TiDBTable;
 
-public final class TiDBIndexGenerator {
+public class TiDBIndexGenerator extends AbstractIndexGenerator<TiDBColumn> {
 
-    private TiDBIndexGenerator() {
+    private final TiDBGlobalState globalState;
+
+    public TiDBIndexGenerator(TiDBGlobalState globalState) {
+        this.globalState = globalState;
+        this.canAffectSchema = true;
     }
 
     public static SQLQueryAdapter getQuery(TiDBGlobalState globalState) throws SQLException {
         if (globalState.getSchema().getIndexCount() > globalState.getDbmsSpecificOptions().maxNumIndexes) {
             throw new IgnoreMeException();
         }
-        ExpectedErrors errors = new ExpectedErrors();
+        return new TiDBIndexGenerator(globalState).getStatement();
+    }
 
+    @Override
+    public void buildStatement() {
         TiDBTable randomTable = globalState.getSchema().getRandomTable(t -> !t.isView());
-        String indexName = globalState.getSchema().getFreeIndexName();
-        StringBuilder sb = new StringBuilder("CREATE ");
-        if (Randomly.getBooleanWithRatherLowProbability()) {
-            sb.append("UNIQUE ");
+        boolean unique = Randomly.getBooleanWithRatherLowProbability();
+        if (unique) {
             errors.add("Duplicate for key");
             errors.add("Duplicate entry ");
             errors.add("A UNIQUE INDEX must include all columns in the table's partitioning function");
         }
-        sb.append("INDEX ");
-        sb.append(indexName);
+        appendCreateIndex(unique);
+        sb.append(globalState.getSchema().getFreeIndexName());
         sb.append(" ON ");
         sb.append(randomTable.getName());
         sb.append("(");
@@ -63,7 +68,6 @@ public final class TiDBIndexGenerator {
         errors.add("index already exist");
         errors.add("Data truncation");
         errors.add("key was too long");
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
 }

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLIndexGenerator.java
@@ -1,9 +1,7 @@
 package sqlancer.yugabyte.ycql.gen;
 
-import java.util.List;
-
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
 import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
@@ -11,33 +9,31 @@ import sqlancer.yugabyte.ycql.YCQLSchema.YCQLTable;
 import sqlancer.yugabyte.ycql.YCQLToStringVisitor;
 import sqlancer.yugabyte.ycql.ast.YCQLExpression;
 
-public final class YCQLIndexGenerator {
+public class YCQLIndexGenerator extends AbstractIndexGenerator<YCQLColumn> {
 
-    private YCQLIndexGenerator() {
+    private final YCQLGlobalState globalState;
+
+    public YCQLIndexGenerator(YCQLGlobalState globalState) {
+        this.globalState = globalState;
+        this.canAffectSchema = true;
     }
 
     public static SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE ");
-        if (Randomly.getBoolean()) {
+        return new YCQLIndexGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        boolean unique = Randomly.getBoolean();
+        if (unique) {
             errors.add("Cant create unique index, table contains duplicate data on indexed column(s)");
-            sb.append("UNIQUE ");
         }
-        sb.append("INDEX ");
+        appendCreateIndex(unique);
         sb.append(Randomly.fromOptions("i0", "i1", "i2", "i3", "i4"));
         sb.append(" ON ");
         YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
         sb.append(table.getName());
-        sb.append("(");
-        List<YCQLColumn> columns = table.getRandomNonEmptyColumnSubset();
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(columns.get(i).getName());
-        }
-        sb.append(")");
+        appendIndexColumnList(table.getRandomNonEmptyColumnSubset(), false);
         if (Randomly.getBoolean()) {
             sb.append(" WHERE ");
             YCQLExpression expr = new YCQLExpressionGenerator(globalState).setColumns(table.getColumns())
@@ -49,7 +45,6 @@ public final class YCQLIndexGenerator {
         errors.add("Invalid CQL Statement");
         errors.add(
                 "Invalid Table Definition. Transactions cannot be enabled in an index of a table without transactions enabled.");
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
 }

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
 import sqlancer.common.DBMSCommon;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractIndexGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.yugabyte.ysql.YSQLErrors;
@@ -17,19 +17,21 @@ import sqlancer.yugabyte.ysql.YSQLSchema.YSQLTable;
 import sqlancer.yugabyte.ysql.YSQLVisitor;
 import sqlancer.yugabyte.ysql.ast.YSQLExpression;
 
-public final class YSQLIndexGenerator {
+public class YSQLIndexGenerator extends AbstractIndexGenerator<YSQLColumn> {
 
-    private YSQLIndexGenerator() {
+    private final YSQLGlobalState globalState;
+
+    public YSQLIndexGenerator(YSQLGlobalState globalState) {
+        this.globalState = globalState;
     }
 
     public static SQLQueryAdapter generate(YSQLGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
-        sb.append("CREATE");
-        if (Randomly.getBoolean()) {
-            sb.append(" UNIQUE");
-        }
-        sb.append(" INDEX ");
+        return new YSQLIndexGenerator(globalState).getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        appendCreateIndex(Randomly.getBoolean());
         YSQLTable randomTable = globalState.getSchema().getRandomTable(t -> !t.isView()); // TODO: materialized
         // views
         String indexName = getNewIndexName(randomTable);
@@ -122,7 +124,6 @@ public final class YSQLIndexGenerator {
         errors.add("result of range difference would not be contiguous");
         errors.add("which is part of the partition key");
         YSQLErrors.addCommonExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors);
     }
 
     private static String getNewIndexName(YSQLTable randomTable) {


### PR DESCRIPTION
Introduce AbstractIndexGenerator<C> with appendCreateIndex(boolean) and appendIndexColumnList(List<C>, boolean) helpers, and convert nine concrete index generators (DuckDB, Doris, Presto, YCQL, TiDB, MariaDB, Materialize, Postgres, YSQL) from static-utility classes to instance-based subclasses whose logic lives in buildStatement().

Public entry points (getQuery/generate) are preserved so callers in the provider classes don't need to change.