### PR TITLE
Refactor: extract common DELETE generation logic into AbstractDeleteG…

### DIFF
--- a/src/sqlancer/cockroachdb/gen/CockroachDBDeleteGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBDeleteGenerator.java
@@ -24,12 +24,10 @@ public final class CockroachDBDeleteGenerator extends AbstractDeleteGenerator {
     @Override
     public void buildStatement() {
         CockroachDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        sb.append("DELETE FROM ");
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             CockroachDBErrors.addExpressionErrors(errors);
-            sb.append(CockroachDBVisitor.asString(new CockroachDBExpressionGenerator(globalState)
+            appendWhereClause(CockroachDBVisitor.asString(new CockroachDBExpressionGenerator(globalState)
                     .setColumns(table.getColumns()).generateExpression(CockroachDBDataType.BOOL.get())));
         } else {
             errors.add("rejected: DELETE without WHERE clause (sql_safe_updates = true)");

--- a/src/sqlancer/cockroachdb/gen/CockroachDBUpdateGenerator.java
+++ b/src/sqlancer/cockroachdb/gen/CockroachDBUpdateGenerator.java
@@ -40,8 +40,7 @@ public final class CockroachDBUpdateGenerator extends AbstractUpdateGenerator<Co
         sb.append(" SET ");
         updateColumns(columns);
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(CockroachDBVisitor.asString(gen.generateExpression(CockroachDBDataType.BOOL.get())));
+            appendWhereClause(CockroachDBVisitor.asString(gen.generateExpression(CockroachDBDataType.BOOL.get())));
         }
         errors.add("violates unique constraint");
         errors.add("violates not-null constraint");

--- a/src/sqlancer/common/gen/AbstractDeleteGenerator.java
+++ b/src/sqlancer/common/gen/AbstractDeleteGenerator.java
@@ -5,4 +5,54 @@ public abstract class AbstractDeleteGenerator extends AbstractGenerator {
     protected AbstractDeleteGenerator() {
     }
 
+    /**
+     * Appends {@code DELETE FROM <tableName>}.
+     *
+     * @param tableName
+     *            the name of the table to delete from.
+     */
+    protected void appendDeleteFromTable(String tableName) {
+        appendDeleteFromTable(tableName, false);
+    }
+
+    /**
+     * Appends {@code DELETE FROM [ONLY ]<tableName>}.
+     *
+     * @param tableName
+     *            the name of the table to delete from.
+     * @param only
+     *            whether to emit the {@code ONLY} keyword (used by some databases to restrict deletion to the named
+     *            table rather than its inheritance descendants).
+     */
+    protected void appendDeleteFromTable(String tableName, boolean only) {
+        sb.append("DELETE FROM ");
+        if (only) {
+            sb.append("ONLY ");
+        }
+        sb.append(tableName);
+    }
+
+    /**
+     * Appends {@code  LIMIT <value>} (with a leading space).
+     *
+     * @param value
+     *            the LIMIT value, e.g. an integer literal or already-rendered expression. Converted via
+     *            {@link StringBuilder#append(Object)}.
+     */
+    protected void appendLimitClause(Object value) {
+        sb.append(" LIMIT ");
+        sb.append(value);
+    }
+
+    /**
+     * Appends {@code  RETURNING <expression>} (with a leading space).
+     *
+     * @param expression
+     *            the rendered RETURNING expression.
+     */
+    protected void appendReturningClause(String expression) {
+        sb.append(" RETURNING ");
+        sb.append(expression);
+    }
+
 }

--- a/src/sqlancer/common/gen/AbstractGenerator.java
+++ b/src/sqlancer/common/gen/AbstractGenerator.java
@@ -17,4 +17,17 @@ public abstract class AbstractGenerator {
 
     public abstract void buildStatement();
 
+    /**
+     * Appends {@code  WHERE <condition>} (with a leading space). Subclasses are responsible for deciding whether to
+     * include the WHERE clause, typically based on a randomized boolean. Used by DELETE, UPDATE, partial-INDEX, and
+     * INSERT...ON CONFLICT generators.
+     *
+     * @param condition
+     *            the rendered WHERE condition.
+     */
+    protected void appendWhereClause(String condition) {
+        sb.append(" WHERE ");
+        sb.append(condition);
+    }
+
 }

--- a/src/sqlancer/databend/gen/DatabendDeleteGenerator.java
+++ b/src/sqlancer/databend/gen/DatabendDeleteGenerator.java
@@ -22,11 +22,9 @@ public final class DatabendDeleteGenerator extends AbstractDeleteGenerator {
 
     @Override
     public void buildStatement() {
-        sb.append("DELETE FROM ");
-        sb.append(globalState.getSchema().getRandomTable(t -> !t.isView()).getName());
+        appendDeleteFromTable(globalState.getSchema().getRandomTable(t -> !t.isView()).getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(DatabendToStringVisitor.asString(
+            appendWhereClause(DatabendToStringVisitor.asString(
                     new DatabendNewExpressionGenerator(globalState).generateExpression(DatabendDataType.BOOLEAN)));
             DatabendErrors.addExpressionErrors(errors);
         }

--- a/src/sqlancer/doris/gen/DorisDeleteGenerator.java
+++ b/src/sqlancer/doris/gen/DorisDeleteGenerator.java
@@ -23,12 +23,10 @@ public final class DorisDeleteGenerator extends AbstractDeleteGenerator {
 
     @Override
     public void buildStatement() {
-        sb.append("DELETE FROM ");
         DorisTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(DorisToStringVisitor.asString(new DorisNewExpressionGenerator(globalState)
+            appendWhereClause(DorisToStringVisitor.asString(new DorisNewExpressionGenerator(globalState)
                     .setColumns(table.getColumns()).generateExpression(DorisSchema.DorisDataType.BOOLEAN)));
             DorisErrors.addExpressionErrors(errors);
         }

--- a/src/sqlancer/doris/gen/DorisUpdateGenerator.java
+++ b/src/sqlancer/doris/gen/DorisUpdateGenerator.java
@@ -35,8 +35,7 @@ public final class DorisUpdateGenerator extends AbstractUpdateGenerator<DorisCol
         sb.append(table.getName());
         sb.append(" SET ");
         updateColumns(columns);
-        sb.append(" WHERE ");
-        sb.append(DorisToStringVisitor.asString(gen.generateExpression(DorisSchema.DorisDataType.BOOLEAN)));
+        appendWhereClause(DorisToStringVisitor.asString(gen.generateExpression(DorisSchema.DorisDataType.BOOLEAN)));
         DorisErrors.addInsertErrors(errors);
     }
 

--- a/src/sqlancer/duckdb/gen/DuckDBDeleteGenerator.java
+++ b/src/sqlancer/duckdb/gen/DuckDBDeleteGenerator.java
@@ -22,12 +22,10 @@ public final class DuckDBDeleteGenerator extends AbstractDeleteGenerator {
 
     @Override
     public void buildStatement() {
-        sb.append("DELETE FROM ");
         DuckDBTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(DuckDBToStringVisitor.asString(
+            appendWhereClause(DuckDBToStringVisitor.asString(
                     new DuckDBExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
         }
         DuckDBErrors.addExpressionErrors(errors);

--- a/src/sqlancer/h2/H2DeleteGenerator.java
+++ b/src/sqlancer/h2/H2DeleteGenerator.java
@@ -20,17 +20,14 @@ public final class H2DeleteGenerator extends AbstractDeleteGenerator {
 
     @Override
     public void buildStatement() {
-        sb.append("DELETE FROM ");
         H2Table table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(H2ToStringVisitor.asString(
+            appendWhereClause(H2ToStringVisitor.asString(
                     new H2ExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
         }
         if (Randomly.getBoolean()) {
-            sb.append(" LIMIT ");
-            sb.append(H2ToStringVisitor.asString(new H2ExpressionGenerator(globalState).generateConstant()));
+            appendLimitClause(H2ToStringVisitor.asString(new H2ExpressionGenerator(globalState).generateConstant()));
         }
         H2Errors.addExpressionErrors(errors);
         H2Errors.addDeleteErrors(errors);

--- a/src/sqlancer/h2/H2UpdateGenerator.java
+++ b/src/sqlancer/h2/H2UpdateGenerator.java
@@ -34,8 +34,7 @@ public final class H2UpdateGenerator extends AbstractUpdateGenerator<H2Column> {
         H2Errors.addInsertErrors(errors);
         H2Errors.addDeleteErrors(errors);
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(H2ToStringVisitor.asString(gen.generateExpression()));
+            appendWhereClause(H2ToStringVisitor.asString(gen.generateExpression()));
         }
         H2Errors.addExpressionErrors(errors);
     }

--- a/src/sqlancer/hsqldb/gen/HSQLDBUpdateGenerator.java
+++ b/src/sqlancer/hsqldb/gen/HSQLDBUpdateGenerator.java
@@ -37,8 +37,7 @@ public final class HSQLDBUpdateGenerator extends AbstractUpdateGenerator<HSQLDBC
         sb.append(" SET ");
         updateColumns(columns);
         if (Randomly.getBooleanWithSmallProbability()) {
-            sb.append(" WHERE ");
-            sb.append(HSQLDBToStringVisitor.asString(
+            appendWhereClause(HSQLDBToStringVisitor.asString(
                     gen.generateExpression(HSQLDBCompositeDataType.getRandomWithType(HSQLDBDataType.BOOLEAN))));
             errors.add("data type of expression is not boolean");
             HSQLDBErrors.addExpressionErrors(errors);

--- a/src/sqlancer/mariadb/gen/MariaDBDeleteGenerator.java
+++ b/src/sqlancer/mariadb/gen/MariaDBDeleteGenerator.java
@@ -57,12 +57,13 @@ public final class MariaDBDeleteGenerator extends AbstractDeleteGenerator {
         sb.append(table.getName());
 
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
+            String condition;
             if (Randomly.getBooleanWithRatherLowProbability()) {
-                sb.append(MariaDBVisitor.asString(MariaDBExpressionGenerator.getRandomConstant(r)));
+                condition = MariaDBVisitor.asString(MariaDBExpressionGenerator.getRandomConstant(r));
             } else {
-                sb.append(MariaDBVisitor.asString(expressionGenerator.getRandomExpression()));
+                condition = MariaDBVisitor.asString(expressionGenerator.getRandomExpression());
             }
+            appendWhereClause(condition);
         }
 
         // ORDER BY + LIMIT
@@ -75,18 +76,18 @@ public final class MariaDBDeleteGenerator extends AbstractDeleteGenerator {
         }
 
         if (Randomly.getBooleanWithRatherLowProbability()) {
-            sb.append(" LIMIT ");
-            sb.append(Randomly.getNotCachedInteger(1, 10));
+            appendLimitClause(Randomly.getNotCachedInteger(1, 10));
         }
 
         // RETURNING clause (MariaDB >= 10.5)
         if (Randomly.getBooleanWithRatherLowProbability()) {
-            sb.append(" RETURNING ");
+            String expression;
             if (Randomly.getBooleanWithRatherLowProbability()) {
-                sb.append(MariaDBVisitor.asString(MariaDBExpressionGenerator.getRandomConstant(r)));
+                expression = MariaDBVisitor.asString(MariaDBExpressionGenerator.getRandomConstant(r));
             } else {
-                sb.append(MariaDBVisitor.asString(expressionGenerator.getRandomExpression()));
+                expression = MariaDBVisitor.asString(expressionGenerator.getRandomExpression());
             }
+            appendReturningClause(expression);
         }
 
         if (sb.toString().contains("RLIKE") || sb.toString().contains("REGEXP")) {

--- a/src/sqlancer/materialize/gen/MaterializeDeleteGenerator.java
+++ b/src/sqlancer/materialize/gen/MaterializeDeleteGenerator.java
@@ -26,12 +26,9 @@ public final class MaterializeDeleteGenerator extends AbstractDeleteGenerator {
         errors.add("violates foreign key constraint");
         errors.add("violates not-null constraint");
         errors.add("could not determine which collation to use for string comparison");
-        sb.append("DELETE FROM");
-        sb.append(" ");
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(MaterializeVisitor.asString(MaterializeExpressionGenerator.generateExpression(globalState,
+            appendWhereClause(MaterializeVisitor.asString(MaterializeExpressionGenerator.generateExpression(globalState,
                     table.getColumns(), MaterializeDataType.BOOLEAN)));
         }
         MaterializeCommon.addCommonExpressionErrors(errors);

--- a/src/sqlancer/materialize/gen/MaterializeUpdateGenerator.java
+++ b/src/sqlancer/materialize/gen/MaterializeUpdateGenerator.java
@@ -52,10 +52,9 @@ public final class MaterializeUpdateGenerator extends AbstractUpdateGenerator<Ma
         errors.add("but expression is of type");
         MaterializeCommon.addCommonExpressionErrors(errors);
         if (!Randomly.getBooleanWithSmallProbability()) {
-            sb.append(" WHERE ");
             MaterializeExpression where = MaterializeExpressionGenerator.generateExpression(globalState,
                     randomTable.getColumns(), MaterializeDataType.BOOLEAN);
-            sb.append(MaterializeVisitor.asString(where));
+            appendWhereClause(MaterializeVisitor.asString(where));
         }
     }
 

--- a/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLDeleteGenerator.java
@@ -40,8 +40,7 @@ public class MySQLDeleteGenerator extends AbstractDeleteGenerator {
         sb.append(" FROM ");
         sb.append(randomTable.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(MySQLVisitor.asString(gen.generateExpression()));
+            appendWhereClause(MySQLVisitor.asString(gen.generateExpression()));
             MySQLErrors.addExpressionErrors(errors);
         }
         errors.addAll(Arrays.asList("doesn't have this option",

--- a/src/sqlancer/mysql/gen/MySQLUpdateGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLUpdateGenerator.java
@@ -34,9 +34,8 @@ public class MySQLUpdateGenerator extends AbstractUpdateGenerator<MySQLColumn> {
         sb.append(" SET ");
         updateColumns(columns);
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             MySQLErrors.addExpressionErrors(errors);
-            sb.append(MySQLVisitor.asString(gen.generateExpression()));
+            appendWhereClause(MySQLVisitor.asString(gen.generateExpression()));
         }
         MySQLErrors.addInsertUpdateErrors(errors);
         errors.add("doesn't have this option");

--- a/src/sqlancer/oceanbase/gen/OceanBaseDeleteGenerator.java
+++ b/src/sqlancer/oceanbase/gen/OceanBaseDeleteGenerator.java
@@ -36,8 +36,7 @@ public class OceanBaseDeleteGenerator extends AbstractDeleteGenerator {
         sb.append(" FROM ");
         sb.append(randomTable.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(OceanBaseVisitor.asString(gen.generateExpression()));
+            appendWhereClause(OceanBaseVisitor.asString(gen.generateExpression()));
             OceanBaseErrors.addExpressionErrors(errors);
         }
         errors.addAll(Arrays.asList("doesn't have this option", "Truncated incorrect DOUBLE value",

--- a/src/sqlancer/oceanbase/gen/OceanBaseUpdateGenerator.java
+++ b/src/sqlancer/oceanbase/gen/OceanBaseUpdateGenerator.java
@@ -39,9 +39,8 @@ public class OceanBaseUpdateGenerator extends AbstractUpdateGenerator<OceanBaseC
         sb.append(" SET ");
         updateColumns(columns);
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             OceanBaseErrors.addExpressionErrors(errors);
-            sb.append(OceanBaseVisitor.asString(gen.generateExpression()));
+            appendWhereClause(OceanBaseVisitor.asString(gen.generateExpression()));
             errors.add("Data Too Long");
         }
         errors.add("Duplicated primary key");

--- a/src/sqlancer/postgres/gen/PostgresDeleteGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresDeleteGenerator.java
@@ -26,20 +26,13 @@ public final class PostgresDeleteGenerator extends AbstractDeleteGenerator {
         errors.add("violates foreign key constraint");
         errors.add("violates not-null constraint");
         errors.add("could not determine which collation to use for string comparison");
-        sb.append("DELETE FROM");
+        appendDeleteFromTable(table.getName(), Randomly.getBoolean());
         if (Randomly.getBoolean()) {
-            sb.append(" ONLY");
-        }
-        sb.append(" ");
-        sb.append(table.getName());
-        if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(PostgresVisitor.asString(PostgresExpressionGenerator.generateExpression(globalState,
+            appendWhereClause(PostgresVisitor.asString(PostgresExpressionGenerator.generateExpression(globalState,
                     table.getColumns(), PostgresDataType.BOOLEAN)));
         }
         if (Randomly.getBoolean()) {
-            sb.append(" RETURNING ");
-            sb.append(PostgresVisitor
+            appendReturningClause(PostgresVisitor
                     .asString(PostgresExpressionGenerator.generateExpression(globalState, table.getColumns())));
         }
         PostgresCommon.addCommonExpressionErrors(errors);

--- a/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresIndexGenerator.java
@@ -107,10 +107,9 @@ public class PostgresIndexGenerator extends AbstractIndexGenerator<PostgresColum
             sb.append(")");
         }
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             PostgresExpression expr = new PostgresExpressionGenerator(globalState).setColumns(randomTable.getColumns())
                     .setGlobalState(globalState).generateExpression(PostgresDataType.BOOLEAN);
-            sb.append(PostgresVisitor.asString(expr));
+            appendWhereClause(PostgresVisitor.asString(expr));
         }
         errors.add("already contains data"); // CONCURRENT INDEX failed
         errors.add("You might need to add explicit type casts");

--- a/src/sqlancer/postgres/gen/PostgresUpdateGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresUpdateGenerator.java
@@ -52,10 +52,9 @@ public final class PostgresUpdateGenerator extends AbstractUpdateGenerator<Postg
         errors.add("but expression is of type");
         PostgresCommon.addCommonExpressionErrors(errors);
         if (!Randomly.getBooleanWithSmallProbability()) {
-            sb.append(" WHERE ");
             PostgresExpression where = PostgresExpressionGenerator.generateExpression(globalState,
                     randomTable.getColumns(), PostgresDataType.BOOLEAN);
-            sb.append(PostgresVisitor.asString(where));
+            appendWhereClause(PostgresVisitor.asString(where));
         }
     }
 

--- a/src/sqlancer/presto/gen/PrestoDeleteGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoDeleteGenerator.java
@@ -24,12 +24,10 @@ public final class PrestoDeleteGenerator extends AbstractDeleteGenerator {
 
     @Override
     public void buildStatement() {
-        sb.append("DELETE FROM ");
         PrestoTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(PrestoToStringVisitor
+            appendWhereClause(PrestoToStringVisitor
                     .asString(new PrestoTypedExpressionGenerator(globalState).setColumns(table.getColumns())
                             .generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull())));
         }

--- a/src/sqlancer/presto/gen/PrestoIndexGenerator.java
+++ b/src/sqlancer/presto/gen/PrestoIndexGenerator.java
@@ -51,10 +51,9 @@ public class PrestoIndexGenerator extends AbstractIndexGenerator<PrestoColumn> {
         }
         sb.append(")");
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             PrestoExpression expr = new PrestoTypedExpressionGenerator(globalState).setColumns(table.getColumns())
                     .generateExpression(PrestoSchema.PrestoCompositeDataType.getRandomWithoutNull());
-            sb.append(PrestoToStringVisitor.asString(expr));
+            appendWhereClause(PrestoToStringVisitor.asString(expr));
         }
         errors.add("already exists!");
     }

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3DeleteGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3DeleteGenerator.java
@@ -33,11 +33,9 @@ public final class SQLite3DeleteGenerator extends AbstractDeleteGenerator {
 
     @Override
     public void buildStatement() {
-        sb.append("DELETE FROM ");
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(SQLite3Visitor.asString(
+            appendWhereClause(SQLite3Visitor.asString(
                     new SQLite3ExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
         }
         SQLite3Errors.addExpectedExpressionErrors(errors);

--- a/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
+++ b/src/sqlancer/sqlite3/gen/dml/SQLite3UpdateGenerator.java
@@ -76,10 +76,9 @@ public final class SQLite3UpdateGenerator extends AbstractUpdateGenerator<SQLite
         }
 
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             String whereClause = SQLite3Visitor.asString(
                     new SQLite3ExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression());
-            sb.append(whereClause);
+            appendWhereClause(whereClause);
         }
 
         // ORDER BY and LIMIT are only supported by enabling a compile-time option

--- a/src/sqlancer/tidb/gen/TiDBDeleteGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBDeleteGenerator.java
@@ -41,8 +41,7 @@ public final class TiDBDeleteGenerator extends AbstractDeleteGenerator {
         sb.append("FROM ");
         sb.append(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(TiDBVisitor.asString(gen.generateExpression()));
+            appendWhereClause(TiDBVisitor.asString(gen.generateExpression()));
             errors.add("Truncated incorrect");
             errors.add("Data truncation");
             errors.add("Truncated incorrect FLOAT value");
@@ -54,8 +53,7 @@ public final class TiDBDeleteGenerator extends AbstractDeleteGenerator {
                     .collect(Collectors.joining(", ")));
         }
         if (Randomly.getBoolean()) {
-            sb.append(" LIMIT ");
-            sb.append(Randomly.getNotCachedInteger(0, Integer.MAX_VALUE));
+            appendLimitClause(Randomly.getNotCachedInteger(0, Integer.MAX_VALUE));
         }
         errors.add("Bad Number");
         errors.add("Truncated incorrect"); // https://github.com/pingcap/tidb/issues/24292

--- a/src/sqlancer/tidb/gen/TiDBUpdateGenerator.java
+++ b/src/sqlancer/tidb/gen/TiDBUpdateGenerator.java
@@ -35,9 +35,8 @@ public final class TiDBUpdateGenerator extends AbstractUpdateGenerator<TiDBColum
         sb.append(" SET ");
         updateColumns(columns);
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             TiDBErrors.addExpressionErrors(errors);
-            sb.append(TiDBVisitor.asString(gen.generateExpression()));
+            appendWhereClause(TiDBVisitor.asString(gen.generateExpression()));
         }
         TiDBErrors.addInsertErrors(errors);
     }

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLDeleteGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLDeleteGenerator.java
@@ -23,11 +23,9 @@ public final class YCQLDeleteGenerator extends AbstractDeleteGenerator {
     @Override
     public void buildStatement() {
         YCQLTable table = globalState.getSchema().getRandomTable(t -> !t.isView());
-        sb.append("DELETE FROM ");
-        sb.append(table.getName());
+        appendDeleteFromTable(table.getName());
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(YCQLToStringVisitor.asString(
+            appendWhereClause(YCQLToStringVisitor.asString(
                     new YCQLExpressionGenerator(globalState).setColumns(table.getColumns()).generateExpression()));
         }
         YCQLErrors.addExpressionErrors(errors);

--- a/src/sqlancer/yugabyte/ycql/gen/YCQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ycql/gen/YCQLIndexGenerator.java
@@ -35,10 +35,9 @@ public class YCQLIndexGenerator extends AbstractIndexGenerator<YCQLColumn> {
         sb.append(table.getName());
         appendIndexColumnList(table.getRandomNonEmptyColumnSubset(), false);
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             YCQLExpression expr = new YCQLExpressionGenerator(globalState).setColumns(table.getColumns())
                     .generateExpression();
-            sb.append(YCQLToStringVisitor.asString(expr));
+            appendWhereClause(YCQLToStringVisitor.asString(expr));
         }
         errors.add("Query timed out after PT2S");
         errors.add("Invalid SQL Statement");

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLDeleteGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLDeleteGenerator.java
@@ -27,20 +27,13 @@ public final class YSQLDeleteGenerator extends AbstractDeleteGenerator {
         errors.add("violates foreign key constraint");
         errors.add("violates not-null constraint");
         errors.add("could not determine which collation to use for string comparison");
-        sb.append("DELETE FROM");
+        appendDeleteFromTable(table.getName(), Randomly.getBoolean());
         if (Randomly.getBoolean()) {
-            sb.append(" ONLY");
-        }
-        sb.append(" ");
-        sb.append(table.getName());
-        if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
-            sb.append(YSQLVisitor.asString(
+            appendWhereClause(YSQLVisitor.asString(
                     YSQLExpressionGenerator.generateExpression(globalState, table.getColumns(), YSQLDataType.BOOLEAN)));
         }
         if (Randomly.getBoolean()) {
-            sb.append(" RETURNING ");
-            sb.append(
+            appendReturningClause(
                     YSQLVisitor.asString(YSQLExpressionGenerator.generateExpression(globalState, table.getColumns())));
         }
         YSQLErrors.addCommonExpressionErrors(errors);

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLIndexGenerator.java
@@ -93,10 +93,9 @@ public class YSQLIndexGenerator extends AbstractIndexGenerator<YSQLColumn> {
             sb.append(")");
         }
         if (Randomly.getBoolean()) {
-            sb.append(" WHERE ");
             YSQLExpression expr = new YSQLExpressionGenerator(globalState).setColumns(randomTable.getColumns())
                     .setGlobalState(globalState).generateExpression(YSQLDataType.BOOLEAN);
-            sb.append(YSQLVisitor.asString(expr));
+            appendWhereClause(YSQLVisitor.asString(expr));
         }
         errors.add("already contains data"); // CONCURRENT INDEX failed
         errors.add("You might need to add explicit type casts");

--- a/src/sqlancer/yugabyte/ysql/gen/YSQLUpdateGenerator.java
+++ b/src/sqlancer/yugabyte/ysql/gen/YSQLUpdateGenerator.java
@@ -54,10 +54,9 @@ public final class YSQLUpdateGenerator extends AbstractUpdateGenerator<YSQLColum
         errors.add("but expression is of type");
         YSQLErrors.addCommonExpressionErrors(errors);
         if (!Randomly.getBooleanWithSmallProbability()) {
-            sb.append(" WHERE ");
             YSQLExpression where = YSQLExpressionGenerator.generateExpression(globalState, randomTable.getColumns(),
                     YSQLDataType.BOOLEAN);
-            sb.append(YSQLVisitor.asString(where));
+            appendWhereClause(YSQLVisitor.asString(where));
         }
     }
 


### PR DESCRIPTION
…enerator

Add appendDeleteFromTable, appendLimitClause, and appendReturningClause helpers in AbstractDeleteGenerator and migrate all 15 DELETE generators that extend it.

Lift the WHERE-clause helper to AbstractGenerator since it is also used by UPDATE, partial-INDEX, and INSERT...ON CONFLICT generators, and migrate 17 of those generators to use it.