### PR TITLE
Citus: skip INHERITS generation until citusdata/citus#8553 is fixed

### DIFF
--- a/src/sqlancer/citus/CitusBugs.java
+++ b/src/sqlancer/citus/CitusBugs.java
@@ -33,6 +33,9 @@ public final class CitusBugs {
     // https://github.com/citusdata/citus/issues/6298
     public static boolean bug6298 = true;
 
+    // https://github.com/citusdata/citus/issues/8553
+    public static boolean bug8553 = true;
+
     private CitusBugs() {
     }
 

--- a/src/sqlancer/citus/gen/CitusTableGenerator.java
+++ b/src/sqlancer/citus/gen/CitusTableGenerator.java
@@ -1,5 +1,6 @@
 package sqlancer.citus.gen;
 
+import sqlancer.citus.CitusBugs;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
 import sqlancer.postgres.PostgresSchema;
@@ -18,6 +19,14 @@ public class CitusTableGenerator extends PostgresTableGenerator {
     public static SQLQueryAdapter generate(String tableName, PostgresSchema newSchema, boolean generateOnlyKnown,
             PostgresGlobalState globalState) {
         return new CitusTableGenerator(tableName, newSchema, generateOnlyKnown, globalState).generate();
+    }
+
+    @Override
+    protected void generateInherits() {
+        if (CitusBugs.bug8553) {
+            return;
+        }
+        super.generateInherits();
     }
 
 }

--- a/src/sqlancer/postgres/gen/PostgresTableGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableGenerator.java
@@ -206,7 +206,7 @@ public class PostgresTableGenerator {
         sb.append(globalState.getRandomTableAccessMethod());
     }
 
-    private void generateInherits() {
+    protected void generateInherits() {
         if (Randomly.getBoolean() && !newSchema.getDatabaseTablesWithoutViews().isEmpty()) {
             sb.append(" INHERITS(");
             sb.append(newSchema.getDatabaseTablesRandomSubsetNotEmpty().stream().map(t -> t.getName())


### PR DESCRIPTION
Citus's distributed planner returns wrong results when an inheritance parent is cross-joined with a distributed table inside a LEFT JOIN ... ON FALSE and a WHERE filters on the parent column, which the TLP-WHERE oracle keeps tripping over (~1 in 8 Citus CI runs). Make PostgresTableGenerator.generateInherits() protected so CitusTableGenerator can override it as a no-op while the new CitusBugs.bug8553 flag is set.