### PR TITLE
Update from MySQL 8.4 to MySQL 9.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -444,7 +444,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:8.4
+        image: mysql:9.7.0
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:

--- a/pom.xml
+++ b/pom.xml
@@ -302,9 +302,9 @@
       <version>3.49.1.0</version>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.30</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>9.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>

--- a/src/sqlancer/mysql/MySQLBugs.java
+++ b/src/sqlancer/mysql/MySQLBugs.java
@@ -45,6 +45,10 @@ public final class MySQLBugs {
     // Creating an index on an integer-type column, then inserting a value which rounds to 1, causes result set mismatch.
     public static boolean bug120711 = true;
 
+    // https://bugs.mysql.com/bug.php?id=120712
+    // Creating an index in between two NULL inserts causes inconsistent CERT result.
+    public static boolean bug120712 = true;
+
     private MySQLBugs() {
     }
 

--- a/src/sqlancer/mysql/MySQLBugs.java
+++ b/src/sqlancer/mysql/MySQLBugs.java
@@ -37,6 +37,10 @@ public final class MySQLBugs {
     // https://bugs.mysql.com/bug.php?id=114534
     public static boolean bug114534 = true;
 
+    // https://bugs.mysql.com/bug.php?id=120711
+    // Creating an index on an integer-type column, then inserting a value which rounds to 1, causes result set mismatch.
+    public static boolean bug120711 = true;
+
     private MySQLBugs() {
     }
 

--- a/src/sqlancer/mysql/MySQLBugs.java
+++ b/src/sqlancer/mysql/MySQLBugs.java
@@ -3,12 +3,8 @@ package sqlancer.mysql;
 // do not make the fields final to avoid warnings
 public final class MySQLBugs {
 
-    // https://bugs.mysql.com/bug.php?id=99127 0.9 > t0.c0 malfunctions when c0 is
-    // an INT UNSIGNED
-    public static boolean bug99127 = true;
-
     // https://bugs.mysql.com/99182 BETWEEN malfunctions for DECIMAL and TEXT
-    public static boolean bug99181 = true;
+    public static boolean bug99182 = true;
 
     // https://bugs.mysql.com/bug.php?id=99183
     public static boolean bug99183 = true;

--- a/src/sqlancer/mysql/MySQLBugs.java
+++ b/src/sqlancer/mysql/MySQLBugs.java
@@ -38,7 +38,8 @@ public final class MySQLBugs {
     public static boolean bug120710 = true;
 
     // https://bugs.mysql.com/bug.php?id=120711
-    // Creating an index on an integer-type column, then inserting a value which rounds to 1, causes result set mismatch.
+    // Creating an index on an integer-type column, then inserting a value which rounds to 1, causes result set
+    // mismatch.
     public static boolean bug120711 = true;
 
     // https://bugs.mysql.com/bug.php?id=120712

--- a/src/sqlancer/mysql/MySQLBugs.java
+++ b/src/sqlancer/mysql/MySQLBugs.java
@@ -37,6 +37,10 @@ public final class MySQLBugs {
     // https://bugs.mysql.com/bug.php?id=114534
     public static boolean bug114534 = true;
 
+    // https://bugs.mysql.com/bug.php?id=120710
+    // Inserting a NULL and a value which rounds to 0 into a DECIMAL column causes result set mismatch.
+    public static boolean bug120710 = true;
+
     // https://bugs.mysql.com/bug.php?id=120711
     // Creating an index on an integer-type column, then inserting a value which rounds to 1, causes result set mismatch.
     public static boolean bug120711 = true;

--- a/src/sqlancer/mysql/MySQLErrors.java
+++ b/src/sqlancer/mysql/MySQLErrors.java
@@ -49,6 +49,7 @@ public final class MySQLErrors {
         errors.add("doesn't have a default value");
         errors.add("Data truncation");
         errors.add("Incorrect integer value");
+        errors.add("Incorrect FLOAT value");
         errors.add("Duplicate entry");
         errors.add("Data truncated for column");
         errors.add("Data truncated for functional index");

--- a/src/sqlancer/mysql/MySQLErrors.java
+++ b/src/sqlancer/mysql/MySQLErrors.java
@@ -50,6 +50,7 @@ public final class MySQLErrors {
         errors.add("Data truncation");
         errors.add("Incorrect integer value");
         errors.add("Incorrect FLOAT value");
+        errors.add("Incorrect DOUBLE value");
         errors.add("Duplicate entry");
         errors.add("Data truncated for column");
         errors.add("Data truncated for functional index");

--- a/src/sqlancer/mysql/ast/MySQLConstant.java
+++ b/src/sqlancer/mysql/ast/MySQLConstant.java
@@ -69,6 +69,11 @@ public abstract class MySQLConstant implements MySQLExpression {
         }
 
         @Override
+        public double getDouble() {
+            return val;
+        }
+
+        @Override
         public String getTextRepresentation() {
             return String.valueOf(val);
         }
@@ -378,6 +383,10 @@ public abstract class MySQLConstant implements MySQLExpression {
     }
 
     public long getInt() {
+        throw new UnsupportedOperationException();
+    }
+
+    public double getDouble() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -253,7 +253,7 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
 
     @Override
     public String generateExplainQuery(MySQLSelect select) {
-        return "EXPLAIN " + select.asString();
+        return "EXPLAIN FORMAT=TRADITIONAL " + select.asString(); // as of MySQL 9.5.0, default EXPLAIN format changed from TRADITIONAL to TREE, hence TRADITIONAL must now be specified
     }
 
     public MySQLAggregate generateAggregate() {

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -112,7 +112,7 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
         case EXISTS:
             return getExists();
         case BETWEEN_OPERATOR:
-            if (MySQLBugs.bug99181) {
+            if (MySQLBugs.bug99182) {
                 // TODO: there are a number of bugs that are triggered by the BETWEEN operator
                 throw new IgnoreMeException();
             }

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -253,7 +253,9 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
 
     @Override
     public String generateExplainQuery(MySQLSelect select) {
-        return "EXPLAIN FORMAT=TRADITIONAL " + select.asString(); // as of MySQL 9.5.0, default EXPLAIN format changed from TRADITIONAL to TREE, hence TRADITIONAL must now be specified
+        return "EXPLAIN FORMAT=TRADITIONAL " + select.asString(); // as of MySQL 9.5.0, default EXPLAIN format changed
+                                                                  // from TRADITIONAL to TREE, hence TRADITIONAL must
+                                                                  // now be specified
     }
 
     public MySQLAggregate generateAggregate() {

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -8,10 +8,14 @@ import sqlancer.Randomly;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.mysql.MySQLErrors;
+import sqlancer.mysql.MySQLBugs;
 import sqlancer.mysql.MySQLGlobalState;
 import sqlancer.mysql.MySQLSchema.MySQLColumn;
+import sqlancer.mysql.MySQLSchema.MySQLDataType;
 import sqlancer.mysql.MySQLSchema.MySQLTable;
 import sqlancer.mysql.MySQLVisitor;
+import sqlancer.mysql.ast.MySQLExpression;
+import sqlancer.mysql.ast.MySQLConstant;
 
 public class MySQLInsertGenerator {
 
@@ -84,8 +88,27 @@ public class MySQLInsertGenerator {
                 if (c != 0) {
                     sb.append(", ");
                 }
-                sb.append(MySQLVisitor.asString(gen.generateConstant()));
-
+                MySQLExpression constExpr;
+                // Bug workaround: for integer columns, reject numeric values that round to 1. Regenerate until valid.
+                if (MySQLBugs.bug120711 && columns.get(c).getType() == MySQLDataType.INT) {
+                    while (true) {
+                        constExpr = gen.generateConstant();
+                        boolean reject = false;
+                        if (constExpr instanceof MySQLConstant.MySQLIntConstant) {
+                            long value = ((MySQLConstant.MySQLIntConstant) constExpr).getInt();
+                            reject = value == 1;
+                        } else if (constExpr instanceof MySQLConstant.MySQLDoubleConstant) {
+                            double value = ((MySQLConstant.MySQLDoubleConstant) constExpr).getDouble();
+                            reject = value >= 0.5 && value < 1.5;
+                        }
+                        if (!reject) {
+                            break;
+                        }
+                    }
+                } else {
+                    constExpr = gen.generateConstant();
+                }
+                sb.append(MySQLVisitor.asString(constExpr));
             }
             sb.append(")");
         }

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -10,6 +10,7 @@ import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.mysql.MySQLErrors;
 import sqlancer.mysql.MySQLBugs;
 import sqlancer.mysql.MySQLGlobalState;
+import sqlancer.mysql.MySQLOracleFactory;
 import sqlancer.mysql.MySQLSchema.MySQLColumn;
 import sqlancer.mysql.MySQLSchema.MySQLDataType;
 import sqlancer.mysql.MySQLSchema.MySQLTable;
@@ -116,6 +117,13 @@ public class MySQLInsertGenerator {
                             double value = ((MySQLConstant.MySQLDoubleConstant) constExpr).getDouble();
                             reject = value >= -0.5 && value < 0.5;
                         } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may be implicitly cast to 0
+                            reject = true;
+                        }
+                    }
+
+                    // Bug workaround: if using CERT oracle, reject NULL values
+                    if (!reject && MySQLBugs.bug120712 && globalState.getDbmsSpecificOptions().getTestOracleFactory().stream().anyMatch(o -> o == MySQLOracleFactory.CERT)) {
+                        if (constExpr instanceof MySQLConstant.MySQLNullConstant) {
                             reject = true;
                         }
                     }

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -105,6 +105,22 @@ public class MySQLInsertGenerator {
                             break;
                         }
                     }
+                // Bug workaround: for decimal columns, reject values that round to 0. Regenerate until valid.
+                } else if (MySQLBugs.bug120710 && columns.get(c).getType() == MySQLDataType.DECIMAL) {
+                    while (true) {
+                        constExpr = gen.generateConstant();
+                        boolean reject = false;
+                        if (constExpr instanceof MySQLConstant.MySQLIntConstant) {
+                            long value = ((MySQLConstant.MySQLIntConstant) constExpr).getInt();
+                            reject = value == 0;
+                        } else if (constExpr instanceof MySQLConstant.MySQLDoubleConstant) {
+                            double value = ((MySQLConstant.MySQLDoubleConstant) constExpr).getDouble();
+                            reject = value >= -0.5 && value < 0.5;
+                        }
+                        if (!reject) {
+                            break;
+                        }
+                    }
                 } else {
                     constExpr = gen.generateConstant();
                 }

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -24,6 +24,7 @@ public class MySQLInsertGenerator {
     private final StringBuilder sb = new StringBuilder();
     private final ExpectedErrors errors = new ExpectedErrors();
     private final MySQLGlobalState globalState;
+    private static final int MAX_REGENERATION_ATTEMPTS = 100; // for regenerating expression until valid (for bug workarounds)
 
     public MySQLInsertGenerator(MySQLGlobalState globalState, MySQLTable table) {
         this.globalState = globalState;
@@ -91,7 +92,12 @@ public class MySQLInsertGenerator {
                 }
                 MySQLExpression constExpr;
                 // loop to regenerate until expression is valid (for bug workarounds)
+                int regenerationAttempts = 0;
                 while (true) {
+                    regenerationAttempts++;
+                    if (regenerationAttempts > MAX_REGENERATION_ATTEMPTS) {
+                        throw new AssertionError("Exceeded " + MAX_REGENERATION_ATTEMPTS + " attempts while generating constant for column " + columns.get(c).getName());
+                    }
                     constExpr = gen.generateConstant();
                     boolean reject = false;
 

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -100,6 +100,8 @@ public class MySQLInsertGenerator {
                         } else if (constExpr instanceof MySQLConstant.MySQLDoubleConstant) {
                             double value = ((MySQLConstant.MySQLDoubleConstant) constExpr).getDouble();
                             reject = value >= 0.5 && value < 1.5;
+                        } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may be implicitly cast to 1
+                            reject = true;
                         }
                         if (!reject) {
                             break;
@@ -116,6 +118,8 @@ public class MySQLInsertGenerator {
                         } else if (constExpr instanceof MySQLConstant.MySQLDoubleConstant) {
                             double value = ((MySQLConstant.MySQLDoubleConstant) constExpr).getDouble();
                             reject = value >= -0.5 && value < 0.5;
+                        } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may be implicitly cast to 0
+                            reject = true;
                         }
                         if (!reject) {
                             break;

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -89,11 +89,13 @@ public class MySQLInsertGenerator {
                     sb.append(", ");
                 }
                 MySQLExpression constExpr;
-                // Bug workaround: for integer columns, reject numeric values that round to 1. Regenerate until valid.
-                if (MySQLBugs.bug120711 && columns.get(c).getType() == MySQLDataType.INT) {
-                    while (true) {
-                        constExpr = gen.generateConstant();
-                        boolean reject = false;
+                // loop to regenerate until expression is valid (for bug workarounds)
+                while (true) {
+                    constExpr = gen.generateConstant();
+                    boolean reject = false;
+
+                    // Bug workaround: for integer columns, reject values that round to 1
+                    if (!reject && MySQLBugs.bug120711 && columns.get(c).getType() == MySQLDataType.INT) {
                         if (constExpr instanceof MySQLConstant.MySQLIntConstant) {
                             long value = ((MySQLConstant.MySQLIntConstant) constExpr).getInt();
                             reject = value == 1;
@@ -103,15 +105,10 @@ public class MySQLInsertGenerator {
                         } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may be implicitly cast to 1
                             reject = true;
                         }
-                        if (!reject) {
-                            break;
-                        }
                     }
-                // Bug workaround: for decimal columns, reject values that round to 0. Regenerate until valid.
-                } else if (MySQLBugs.bug120710 && columns.get(c).getType() == MySQLDataType.DECIMAL) {
-                    while (true) {
-                        constExpr = gen.generateConstant();
-                        boolean reject = false;
+
+                    // Bug workaround: for decimal columns, reject values that round to 0
+                    if (!reject && MySQLBugs.bug120710 && columns.get(c).getType() == MySQLDataType.DECIMAL) {
                         if (constExpr instanceof MySQLConstant.MySQLIntConstant) {
                             long value = ((MySQLConstant.MySQLIntConstant) constExpr).getInt();
                             reject = value == 0;
@@ -121,12 +118,11 @@ public class MySQLInsertGenerator {
                         } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may be implicitly cast to 0
                             reject = true;
                         }
-                        if (!reject) {
-                            break;
-                        }
                     }
-                } else {
-                    constExpr = gen.generateConstant();
+
+                    if (!reject) {
+                        break;
+                    }
                 }
                 sb.append(MySQLVisitor.asString(constExpr));
             }

--- a/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLInsertGenerator.java
@@ -7,16 +7,16 @@ import java.util.stream.Collectors;
 import sqlancer.Randomly;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
-import sqlancer.mysql.MySQLErrors;
 import sqlancer.mysql.MySQLBugs;
+import sqlancer.mysql.MySQLErrors;
 import sqlancer.mysql.MySQLGlobalState;
 import sqlancer.mysql.MySQLOracleFactory;
 import sqlancer.mysql.MySQLSchema.MySQLColumn;
 import sqlancer.mysql.MySQLSchema.MySQLDataType;
 import sqlancer.mysql.MySQLSchema.MySQLTable;
 import sqlancer.mysql.MySQLVisitor;
-import sqlancer.mysql.ast.MySQLExpression;
 import sqlancer.mysql.ast.MySQLConstant;
+import sqlancer.mysql.ast.MySQLExpression;
 
 public class MySQLInsertGenerator {
 
@@ -24,7 +24,8 @@ public class MySQLInsertGenerator {
     private final StringBuilder sb = new StringBuilder();
     private final ExpectedErrors errors = new ExpectedErrors();
     private final MySQLGlobalState globalState;
-    private static final int MAX_REGENERATION_ATTEMPTS = 100; // for regenerating expression until valid (for bug workarounds)
+    private static final int MAX_REGENERATION_ATTEMPTS = 100; // for regenerating expression until valid (for bug
+                                                              // workarounds)
 
     public MySQLInsertGenerator(MySQLGlobalState globalState, MySQLTable table) {
         this.globalState = globalState;
@@ -96,7 +97,8 @@ public class MySQLInsertGenerator {
                 while (true) {
                     regenerationAttempts++;
                     if (regenerationAttempts > MAX_REGENERATION_ATTEMPTS) {
-                        throw new AssertionError("Exceeded " + MAX_REGENERATION_ATTEMPTS + " attempts while generating constant for column " + columns.get(c).getName());
+                        throw new AssertionError("Exceeded " + MAX_REGENERATION_ATTEMPTS
+                                + " attempts while generating constant for column " + columns.get(c).getName());
                     }
                     constExpr = gen.generateConstant();
                     boolean reject = false;
@@ -109,7 +111,8 @@ public class MySQLInsertGenerator {
                         } else if (constExpr instanceof MySQLConstant.MySQLDoubleConstant) {
                             double value = ((MySQLConstant.MySQLDoubleConstant) constExpr).getDouble();
                             reject = value >= 0.5 && value < 1.5;
-                        } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may be implicitly cast to 1
+                        } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may
+                                                                                           // be implicitly cast to 1
                             reject = true;
                         }
                     }
@@ -122,16 +125,18 @@ public class MySQLInsertGenerator {
                         } else if (constExpr instanceof MySQLConstant.MySQLDoubleConstant) {
                             double value = ((MySQLConstant.MySQLDoubleConstant) constExpr).getDouble();
                             reject = value >= -0.5 && value < 0.5;
-                        } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may be implicitly cast to 0
+                        } else if (constExpr instanceof MySQLConstant.MySQLTextConstant) { // reject strings, which may
+                                                                                           // be implicitly cast to 0
                             reject = true;
                         }
                     }
 
                     // Bug workaround: if using CERT oracle, reject NULL values
-                    if (!reject && MySQLBugs.bug120712 && globalState.getDbmsSpecificOptions().getTestOracleFactory().stream().anyMatch(o -> o == MySQLOracleFactory.CERT)) {
-                        if (constExpr instanceof MySQLConstant.MySQLNullConstant) {
-                            reject = true;
-                        }
+                    if (!reject && MySQLBugs.bug120712
+                            && globalState.getDbmsSpecificOptions().getTestOracleFactory().stream()
+                                    .anyMatch(o -> o == MySQLOracleFactory.CERT)
+                            && constExpr instanceof MySQLConstant.MySQLNullConstant) {
+                        reject = true;
                     }
 
                     if (!reject) {

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -360,7 +360,9 @@ public class MySQLTableGenerator {
             if (Randomly.getBoolean() && randomType != MySQLDataType.INT) {
                 sb.append(" UNSIGNED");
             }
-            if (Randomly.getBoolean() && !globalState.getDbmsSpecificOptions().getTestOracleFactory().stream().anyMatch(o -> o == MySQLOracleFactory.TLP_WHERE || o == MySQLOracleFactory.PQS || o == MySQLOracleFactory.DQP)) {
+            if (Randomly.getBoolean() && !globalState.getDbmsSpecificOptions().getTestOracleFactory().stream()
+                    .anyMatch(o -> o == MySQLOracleFactory.TLP_WHERE || o == MySQLOracleFactory.PQS
+                            || o == MySQLOracleFactory.DQP)) {
                 sb.append(" ZEROFILL");
             }
         }

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -13,6 +13,7 @@ import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.mysql.MySQLBugs;
 import sqlancer.mysql.MySQLGlobalState;
+import sqlancer.mysql.MySQLOracleFactory;
 import sqlancer.mysql.MySQLSchema;
 import sqlancer.mysql.MySQLSchema.MySQLDataType;
 import sqlancer.mysql.MySQLSchema.MySQLTable.MySQLEngine;
@@ -356,10 +357,10 @@ public class MySQLTableGenerator {
             throw new AssertionError();
         }
         if (randomType.isNumeric()) {
-            if (Randomly.getBoolean() && randomType != MySQLDataType.INT && !MySQLBugs.bug99127) {
+            if (Randomly.getBoolean() && randomType != MySQLDataType.INT) {
                 sb.append(" UNSIGNED");
             }
-            if (!globalState.usesPQS() && Randomly.getBoolean()) {
+            if (Randomly.getBoolean() && !globalState.getDbmsSpecificOptions().getTestOracleFactory().stream().anyMatch(o -> o == MySQLOracleFactory.TLP_WHERE || o == MySQLOracleFactory.PQS || o == MySQLOracleFactory.DQP)) {
                 sb.append(" ZEROFILL");
             }
         }

--- a/src/sqlancer/mysql/gen/datadef/MySQLIndexGenerator.java
+++ b/src/sqlancer/mysql/gen/datadef/MySQLIndexGenerator.java
@@ -120,6 +120,8 @@ public class MySQLIndexGenerator {
         errors.add("Data truncated for functional index");
         errors.add("used in key specification without a key length");
         errors.add("Row size too large"); // seems to happen together with MIN_ROWS in the table declaration
+        errors.add("in the PARTITION BY KEY() clause is not supported"); // prefix key parts disallowed on
+                                                                         // KEY-partitioned columns
         return new SQLQueryAdapter(string, errors, true);
     }
 

--- a/src/sqlancer/mysql/oracle/MySQLDQEOracle.java
+++ b/src/sqlancer/mysql/oracle/MySQLDQEOracle.java
@@ -71,6 +71,10 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
             for (MySQLColumn column : Randomly.nonEmptySubset(mySQLTables.getColumns())) {
                 orderColumns.add(column.getFullQualifiedName());
             }
+            // rowId tiebreaker ensures ORDER BY LIMIT is deterministic when user columns have duplicate values
+            for (MySQLTable table : mySQLTables.getTables()) {
+                orderColumns.add(table.getName() + "." + COLUMN_ROWID);
+            }
 
             if (Randomly.getBooleanWithRatherLowProbability()) {
                 generateLimit = true;
@@ -185,7 +189,13 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
     public String compareSelectAndUpdate(SQLQueryResult selectResult, SQLQueryResult updateResult) {
         if (updateResult.hasEmptyErrors()) {
             if (!selectResult.hasEmptyErrors()) {
-                return "SELECT has errors, but UPDATE does not.";
+                // Tolerate SELECT-only discrepancy errors (e.g. 1292 raised in SELECT but not UPDATE
+                // due to different short-circuit evaluation paths).
+                boolean selectHasNonDiscrepancyErrors = selectResult.getQueryErrors().stream()
+                        .anyMatch(e -> !isKnownSelectDMLDiscrepancy(e));
+                if (selectHasNonDiscrepancyErrors) {
+                    return "SELECT has errors, but UPDATE does not.";
+                }
             }
             if (!selectResult.hasSameAccessedRows(updateResult)) {
                 return "SELECT accessed different rows from UPDATE.";
@@ -201,9 +211,14 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
             }
 
             // update errors should all appear in the select errors
+            // WHERE coercion errors (1292, 1366) are skipped: MySQL may raise these in UPDATE but not SELECT
+            // due to differing short-circuit evaluation of type-incompatible literals in the WHERE clause.
             List<SQLQueryError> selectErrors = new ArrayList<>(selectResult.getQueryErrors());
             for (int i = 0; i < updateResult.getQueryErrors().size(); i++) {
                 SQLQueryError updateError = updateResult.getQueryErrors().get(i);
+                if (isKnownSelectDMLDiscrepancy(updateError)) {
+                    continue;
+                }
                 if (!isFound(selectErrors, updateError)) {
                     return "SELECT has different errors from UPDATE.";
                 }
@@ -247,7 +262,13 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
     public String compareSelectAndDelete(SQLQueryResult selectResult, SQLQueryResult deleteResult) {
         if (deleteResult.hasEmptyErrors()) {
             if (!selectResult.hasEmptyErrors()) {
-                return "SELECT has errors, but DELETE does not.";
+                // Tolerate SELECT-only discrepancy errors (e.g. 1292 raised in SELECT but not DELETE
+                // due to different short-circuit evaluation paths).
+                boolean selectHasNonDiscrepancyErrors = selectResult.getQueryErrors().stream()
+                        .anyMatch(e -> !isKnownSelectDMLDiscrepancy(e));
+                if (selectHasNonDiscrepancyErrors) {
+                    return "SELECT has errors, but DELETE does not.";
+                }
             }
             if (!selectResult.hasSameAccessedRows(deleteResult)) {
                 return "SELECT accessed different rows from DELETE.";
@@ -263,9 +284,14 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
             }
 
             // delete errors should all appear in the select errors
+            // WHERE coercion errors (1292, 1366) are skipped: MySQL may raise these in DELETE but not SELECT
+            // due to differing short-circuit evaluation of type-incompatible literals in the WHERE clause.
             List<SQLQueryError> selectErrors = new ArrayList<>(selectResult.getQueryErrors());
             for (int i = 0; i < deleteResult.getQueryErrors().size(); i++) {
                 SQLQueryError deleteError = deleteResult.getQueryErrors().get(i);
+                if (isKnownSelectDMLDiscrepancy(deleteError)) {
+                    continue;
+                }
                 if (!isFound(selectErrors, deleteError)) {
                     return "SELECT has different errors from DELETE.";
                 }
@@ -347,6 +373,33 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
         return deleteResult.getQueryErrors().stream().anyMatch(
                 error -> new MySQLErrorCodeStrategy().getDeleteSpecificErrorCodes().contains(error.getCode()));
 
+    }
+
+    /*
+     * Errors that MySQL may raise in UPDATE/DELETE but not SELECT due to different execution paths. These are
+     * acceptable discrepancies and should be skipped when checking that DML errors appear in SELECT errors. They are
+     * not treated as stop errors (hasStopErrors) so row comparison still proceeds normally.
+     *
+     * 1292: Truncated incorrect DOUBLE value — WHERE clause type coercion; MySQL may short-circuit in SELECT but
+     * evaluate fully in UPDATE/DELETE, raising this at ERROR level vs WARNING in SELECT. 1366: Incorrect
+     * integer/decimal/float value for column — same WHERE clause coercion discrepancy. 1030: Got error from storage
+     * engine — raised during functional index maintenance on UPDATE/DELETE; SELECT never writes indexes so cannot
+     * produce this error. 3170: range_optimizer_max_mem_size exceeded — MySQL applies this memory budget differently
+     * for SELECT vs DML; the fallback full-scan still evaluates the WHERE predicate correctly. 3751: Data truncated for
+     * functional index — raised when a functional index expression truncates a value during DML; structurally
+     * impossible in SELECT.
+     */
+    private static boolean isKnownSelectDMLDiscrepancy(SQLQueryError error) {
+        switch (error.getCode()) {
+        case 1030:
+        case 1292:
+        case 1366:
+        case 3170:
+        case 3751:
+            return true;
+        default:
+            return false;
+        }
     }
 
     private boolean hasStopErrors(SQLQueryResult queryResult) {

--- a/src/sqlancer/mysql/oracle/MySQLDQEOracle.java
+++ b/src/sqlancer/mysql/oracle/MySQLDQEOracle.java
@@ -467,7 +467,7 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
     public void addAuxiliaryColumns(AbstractRelationalTable<?, ?, ?> table) throws SQLException {
         String tableName = table.getName();
 
-        String addColumnRowID = String.format("ALTER TABLE %s ADD %s TEXT", tableName, COLUMN_ROWID);
+        String addColumnRowID = String.format("ALTER TABLE %s ADD %s VARCHAR(36)", tableName, COLUMN_ROWID);
         new SQLQueryAdapter(addColumnRowID).execute(state, false);
         state.getState().getLocalState().log(addColumnRowID);
 

--- a/src/sqlancer/mysql/oracle/MySQLDQEOracle.java
+++ b/src/sqlancer/mysql/oracle/MySQLDQEOracle.java
@@ -211,8 +211,7 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
             }
 
             // update errors should all appear in the select errors
-            // WHERE coercion errors (1292, 1366) are skipped: MySQL may raise these in UPDATE but not SELECT
-            // due to differing short-circuit evaluation of type-incompatible literals in the WHERE clause.
+            // known SELECT/DML discrepancy errors are skipped: see KnownSelectDMLDiscrepancy for the full list.
             List<SQLQueryError> selectErrors = new ArrayList<>(selectResult.getQueryErrors());
             for (int i = 0; i < updateResult.getQueryErrors().size(); i++) {
                 SQLQueryError updateError = updateResult.getQueryErrors().get(i);
@@ -284,8 +283,7 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
             }
 
             // delete errors should all appear in the select errors
-            // WHERE coercion errors (1292, 1366) are skipped: MySQL may raise these in DELETE but not SELECT
-            // due to differing short-circuit evaluation of type-incompatible literals in the WHERE clause.
+            // known SELECT/DML discrepancy errors are skipped: see KnownSelectDMLDiscrepancy for the full list.
             List<SQLQueryError> selectErrors = new ArrayList<>(selectResult.getQueryErrors());
             for (int i = 0; i < deleteResult.getQueryErrors().size(); i++) {
                 SQLQueryError deleteError = deleteResult.getQueryErrors().get(i);
@@ -375,31 +373,36 @@ public class MySQLDQEOracle extends DQEBase<MySQLGlobalState> implements TestOra
 
     }
 
-    /*
-     * Errors that MySQL may raise in UPDATE/DELETE but not SELECT due to different execution paths. These are
-     * acceptable discrepancies and should be skipped when checking that DML errors appear in SELECT errors. They are
-     * not treated as stop errors (hasStopErrors) so row comparison still proceeds normally.
-     *
-     * 1292: Truncated incorrect DOUBLE value — WHERE clause type coercion; MySQL may short-circuit in SELECT but
-     * evaluate fully in UPDATE/DELETE, raising this at ERROR level vs WARNING in SELECT. 1366: Incorrect
-     * integer/decimal/float value for column — same WHERE clause coercion discrepancy. 1030: Got error from storage
-     * engine — raised during functional index maintenance on UPDATE/DELETE; SELECT never writes indexes so cannot
-     * produce this error. 3170: range_optimizer_max_mem_size exceeded — MySQL applies this memory budget differently
-     * for SELECT vs DML; the fallback full-scan still evaluates the WHERE predicate correctly. 3751: Data truncated for
-     * functional index — raised when a functional index expression truncates a value during DML; structurally
-     * impossible in SELECT.
-     */
-    private static boolean isKnownSelectDMLDiscrepancy(SQLQueryError error) {
-        switch (error.getCode()) {
-        case 1030:
-        case 1292:
-        case 1366:
-        case 3170:
-        case 3751:
-            return true;
-        default:
-            return false;
+    // Errors MySQL may raise in UPDATE/DELETE but not SELECT due to different execution paths. Acceptable
+    // discrepancies that should be skipped; not treated as stop errors so row comparison proceeds normally.
+    private enum KnownSelectDMLDiscrepancy {
+        // WHERE clause type coercion: MySQL may short-circuit in SELECT but evaluate fully in UPDATE/DELETE,
+        // raising this at ERROR level vs WARNING in SELECT.
+        TRUNCATED_DOUBLE_VALUE(1292),
+        // Same WHERE clause coercion discrepancy as TRUNCATED_DOUBLE_VALUE.
+        INCORRECT_COLUMN_VALUE(1366),
+        // Raised during functional index maintenance on UPDATE/DELETE; SELECT never writes indexes.
+        STORAGE_ENGINE_ERROR(1030),
+        // MySQL applies this memory budget differently for SELECT vs DML; the fallback full-scan still
+        // evaluates the WHERE predicate correctly.
+        RANGE_OPTIMIZER_MEM_EXCEEDED(3170),
+        // Raised when a functional index expression truncates a value during DML; structurally impossible in SELECT.
+        FUNCTIONAL_INDEX_DATA_TRUNCATED(3751);
+
+        private final int code;
+
+        KnownSelectDMLDiscrepancy(int code) {
+            this.code = code;
         }
+    }
+
+    private static boolean isKnownSelectDMLDiscrepancy(SQLQueryError error) {
+        for (KnownSelectDMLDiscrepancy discrepancy : KnownSelectDMLDiscrepancy.values()) {
+            if (discrepancy.code == error.getCode()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean hasStopErrors(SQLQueryResult queryResult) {


### PR DESCRIPTION
### Summary

This PR updates the supported MySQL version from 8.4 to 9.7.0, and the associated JDBC driver from mysql-connector-java 8.0.30 to mysql-connector-j 9.7.0.

- Existing bugs in MySQLBugs have been reviewed and removed if they have been fixed since being originally reported.
- Testing has been carried out using every oracle supported for MySQL.
- Identified bugs have been simplified and flagged to the developers. The bug reports are linked to in MySQLBugs.java.

Below is an overview of the newly encountered errors and their fixes.

### Test case 1

**Reduced input:**

```sql
CREATE TABLE t0(c0 FLOAT ZEROFILL , c1 FLOAT ZEROFILL  UNIQUE KEY);
REPLACE INTO t0(c0, c1) VALUES(454327608, ""), ("0b#vNkoT", -64193336), ("0.0", -1067204564);
```

**Error:**

`Incorrect FLOAT value: '' for column 'c1' at row 1`

**Conclusion:**

This is not a DBMS bug; rather, it is due to invalid insertion by SQLancer. A solution would be to modify the SQLancer generation phase to avoid placing strings in FLOAT fields. However (in keeping with SQLancer’s approach for similar cases), the implemented solution is to add the error as an ExpectedError to MySQLErrors.

Likewise for `Incorrect DOUBLE value`.

### Test case 2

**Reduced input:**

```sql
CREATE TABLE t0(c0 DOUBLE ZEROFILL);
INSERT INTO t0(c0) VALUES(12345678);
-- Query 1, returns 0000000000000012345678:
SELECT t0.c0 AS ref0 FROM t0;
-- Query 2, returns 12345678:
SELECT t0.c0 AS ref0 FROM t0 UNION ALL SELECT t0.c0 AS ref0 FROM t0 WHERE (!t0.c0) UNION ALL SELECT t0.c0 AS ref0 FROM t0 WHERE (t0.c0 IS UNKNOWN);
```

**Error:**

TLPWhereOracle: `The content of the result sets mismatch!`

**Conclusion:**

It appears that the `ZEROFILL` property is lost when doing a union of multiple tables, causing the first query to be zero-filled and not the second. 

However, this is expected behaviour as per MySQL documentation, which states, “The ZEROFILL attribute is ignored for columns involved in expressions or UNION queries.” (https://dev.mysql.com/doc/refman/9.7/en/numeric-type-attributes.html). Therefore, this is not a DBMS bug.

The implemented solution is to prevent use of the ZEROFILL attribute when testing with oracles for which inconsistent ZEROFILL may lead to flagging of errors (PQS, TLP, and DQP).

Note, the `ZEROFILL` attribute in MySQL is deprecated for numeric data types, so may be removed in a future version (https://dev.mysql.com/doc/refman/9.7/en/numeric-type-syntax.html). However, while it remains available, it will continue to be implemented in SQLancer.

### Test case 3 (bug**120710**)

**Reduced input (exhibit A):**

```sql
CREATE TABLE t0(c0 DECIMAL UNIQUE);
INSERT INTO t0 VALUES(0);
INSERT INTO t0 VALUES(NULL);
-- Query 1, returns 2 rows (NULL and 0)
SELECT t0.c0 AS ref0 FROM t0;
-- Query 2, returns 3 rows (0, NULL and 0)
SELECT ALL t0.c0 AS ref0 FROM t0 WHERE (t0.c0) || (IFNULL(NULL, t0.c0)) UNION ALL SELECT ALL t0.c0 AS ref0 FROM t0 WHERE (! ((t0.c0) || (IFNULL(NULL, t0.c0)))) UNION ALL SELECT ALL t0.c0 AS ref0 FROM t0 WHERE ((t0.c0) || (IFNULL(NULL, t0.c0))) IS UNKNOWN;
```

**Error:**

TLPWhereOracle: `The size of the result sets mismatch!`

The bug appears when inserting a number that rounds to 0 followed by a NULL value (or the other way round) into a `DECIMAL`-type column. The identified bug-inducing test cases all involve the `IFNULL` function.

This bug is not present in MySQL 8.4.

**Conclusion:**

This is a DBMS bug. It has been simplified and reported to the developers (https://bugs.mysql.com/bug.php?id=120710).

Until the bug is fixed, the workaround implemented in SQLancer is to avoid the insertion of numbers that round to 0 into `DECIMAL`-type columns in MySQL.

### Test case 4 (bug120711)

**Reduced input:**

```sql
CREATE TABLE t0(c0 INT);
CREATE INDEX b ON t0(c0);
INSERT INTO t0 VALUES(1);
-- Query 1, returns 1 rows (1)
SELECT ALL t0.c0 AS ref0 FROM t0;
-- Query 2, returns 2 rows (1 and 1)
SELECT ALL t0.c0 AS ref0 FROM t0 WHERE (IFNULL(NULL, 0.9)) IN (t0.c0) UNION ALL SELECT ALL t0.c0 AS ref0 FROM t0 WHERE (NOT ((IFNULL(NULL, 0.9)) IN (t0.c0))) UNION ALL SELECT t0.c0 AS ref0 FROM t0 WHERE ((IFNULL(NULL, 0.9)) IN (t0.c0)) IS NULL;
```

**Error:**

TLPWhereOracle: `The size of the result sets mismatch!`

The bug appears when creating an index on a column, then inserting a value in the range $[0.5,1.5)$ (i.e., which rounds to 1). The bug also appears the other way round (i.e., when first inserting and then creating an index). The identified bug-inducing test cases all involve the `IFNULL` function.

The bug is present for any of the integer data types (`INTEGER`, `INT`, `SMALLINT`, `TINYINT`, `MEDIUMINT`, `BIGINT`).

The bug is also present in MySQL 8.4.

**Conclusion:**

This is a DBMS bug. It has been simplified and reported to the developers (https://bugs.mysql.com/bug.php?id=120711).

Until the bug is fixed, the workaround implemented in SQLancer is to avoid the insertion of values which round to 1 into integer-type columns. This approach restricts the search space less than preventing index creation.

### Test case 5

**Error:**

All runs using CERTOracle throw `SQLException: Column Index out of range, 10 > 1`.

**Conclusion:**

This is not a DBMS bug; rather, it is due to an assumption of SQLancer no longer being valid. As of MySQL 9.5.0, the default explain format changed from `TRADITIONAL` to `TREE` (https://dev.mysql.com/doc/relnotes/mysql/9.7/en/news-9-5-0.html). This breaks the parser of CERTOracle’s EXPLAIN queries.

The implemented solution is to modify `MySQLExpressionGenerator`'s implementation of the `generateExplainQuery` method to specify `FORMAT=TRADITIONAL` in the generated statement.

### Test case 6 (bug120712)

**Input:**

```sql
CREATE TABLE t0(c0 INT);
INSERT INTO t0 VALUES(NULL);
CREATE INDEX a ON t0(c0);
INSERT INTO t0 VALUES(NULL);
ANALYZE TABLE t0 UPDATE HISTOGRAM ON c0;
-- Query 1, estimates 1 row
EXPLAIN FORMAT=TRADITIONAL SELECT ALL t0.c0 AS ref0 FROM t0;
-- Query 2, estimates 2 rows
EXPLAIN FORMAT=TRADITIONAL SELECT ALL t0.c0 AS ref0 FROM t0 WHERE (t0.c0) IS UNKNOWN;
```

**Error:**

CERTOracle: `Inconsistent result for query`. The more restrictive query (query 2) is estimated to have a higher row count than the more relaxed query (query 1).

The bug occurs when an index is created between two NULL inserts. The issue is not specific to INT columns (it is still present when the column is changed to FLOAT).

**Conclusion:**

This is a DBMS bug. It has been simplified and reported to the developers (https://bugs.mysql.com/bug.php?id=120712).

This must be worked around in SQLancer until the bug is fixed. We would ideally either prevent creating indices on columns which already have a NULL value, or prevent inserting a NULL value into columns which already have an index.

However, both of these options would involve a large refactor. Implementing the former would require tracking whether each column has had a NULL inserted or not; the latter would require tracking whether each column is currently an index or not. Alternatively, one could query for nulls each time a CREATE INDEX statement may be generated, or read schema information each time a NULL may be generated (respectively). However, this would be too computationally expensive.

The simpler options are to either prevent index creation entirely or prevent NULL inserts entirely. Unfortunately, either of these would restrict a lot of the search space (as many bugs are discovered through inserting NULLs or creating indices). As this bug is related specifically to the CERT oracle and the EXPLAIN statement, index creation is particularly relevant, as it is more closely tied to the optimiser’s row estimation logic. Therefore, it was chosen to prevent NULL inserts. The workaround is only implemented when the CERT oracle is used (therefore, the search space remains relaxed for other oracles).

However, preventing NULL inserts poses difficulties when using C-Reduce to reduce other bug-inducing CERT test cases. C-Reduce may, for example, reduce `INSERT INTO t0 VALUES(123);` to `INSERT INTO t0 VALUES();`, which is effectively inserting a NULL value. Therefore, though the bug is avoided by SQLancer, it may be encountered during C-Reduce’s reduction of a different bug, causing the process to become side-tracked from the actual bug of interest. Those using C-Reduce should bear this in mind when attempting to reduce MySQL bugs flagged by the CERT oracle.