### PR TITLE
Refactor: extract common CREATE TABLE logic into AbstractTableGenerator

### DIFF
--- a/src/sqlancer/common/gen/AbstractTableGenerator.java
+++ b/src/sqlancer/common/gen/AbstractTableGenerator.java
@@ -1,0 +1,42 @@
+package sqlancer.common.gen;
+
+import java.util.List;
+
+import sqlancer.common.schema.AbstractTableColumn;
+
+public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>> extends AbstractGenerator {
+
+    protected void appendCreateTable(String tableName) {
+        appendCreateTable(tableName, false);
+    }
+
+    protected void appendCreateTable(String tableName, boolean ifNotExists) {
+        sb.append("CREATE TABLE ");
+        if (ifNotExists) {
+            sb.append("IF NOT EXISTS ");
+        }
+        sb.append(tableName);
+    }
+
+    protected void appendColumnDefinitions(List<C> columns) {
+        sb.append("(");
+        appendColumnDefinitionList(columns);
+        sb.append(")");
+    }
+
+    protected void appendColumnDefinitionList(List<C> columns) {
+        for (int i = 0; i < columns.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            appendColumnDefinition(columns.get(i));
+        }
+    }
+
+    protected void appendColumnDefinition(C column) {
+        sb.append(column.getName());
+        sb.append(" ");
+        sb.append(column.getType());
+    }
+
+}

--- a/src/sqlancer/common/gen/AbstractTableGenerator.java
+++ b/src/sqlancer/common/gen/AbstractTableGenerator.java
@@ -6,10 +6,12 @@ import sqlancer.common.schema.AbstractTableColumn;
 
 public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>> extends AbstractGenerator {
 
+    /** Appends {@code CREATE TABLE <name>}. */
     protected void appendCreateTable(String tableName) {
         appendCreateTable(tableName, false);
     }
 
+    /** Appends {@code CREATE TABLE [IF NOT EXISTS ]<name>}. */
     protected void appendCreateTable(String tableName, boolean ifNotExists) {
         sb.append("CREATE TABLE ");
         if (ifNotExists) {
@@ -18,12 +20,20 @@ public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>
         sb.append(tableName);
     }
 
+    /**
+     * Appends a parenthesized, comma-separated column definition list, e.g. {@code (c0 INT, c1 TEXT)}. Delegates each
+     * column's rendering to {@link #appendColumnDefinition(AbstractTableColumn)}.
+     */
     protected void appendColumnDefinitions(List<C> columns) {
         sb.append("(");
         appendColumnDefinitionList(columns);
         sb.append(")");
     }
 
+    /**
+     * Appends a comma-separated column definition list without enclosing parentheses, e.g. {@code c0 INT, c1 TEXT}.
+     * Useful when subclasses also emit table-level constraints (e.g. {@code PRIMARY KEY (...)}) inside the same parens.
+     */
     protected void appendColumnDefinitionList(List<C> columns) {
         for (int i = 0; i < columns.size(); i++) {
             if (i != 0) {
@@ -33,6 +43,10 @@ public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>
         }
     }
 
+    /**
+     * Appends a single column's definition. Default output is {@code <name> <type>}, e.g. {@code c0 INT}. Override to
+     * add constraints such as {@code NOT NULL}, {@code DEFAULT ...}, or {@code CHECK (...)}.
+     */
     protected void appendColumnDefinition(C column) {
         sb.append(column.getName());
         sb.append(" ");

--- a/src/sqlancer/common/gen/AbstractTableGenerator.java
+++ b/src/sqlancer/common/gen/AbstractTableGenerator.java
@@ -6,12 +6,24 @@ import sqlancer.common.schema.AbstractTableColumn;
 
 public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>> extends AbstractGenerator {
 
-    /** Appends {@code CREATE TABLE <name>}. */
+    /**
+     * Appends {@code CREATE TABLE <name>}.
+     *
+     * @param tableName
+     *            the name of the table to create.
+     */
     protected void appendCreateTable(String tableName) {
         appendCreateTable(tableName, false);
     }
 
-    /** Appends {@code CREATE TABLE [IF NOT EXISTS ]<name>}. */
+    /**
+     * Appends {@code CREATE TABLE [IF NOT EXISTS ]<name>}.
+     *
+     * @param tableName
+     *            the name of the table to create.
+     * @param ifNotExists
+     *            whether to emit the {@code IF NOT EXISTS} clause.
+     */
     protected void appendCreateTable(String tableName, boolean ifNotExists) {
         sb.append("CREATE TABLE ");
         if (ifNotExists) {
@@ -23,6 +35,9 @@ public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>
     /**
      * Appends a parenthesized, comma-separated column definition list, e.g. {@code (c0 INT, c1 TEXT)}. Delegates each
      * column's rendering to {@link #appendColumnDefinition(AbstractTableColumn)}.
+     *
+     * @param columns
+     *            the columns to render.
      */
     protected void appendColumnDefinitions(List<C> columns) {
         sb.append("(");
@@ -33,6 +48,9 @@ public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>
     /**
      * Appends a comma-separated column definition list without enclosing parentheses, e.g. {@code c0 INT, c1 TEXT}.
      * Useful when subclasses also emit table-level constraints (e.g. {@code PRIMARY KEY (...)}) inside the same parens.
+     *
+     * @param columns
+     *            the columns to render.
      */
     protected void appendColumnDefinitionList(List<C> columns) {
         for (int i = 0; i < columns.size(); i++) {
@@ -46,6 +64,9 @@ public abstract class AbstractTableGenerator<C extends AbstractTableColumn<?, ?>
     /**
      * Appends a single column's definition. Default output is {@code <name> <type>}, e.g. {@code c0 INT}. Override to
      * add constraints such as {@code NOT NULL}, {@code DEFAULT ...}, or {@code CHECK (...)}.
+     *
+     * @param column
+     *            the column whose definition to render.
      */
     protected void appendColumnDefinition(C column) {
         sb.append(column.getName());

--- a/src/sqlancer/databend/gen/DatabendTableGenerator.java
+++ b/src/sqlancer/databend/gen/DatabendTableGenerator.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import sqlancer.Randomly;
+import sqlancer.common.gen.AbstractTableGenerator;
 import sqlancer.common.gen.TypedExpressionGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.databend.DatabendErrors;
 import sqlancer.databend.DatabendProvider.DatabendGlobalState;
@@ -15,44 +15,49 @@ import sqlancer.databend.DatabendSchema.DatabendDataType;
 import sqlancer.databend.DatabendToStringVisitor;
 import sqlancer.databend.ast.DatabendExpression;
 
-public class DatabendTableGenerator {
+public class DatabendTableGenerator extends AbstractTableGenerator<DatabendColumn> {
+
+    private DatabendGlobalState globalState;
+    private TypedExpressionGenerator<DatabendExpression, DatabendColumn, DatabendDataType> gen;
+
+    public DatabendTableGenerator() {
+        this.canAffectSchema = true;
+    }
 
     public SQLQueryAdapter getQuery(DatabendGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
+        this.globalState = globalState;
+        return getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         DatabendErrors.addExpressionErrors(errors);
-        StringBuilder sb = new StringBuilder();
         String tableName = globalState.getSchema().getFreeTableName();
-        sb.append("CREATE TABLE ");
-        sb.append(tableName);
-        sb.append("(");
+        appendCreateTable(tableName);
         List<DatabendColumn> columns = getNewColumns();
-        TypedExpressionGenerator<DatabendExpression, DatabendColumn, DatabendDataType> gen = new DatabendNewExpressionGenerator(
-                globalState).setColumns(columns);
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(columns.get(i).getName());
-            sb.append(" ");
-            sb.append(columns.get(i).getType());
+        gen = new DatabendNewExpressionGenerator(globalState).setColumns(columns);
+        appendColumnDefinitions(columns);
+    }
 
-            if (globalState.getDbmsSpecificOptions().testNotNullConstraints
-                    && Randomly.getBooleanWithRatherLowProbability()) {
-                sb.append(" NOT NULL");
-            } else {
-                sb.append(" NULL"); // Databend 默认字段为非空，这个将它默认设置为允许空
-            }
+    @Override
+    protected void appendColumnDefinition(DatabendColumn column) {
+        sb.append(column.getName());
+        sb.append(" ");
+        sb.append(column.getType());
 
-            if (Randomly.getBoolean() && globalState.getDbmsSpecificOptions().testDefaultValues) {
-                sb.append(" DEFAULT(");
-                sb.append(DatabendToStringVisitor.asString(// 常量类型于字段类型等同
-                        gen.generateConstant(columns.get(i).getType().getPrimitiveDataType())));
-                sb.append(")");
-            }
+        if (globalState.getDbmsSpecificOptions().testNotNullConstraints
+                && Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" NOT NULL");
+        } else {
+            sb.append(" NULL"); // Databend 默认字段为非空，这个将它默认设置为允许空
         }
 
-        sb.append(")");
-        return new SQLQueryAdapter(sb.toString(), errors, true);
+        if (Randomly.getBoolean() && globalState.getDbmsSpecificOptions().testDefaultValues) {
+            sb.append(" DEFAULT(");
+            sb.append(DatabendToStringVisitor.asString(// 常量类型于字段类型等同
+                    gen.generateConstant(column.getType().getPrimitiveDataType())));
+            sb.append(")");
+        }
     }
 
     private static List<DatabendColumn> getNewColumns() {

--- a/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBTableGenerator.java
@@ -5,8 +5,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
+import sqlancer.common.gen.AbstractTableGenerator;
 import sqlancer.common.gen.UntypedExpressionGenerator;
-import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.duckdb.DuckDBErrors;
 import sqlancer.duckdb.DuckDBProvider.DuckDBGlobalState;
@@ -16,50 +16,28 @@ import sqlancer.duckdb.DuckDBSchema.DuckDBDataType;
 import sqlancer.duckdb.DuckDBToStringVisitor;
 import sqlancer.duckdb.ast.DuckDBExpression;
 
-public class DuckDBTableGenerator {
+public class DuckDBTableGenerator extends AbstractTableGenerator<DuckDBColumn> {
+
+    private DuckDBGlobalState globalState;
+    private UntypedExpressionGenerator<DuckDBExpression, DuckDBColumn> gen;
+
+    public DuckDBTableGenerator() {
+        this.canAffectSchema = true;
+    }
 
     public SQLQueryAdapter getQuery(DuckDBGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
+        this.globalState = globalState;
+        return getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         String tableName = globalState.getSchema().getFreeTableName();
-        sb.append("CREATE TABLE ");
-        sb.append(tableName);
-        sb.append("(");
+        appendCreateTable(tableName);
         List<DuckDBColumn> columns = getNewColumns();
-        UntypedExpressionGenerator<DuckDBExpression, DuckDBColumn> gen = new DuckDBExpressionGenerator(globalState)
-                .setColumns(columns);
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(columns.get(i).getName());
-            sb.append(" ");
-            sb.append(columns.get(i).getType());
-            if (globalState.getDbmsSpecificOptions().testCollate && Randomly.getBooleanWithRatherLowProbability()
-                    && columns.get(i).getType().getPrimitiveDataType() == DuckDBDataType.VARCHAR) {
-                sb.append(" COLLATE ");
-                sb.append(getRandomCollate());
-            }
-            if (globalState.getDbmsSpecificOptions().testIndexes && Randomly.getBooleanWithRatherLowProbability()) {
-                sb.append(" UNIQUE");
-            }
-            if (globalState.getDbmsSpecificOptions().testNotNullConstraints
-                    && Randomly.getBooleanWithRatherLowProbability()) {
-                sb.append(" NOT NULL");
-            }
-            if (globalState.getDbmsSpecificOptions().testCheckConstraints
-                    && Randomly.getBooleanWithRatherLowProbability()) {
-                sb.append(" CHECK(");
-                sb.append(DuckDBToStringVisitor.asString(gen.generateExpression()));
-                DuckDBErrors.addExpressionErrors(errors);
-                sb.append(")");
-            }
-            if (Randomly.getBoolean() && globalState.getDbmsSpecificOptions().testDefaultValues) {
-                sb.append(" DEFAULT(");
-                sb.append(DuckDBToStringVisitor.asString(gen.generateConstant()));
-                sb.append(")");
-            }
-        }
+        gen = new DuckDBExpressionGenerator(globalState).setColumns(columns);
+        sb.append("(");
+        appendColumnDefinitionList(columns);
         if (globalState.getDbmsSpecificOptions().testIndexes && Randomly.getBoolean()) {
             errors.add("Invalid type for index");
             List<DuckDBColumn> primaryKeyColumns = Randomly.nonEmptySubset(columns);
@@ -68,7 +46,37 @@ public class DuckDBTableGenerator {
             sb.append(")");
         }
         sb.append(")");
-        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+    @Override
+    protected void appendColumnDefinition(DuckDBColumn column) {
+        sb.append(column.getName());
+        sb.append(" ");
+        sb.append(column.getType());
+        if (globalState.getDbmsSpecificOptions().testCollate && Randomly.getBooleanWithRatherLowProbability()
+                && column.getType().getPrimitiveDataType() == DuckDBDataType.VARCHAR) {
+            sb.append(" COLLATE ");
+            sb.append(getRandomCollate());
+        }
+        if (globalState.getDbmsSpecificOptions().testIndexes && Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" UNIQUE");
+        }
+        if (globalState.getDbmsSpecificOptions().testNotNullConstraints
+                && Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" NOT NULL");
+        }
+        if (globalState.getDbmsSpecificOptions().testCheckConstraints
+                && Randomly.getBooleanWithRatherLowProbability()) {
+            sb.append(" CHECK(");
+            sb.append(DuckDBToStringVisitor.asString(gen.generateExpression()));
+            DuckDBErrors.addExpressionErrors(errors);
+            sb.append(")");
+        }
+        if (Randomly.getBoolean() && globalState.getDbmsSpecificOptions().testDefaultValues) {
+            sb.append(" DEFAULT(");
+            sb.append(DuckDBToStringVisitor.asString(gen.generateConstant()));
+            sb.append(")");
+        }
     }
 
     public static String getRandomCollate() {

--- a/src/sqlancer/hsqldb/gen/HSQLDBTableGenerator.java
+++ b/src/sqlancer/hsqldb/gen/HSQLDBTableGenerator.java
@@ -5,44 +5,48 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractTableGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.hsqldb.HSQLDBProvider;
 import sqlancer.hsqldb.HSQLDBSchema;
 
-public class HSQLDBTableGenerator {
+public class HSQLDBTableGenerator extends AbstractTableGenerator<HSQLDBSchema.HSQLDBColumn> {
+
+    private HSQLDBProvider.HSQLDBGlobalState globalState;
+    private String tableName;
+
+    public HSQLDBTableGenerator() {
+        this.canAffectSchema = true;
+    }
 
     public SQLQueryAdapter getQuery(HSQLDBProvider.HSQLDBGlobalState globalState, @Nullable String tableName) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
+        this.globalState = globalState;
+        this.tableName = tableName;
+        return getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         String name = tableName;
-        if (tableName == null) {
+        if (name == null) {
             name = globalState.getSchema().getFreeTableName();
         }
-        sb.append("CREATE TABLE ");
-        if (Randomly.getBoolean()) {
-            sb.append("IF NOT EXISTS ");
-        }
-        sb.append(name);
-        sb.append("(");
-        List<HSQLDBSchema.HSQLDBColumn> columns = getNewColumns();
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(columns.get(i).getName());
-            sb.append(" ");
-            sb.append(columns.get(i).getType().getType().name());
-            if (columns.get(i).getType().getSize() > 0) {
-                // Cannot specify size for non composite data types
-                sb.append("(");
-                sb.append(columns.get(i).getType().getSize());
-                sb.append(")");
-            }
-        }
-        sb.append(")");
+        appendCreateTable(name, Randomly.getBoolean());
+        appendColumnDefinitions(getNewColumns());
         sb.append(";");
-        return new SQLQueryAdapter(sb.toString(), errors, true);
+    }
+
+    @Override
+    protected void appendColumnDefinition(HSQLDBSchema.HSQLDBColumn column) {
+        sb.append(column.getName());
+        sb.append(" ");
+        sb.append(column.getType().getType().name());
+        if (column.getType().getSize() > 0) {
+            // Cannot specify size for non composite data types
+            sb.append("(");
+            sb.append(column.getType().getSize());
+            sb.append(")");
+        }
     }
 
     private static List<HSQLDBSchema.HSQLDBColumn> getNewColumns() {

--- a/src/sqlancer/presto/gen/PrestoTableGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoTableGenerator.java
@@ -4,13 +4,35 @@ import java.util.ArrayList;
 import java.util.List;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractTableGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.presto.PrestoGlobalState;
 import sqlancer.presto.PrestoSchema.PrestoColumn;
 import sqlancer.presto.PrestoSchema.PrestoCompositeDataType;
 
-public class PrestoTableGenerator {
+public class PrestoTableGenerator extends AbstractTableGenerator<PrestoColumn> {
+
+    private PrestoGlobalState globalState;
+
+    public PrestoTableGenerator() {
+        this.canAffectSchema = true;
+        this.canonicalizeString = false;
+    }
+
+    public SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
+        this.globalState = globalState;
+        return getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
+        String catalog = globalState.getDbmsSpecificOptions().catalog;
+        String schema = globalState.getDatabaseName();
+        String tableName = globalState.getSchema().getFreeTableName();
+        String qualifiedName = catalog + "." + schema + "." + tableName;
+        appendCreateTable(qualifiedName);
+        appendColumnDefinitions(getNewColumns());
+    }
 
     private static List<PrestoColumn> getNewColumns() {
         List<PrestoColumn> columns = new ArrayList<>();
@@ -20,50 +42,6 @@ public class PrestoTableGenerator {
             columns.add(new PrestoColumn(columnName, columnType, false, false));
         }
         return columns;
-    }
-
-    public SQLQueryAdapter getQuery(PrestoGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
-        String tableName = globalState.getSchema().getFreeTableName();
-        sb.append("CREATE TABLE ");
-        String catalog = globalState.getDbmsSpecificOptions().catalog;
-        String schema = globalState.getDatabaseName();
-
-        sb.append(catalog).append(".");
-        sb.append(schema).append(".");
-
-        sb.append(tableName);
-        sb.append("(");
-        List<PrestoColumn> columns = getNewColumns();
-        // TypedExpressionGenerator<Node<PrestoExpression>, PrestoColumn, PrestoCompositeDataType>
-        // typedExpressionGenerator = new PrestoTypedExpressionGenerator(globalState).setColumns(columns);
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            PrestoColumn column = columns.get(i);
-            sb.append(column.getName());
-            sb.append(" ");
-            sb.append(column.getType());
-            // if (globalState.getDbmsSpecificOptions().testIndexes && Randomly.getBooleanWithRatherLowProbability()) {
-            // sb.append(" UNIQUE");
-            // }
-            // if (globalState.getDbmsSpecificOptions().testNotNullConstraints
-            // && Randomly.getBooleanWithRatherLowProbability()) {
-            // sb.append(" NOT NULL");
-            // }
-        }
-        // if (globalState.getDbmsSpecificOptions().testIndexes && Randomly.getBoolean()) {
-        // errors.add("Invalid type for index");
-        // List<PrestoColumn> primaryKeyColumns = Randomly.nonEmptySubset(columns);
-        // sb.append(", PRIMARY KEY(");
-        // sb.append(primaryKeyColumns.stream().map(c -> c.getName()).collect(Collectors.joining(", ")));
-        // sb.append(")");
-        // }
-        sb.append(")");
-
-        return new SQLQueryAdapter(sb.toString(), errors, true, false);
     }
 
 }

--- a/src/sqlancer/questdb/gen/QuestDBTableGenerator.java
+++ b/src/sqlancer/questdb/gen/QuestDBTableGenerator.java
@@ -5,40 +5,37 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractTableGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.questdb.QuestDBProvider.QuestDBGlobalState;
 import sqlancer.questdb.QuestDBSchema.QuestDBColumn;
 import sqlancer.questdb.QuestDBSchema.QuestDBCompositeDataType;
 
-public class QuestDBTableGenerator {
+public class QuestDBTableGenerator extends AbstractTableGenerator<QuestDBColumn> {
+
+    private QuestDBGlobalState globalState;
+    private String tableName;
+
+    public QuestDBTableGenerator() {
+        this.canAffectSchema = true;
+    }
 
     public SQLQueryAdapter getQuery(QuestDBGlobalState globalState, @Nullable String tableName) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
+        this.globalState = globalState;
+        this.tableName = tableName;
+        return getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         String name = tableName;
-        if (tableName == null) {
+        if (name == null) {
             name = globalState.getSchema().getFreeTableName();
         }
-        sb.append("CREATE TABLE ");
-        if (Randomly.getBoolean()) {
-            sb.append("IF NOT EXISTS ");
-        }
-        sb.append(name);
-        sb.append("(");
-        List<QuestDBColumn> columns = getNewColumns();
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(columns.get(i).getName());
-            sb.append(" ");
-            sb.append(columns.get(i).getType());
-        }
-        sb.append(")");
+        appendCreateTable(name, Randomly.getBoolean());
+        appendColumnDefinitions(getNewColumns());
         sb.append(";");
         errors.add("table already exists");
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
     private static List<QuestDBColumn> getNewColumns() {

--- a/src/sqlancer/spark/gen/SparkTableGenerator.java
+++ b/src/sqlancer/spark/gen/SparkTableGenerator.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import sqlancer.Randomly;
 import sqlancer.common.DBMSCommon;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractTableGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.spark.SparkErrors;
 import sqlancer.spark.SparkGlobalState;
@@ -15,7 +15,7 @@ import sqlancer.spark.SparkSchema.SparkDataType;
 import sqlancer.spark.SparkSchema.SparkTable;
 import sqlancer.spark.SparkToStringVisitor;
 
-public class SparkTableGenerator {
+public class SparkTableGenerator extends AbstractTableGenerator<SparkColumn> {
 
     private enum ColumnConstraints {
         NOT_NULL, DEFAULT
@@ -27,7 +27,6 @@ public class SparkTableGenerator {
 
     private final SparkGlobalState globalState;
     private final String tableName;
-    private final StringBuilder sb = new StringBuilder();
     private final SparkExpressionGenerator gen;
     private final SparkTable table;
     private final List<SparkColumn> columnsToBeAdded = new ArrayList<>();
@@ -37,28 +36,25 @@ public class SparkTableGenerator {
         this.globalState = globalState;
         this.table = new SparkTable(tableName, columnsToBeAdded, false);
         this.gen = new SparkExpressionGenerator(globalState).setColumns(columnsToBeAdded);
+        this.canAffectSchema = true;
+        this.canonicalizeString = false;
     }
 
     public static SQLQueryAdapter generate(SparkGlobalState globalState, String tableName) {
-        SparkTableGenerator generator = new SparkTableGenerator(globalState, tableName);
-        return generator.create();
+        return new SparkTableGenerator(globalState, tableName).getStatement();
     }
 
-    private SQLQueryAdapter create() {
-        ExpectedErrors errors = new ExpectedErrors();
-
-        sb.append("CREATE TABLE ");
-        sb.append(globalState.getDatabaseName());
-        sb.append(".");
-        sb.append(tableName);
-        sb.append(" (");
-        for (int i = 0; i < Randomly.smallNumber() + 1; i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            appendColumn(i);
+    @Override
+    public void buildStatement() {
+        int columnCount = Randomly.smallNumber() + 1;
+        for (int i = 0; i < columnCount; i++) {
+            String columnName = DBMSCommon.createColumnName(i);
+            SparkDataType type = SparkSchema.SparkDataType.getRandomType();
+            columnsToBeAdded.add(new SparkColumn(columnName, table, type));
         }
-        sb.append(")");
+        appendCreateTable(globalState.getDatabaseName() + "." + tableName);
+        sb.append(" ");
+        appendColumnDefinitions(columnsToBeAdded);
         sb.append(" USING PARQUET");
 
         // TODO: implement PARTITION BY clause
@@ -67,16 +63,13 @@ public class SparkTableGenerator {
         // TODO: randomly add some predefined TABLEPROPERTIES
 
         SparkErrors.addExpressionErrors(errors);
-        return new SQLQueryAdapter(sb.toString(), errors, true, false);
     }
 
-    private void appendColumn(int columnId) {
-        String columnName = DBMSCommon.createColumnName(columnId);
-        sb.append(columnName);
+    @Override
+    protected void appendColumnDefinition(SparkColumn column) {
+        sb.append(column.getName());
         sb.append(" ");
-        SparkDataType randType = SparkSchema.SparkDataType.getRandomType();
-        sb.append(randType);
-        columnsToBeAdded.add(new SparkColumn(columnName, table, randType));
+        sb.append(column.getType());
         appendColumnConstraint();
     }
 

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLTableGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLTableGenerator.java
@@ -5,35 +5,33 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.Randomly;
-import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.gen.AbstractTableGenerator;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.common.schema.AbstractTableColumn;
 import sqlancer.yugabyte.ycql.YCQLProvider.YCQLGlobalState;
 import sqlancer.yugabyte.ycql.YCQLSchema.YCQLColumn;
 import sqlancer.yugabyte.ycql.YCQLSchema.YCQLCompositeDataType;
 
-public class YCQLTableGenerator {
+public class YCQLTableGenerator extends AbstractTableGenerator<YCQLColumn> {
+
+    private YCQLGlobalState globalState;
+
+    public YCQLTableGenerator() {
+        this.canAffectSchema = true;
+    }
 
     public SQLQueryAdapter getQuery(YCQLGlobalState globalState) {
-        ExpectedErrors errors = new ExpectedErrors();
-        StringBuilder sb = new StringBuilder();
+        this.globalState = globalState;
+        return getStatement();
+    }
+
+    @Override
+    public void buildStatement() {
         String tableName = globalState.getSchema().getFreeTableName();
-        sb.append("CREATE TABLE ");
-        if (Randomly.getBoolean()) {
-            sb.append("IF NOT EXISTS ");
-        }
-        sb.append(tableName);
-        sb.append("(");
+        appendCreateTable(tableName, Randomly.getBoolean());
         List<YCQLColumn> columns = getNewColumns();
-        for (int i = 0; i < columns.size(); i++) {
-            if (i != 0) {
-                sb.append(", ");
-            }
-            sb.append(columns.get(i).getName());
-            sb.append(" ");
-            sb.append(columns.get(i).getType());
-            // todo PK, STATIC
-        }
+        sb.append("(");
+        appendColumnDefinitionList(columns);
         errors.add("Query timed out after PT2S");
         errors.add("Invalid type for index");
         List<YCQLColumn> primaryKeyColumns = Randomly.nonEmptySubset(columns);
@@ -41,7 +39,6 @@ public class YCQLTableGenerator {
         sb.append(primaryKeyColumns.stream().map(AbstractTableColumn::getName).collect(Collectors.joining(", ")));
         sb.append(")");
         sb.append(")");
-        return new SQLQueryAdapter(sb.toString(), errors, true);
     }
 
     private static List<YCQLColumn> getNewColumns() {


### PR DESCRIPTION
Introduce AbstractTableGenerator<C> with appendCreateTable header helpers and appendColumnDefinitions / appendColumnDefinitionList iteration helpers that delegate to an overridable appendColumnDefinition(C) (default: "name type"). Convert four concrete table generators (QuestDB, HSQLDB, Databend, DuckDB) from plain classes to instance-based subclasses whose logic lives in buildStatement().

Public entry points (getQuery) are preserved so callers in the provider classes don't need to change. Generators with DB-specific shape (temporary/unlogged modifiers, in-place column building, partitioning, custom return types, etc.) are left alone.