### PR TITLE
CI: cache Rust build and pinned tarball downloads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,9 +154,15 @@ jobs:
           cache: 'maven'
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
+      - name: Cache CockroachDB tarball
+        uses: actions/cache@v4
+        with:
+          path: cockroach-v24.2.0.linux-amd64.tgz
+          key: cockroach-v24.2.0-linux-amd64-tgz
       - name: Set up CockroachDB
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz | tar  xvz
+          [ -f cockroach-v24.2.0.linux-amd64.tgz ] || wget -q https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz
+          tar xzf cockroach-v24.2.0.linux-amd64.tgz
           cd  cockroach-v24.2.0.linux-amd64/ && ./cockroach start-single-node --insecure &
           until cockroach-v24.2.0.linux-amd64/cockroach sql --insecure -e "SELECT 1" 2>/dev/null; do sleep 2; done
       - name: Create SQLancer user
@@ -180,9 +186,15 @@ jobs:
           cache: 'maven'
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
+      - name: Cache CockroachDB tarball
+        uses: actions/cache@v4
+        with:
+          path: cockroach-v24.2.0.linux-amd64.tgz
+          key: cockroach-v24.2.0-linux-amd64-tgz
       - name: Set up CockroachDB
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz | tar  xvz
+          [ -f cockroach-v24.2.0.linux-amd64.tgz ] || wget -q https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz
+          tar xzf cockroach-v24.2.0.linux-amd64.tgz
           cd  cockroach-v24.2.0.linux-amd64/ && ./cockroach start-single-node --insecure &
           until cockroach-v24.2.0.linux-amd64/cockroach sql --insecure -e "SELECT 1" 2>/dev/null; do sleep 2; done
       - name: Create SQLancer user
@@ -228,6 +240,10 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src/sqlancer/datafusion/server/datafusion_server
       - name: Build DataFusion Server
         run: |
           cd src/sqlancer/datafusion/server/datafusion_server
@@ -690,10 +706,15 @@ jobs:
         run: |
           sudo apt update
           sudo apt install mysql-client --assume-yes
+      - name: Cache Apache Doris tarball
+        uses: actions/cache@v4
+        with:
+          path: apache-doris-2.1.4-bin-x64.tar.gz
+          key: apache-doris-2.1.4-bin-x64-tarball
       - name: Set up Apache Doris
         run: |
           sudo sysctl -w vm.max_map_count=2000000
-          wget -q https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.1.4-bin-x64.tar.gz
+          [ -f apache-doris-2.1.4-bin-x64.tar.gz ] || wget -q https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-2.1.4-bin-x64.tar.gz
           tar zxf apache-doris-2.1.4-bin-x64.tar.gz
           mv apache-doris-2.1.4-bin-x64 apache-doris
           sudo swapoff -a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,15 +154,9 @@ jobs:
           cache: 'maven'
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Cache CockroachDB tarball
-        uses: actions/cache@v4
-        with:
-          path: cockroach-v24.2.0.linux-amd64.tgz
-          key: cockroach-v24.2.0-linux-amd64-tgz
       - name: Set up CockroachDB
         run: |
-          [ -f cockroach-v24.2.0.linux-amd64.tgz ] || wget -q https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz
-          tar xzf cockroach-v24.2.0.linux-amd64.tgz
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz | tar  xvz
           cd  cockroach-v24.2.0.linux-amd64/ && ./cockroach start-single-node --insecure &
           until cockroach-v24.2.0.linux-amd64/cockroach sql --insecure -e "SELECT 1" 2>/dev/null; do sleep 2; done
       - name: Create SQLancer user
@@ -186,15 +180,9 @@ jobs:
           cache: 'maven'
       - name: Build SQLancer
         run: mvn -B package -DskipTests=true
-      - name: Cache CockroachDB tarball
-        uses: actions/cache@v4
-        with:
-          path: cockroach-v24.2.0.linux-amd64.tgz
-          key: cockroach-v24.2.0-linux-amd64-tgz
       - name: Set up CockroachDB
         run: |
-          [ -f cockroach-v24.2.0.linux-amd64.tgz ] || wget -q https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz
-          tar xzf cockroach-v24.2.0.linux-amd64.tgz
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v24.2.0.linux-amd64.tgz | tar  xvz
           cd  cockroach-v24.2.0.linux-amd64/ && ./cockroach start-single-node --insecure &
           until cockroach-v24.2.0.linux-amd64/cockroach sql --insecure -e "SELECT 1" 2>/dev/null; do sleep 2; done
       - name: Create SQLancer user


### PR DESCRIPTION
Three caches that avoid repeated network work, keyed on pinned versions:
- Swatinem/rust-cache for the DataFusion Rust build (cargo registry + target)
- actions/cache for the CockroachDB tarball (cockroachdb + cockroachdb-qpg)
- actions/cache for the Doris tarball

Tarballs are cached as raw .tgz/.tar.gz files rather than extracted dirs, so runtime state from previous runs is not persisted.