### PR TITLE
Fix YugabyteDB CI by adding ysql_yb_enable_listen_notify flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -648,6 +648,7 @@ jobs:
           docker pull yugabytedb/yugabyte:latest
           docker run -d --name yugabyte -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 yugabytedb/yugabyte:latest bin/yugabyted start --daemon=false --tserver_flags="ysql_yb_enable_listen_notify=true" --master_flags="ysql_yb_enable_listen_notify=true"
           until pg_isready -h localhost -p 5433; do sleep 1; done
+          until nc -z localhost 9042; do sleep 1; done
       - name: Run Tests
         run: |
           YUGABYTE_AVAILABLE=true mvn -Djacoco.skip=true -Dtest=TestYSQLNoREC test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -646,7 +646,7 @@ jobs:
       - name: Set up Yugabyte
         run: |
           docker pull yugabytedb/yugabyte:latest
-          docker run -d --name yugabyte -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 yugabytedb/yugabyte:latest bin/yugabyted start --daemon=false
+          docker run -d --name yugabyte -p7000:7000 -p9000:9000 -p5433:5433 -p9042:9042 yugabytedb/yugabyte:latest bin/yugabyted start --daemon=false --tserver_flags="ysql_yb_enable_listen_notify=true" --master_flags="ysql_yb_enable_listen_notify=true"
           until pg_isready -h localhost -p 5433; do sleep 1; done
       - name: Run Tests
         run: |


### PR DESCRIPTION
## Summary

The YugabyteDB CI job was failing because SQLancer generates `LISTEN`, `NOTIFY`, and `UNLISTEN` statements, but YugabyteDB has this feature disabled by default. This caused an `AssertionError` each time one of these statements was executed, terminating the test run.

The fix enables the `ysql_yb_enable_listen_notify` runtime flag on both the tserver and master when starting YugabyteDB in CI, allowing these statements to execute as intended.

## Changes

- `.github/workflows/main.yml`: Pass `--tserver_flags` and `--master_flags` to `yugabyted start` to enable `ysql_yb_enable_listen_notify`