### PR TITLE
Fix bugs in reproducer and test-case reduction

### DIFF
--- a/src/sqlancer/ASTBasedReducer.java
+++ b/src/sqlancer/ASTBasedReducer.java
@@ -103,8 +103,7 @@ public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpeci
                     });
 
                     if (!initFlag) {
-                        newGlobalState.getLogger()
-                                .logReducer("warning: failed parsing the statement at transformer : " + t);
+                        System.out.println("Error when parsing the statement at transformer :" + t);
                         continue;
                     }
                     t.apply();
@@ -114,7 +113,8 @@ public class ASTBasedReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpeci
         } while (observeChange);
 
         newGlobalState.getState().setStatements(new ArrayList<>(reducedStatements));
-        newGlobalState.getLogger().logReduced(newGlobalState.getState());
+        newGlobalState.getLogger().logReduced(newGlobalState.getState(),
+                "AST-based reduction finished; the following statements remain");
     }
 
     public boolean bugStillTriggers() throws Exception {

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -80,6 +80,9 @@ public final class Main {
         private FileWriter queryPlanFileWriter;
         private FileWriter reduceFileWriter;
         private Path reproduceFilePath;
+        private List<Query<?>> reduceSetupStatements;
+        private String reduceBugInformation;
+        private int nrReductionAttempts;
 
         private static final List<String> INITIALIZED_PROVIDER_NAMES = new ArrayList<>();
         private final boolean logEachSelect;
@@ -262,33 +265,32 @@ public final class Main {
             }
         }
 
-        public void logReducer(String reducerLog) {
-            FileWriter reduceFileWriter = getReduceFileWriter();
-
-            StringBuilder sb = new StringBuilder();
-            sb.append("[reducer log] ");
-            sb.append(reducerLog);
-            try {
-                reduceFileWriter.write(sb.toString());
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            } finally {
-                try {
-                    reduceFileWriter.flush();
-                } catch (IOException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
-            }
+        public void setReductionContext(List<Query<?>> setupStatements, String bugInformation) {
+            this.reduceSetupStatements = setupStatements;
+            this.reduceBugInformation = bugInformation;
         }
 
         public void logReduced(StateToReproduce state) {
+            nrReductionAttempts++;
+            logReduced(state, "Reduction attempt " + nrReductionAttempts
+                    + ": the bug was still triggered with the following statements");
+        }
+
+        public void logReduced(StateToReproduce state, String description) {
             FileWriter reduceFileWriter = getReduceFileWriter();
 
             StringBuilder sb = new StringBuilder();
-            for (Query<?> s : state.getStatements()) {
-                sb.append(databaseProvider.getLoggableFactory().createLoggable(s.getLogString()).getLogString());
+            sb.append("-- ").append(description).append(System.lineSeparator());
+            if (reduceSetupStatements != null && !reduceSetupStatements.isEmpty()) {
+                appendStatements(sb, reduceSetupStatements);
+                // e.g. DROP DATABASE IF EXISTS db; CREATE DATABASE db; USE db;
+                // these statements are executed at the start of every test case and are never reduced
             }
+            appendStatements(sb, state.getStatements());
+            if (reduceBugInformation != null) {
+                sb.append(reduceBugInformation);
+            }
+            sb.append(System.lineSeparator());
             try {
                 reduceFileWriter.write(sb.toString());
 
@@ -303,6 +305,12 @@ public final class Main {
                 }
             }
 
+        }
+
+        private void appendStatements(StringBuilder sb, List<Query<?>> statements) {
+            for (Query<?> s : statements) {
+                sb.append(databaseProvider.getLoggableFactory().createLoggable(s.getLogString()).getLogString());
+            }
         }
 
         public void logException(Throwable reduce, StateToReproduce state) {
@@ -460,6 +468,9 @@ public final class Main {
                 if (options.logEachSelect()) {
                     logger.writeCurrent(state.getState());
                 }
+                // statements logged so far stem from the database setup (e.g., DROP DATABASE IF
+                // EXISTS, CREATE DATABASE, USE), performed by createDatabase
+                int nrSetupStatements = stateToRepro.getStatements().size();
                 Reproducer<G> reproducer = null;
                 if (options.enableQPG()) {
                     provider.generateAndTestDatabaseWithQueryPlanGuidance(state);
@@ -484,6 +495,17 @@ public final class Main {
                         logger.getReduceFileWriter().write("current oracle does not support experimental reducer.");
                         throw new IgnoreMeException();
                     }
+
+                    // reduce only the generation statements: the database setup (logged by
+                    // createDatabase) is re-executed by the reducers for every candidate, and the
+                    // oracle queries (logged by the oracle's local state) by the reproducer
+                    List<Query<?>> allStatements = new ArrayList<>(stateToRepro.getStatements());
+                    List<Query<?>> setupStatements = new ArrayList<>(allStatements.subList(0, nrSetupStatements));
+                    List<Query<?>> oracleQueryStatements = stateToRepro.getLocalState() == null ? new ArrayList<>()
+                            : new ArrayList<>(stateToRepro.getLocalState().getStatements());
+                    stateToRepro.setStatements(new ArrayList<>(allStatements.subList(nrSetupStatements,
+                            allStatements.size() - oracleQueryStatements.size())));
+
                     G newGlobalState = createGlobalState();
                     newGlobalState.setState(stateToRepro);
                     newGlobalState.setRandomly(r);
@@ -493,6 +515,7 @@ public final class Main {
                     QueryManager<C> newManager = new QueryManager<>(newGlobalState);
                     newGlobalState.setStateLogger(new StateLogger(databaseName, provider, options));
                     newGlobalState.setManager(newManager);
+                    newGlobalState.getLogger().setReductionContext(setupStatements, reproducer.getBugInformation());
 
                     Reducer<G> reducer = new StatementReducer<>(provider);
                     reducer.reduce(state, reproducer, newGlobalState);
@@ -502,11 +525,18 @@ public final class Main {
                         astBasedReducer.reduce(state, reproducer, newGlobalState);
                     }
 
+                    // reassemble the statements so that the main log looks like one produced
+                    // without the reducer, with the generation statements replaced by the reduced
+                    // ones and the oracle queries at the end
+                    List<Query<?>> finalStatements = new ArrayList<>(setupStatements);
+                    finalStatements.addAll(stateToRepro.getStatements());
+                    finalStatements.addAll(oracleQueryStatements);
+                    stateToRepro.setStatements(finalStatements);
                     String bugInformation = reproducer.getBugInformation();
                     if (bugInformation != null) {
-                        // log through newGlobalState's logger: it already holds the reduce file
-                        // writer, and opening it through another StateLogger truncates the file
-                        newGlobalState.getLogger().logReducer(bugInformation);
+                        for (String line : bugInformation.split(System.lineSeparator())) {
+                            stateToRepro.logStatement(line);
+                        }
                     }
 
                     StateLogger reduceLogger = newGlobalState.getLogger();

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -502,10 +502,18 @@ public final class Main {
                         astBasedReducer.reduce(state, reproducer, newGlobalState);
                     }
 
-                    if (logger.reduceFileWriter != null) {
+                    String bugInformation = reproducer.getBugInformation();
+                    if (bugInformation != null) {
+                        // log through newGlobalState's logger: it already holds the reduce file
+                        // writer, and opening it through another StateLogger truncates the file
+                        newGlobalState.getLogger().logReducer(bugInformation);
+                    }
+
+                    StateLogger reduceLogger = newGlobalState.getLogger();
+                    if (reduceLogger.reduceFileWriter != null) {
                         try {
-                            logger.reduceFileWriter.close();
-                            logger.reduceFileWriter = null;
+                            reduceLogger.reduceFileWriter.close();
+                            reduceLogger.reduceFileWriter = null;
                         } catch (IOException e) {
                             throw new AssertionError(e);
                         }

--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -502,11 +502,13 @@ public final class Main {
                         astBasedReducer.reduce(state, reproducer, newGlobalState);
                     }
 
-                    try {
-                        logger.getReduceFileWriter().close();
-                        logger.reduceFileWriter = null;
-                    } catch (IOException e) {
-                        throw new AssertionError(e);
+                    if (logger.reduceFileWriter != null) {
+                        try {
+                            logger.reduceFileWriter.close();
+                            logger.reduceFileWriter = null;
+                        } catch (IOException e) {
+                            throw new AssertionError(e);
+                        }
                     }
 
                     throw new AssertionError("Found a potential bug, please check reducer log for detail.");

--- a/src/sqlancer/MainOptions.java
+++ b/src/sqlancer/MainOptions.java
@@ -126,10 +126,10 @@ public class MainOptions {
     @Parameter(names = "--serialize-reproduce-state", description = "Serialize the state to reproduce")
     private boolean serializeReproduceState = false; // NOPMD
 
-    @Parameter(names = "--use-reducer", description = "EXPERIMENTAL Attempt to reduce queries using a simple reducer")
+    @Parameter(names = "--use-reducer", description = "EXPERIMENTAL Attempt to reduce queries using a simple reducer. Implemented for TLP WHERE and NoREC only")
     private boolean useReducer = false; // NOPMD
 
-    @Parameter(names = "--reduce-ast", description = "EXPERIMENTAL perform AST reduction after statement reduction")
+    @Parameter(names = "--reduce-ast", description = "EXPERIMENTAL Perform AST reduction after statement reduction")
     private boolean reduceAST = false; // NOPMD
 
     @Parameter(names = "--statement-reducer-max-steps", description = "EXPERIMENTAL Maximum steps the statement reducer will do")

--- a/src/sqlancer/Reproducer.java
+++ b/src/sqlancer/Reproducer.java
@@ -2,4 +2,14 @@ package sqlancer;
 
 public interface Reproducer<G extends GlobalState<?, ?, ?>> {
     boolean bugStillTriggers(G globalState);
+
+    /**
+     * Describes how to trigger the bug on the database set up by the reduced statements (e.g., the oracle queries to
+     * run and the failure to expect), so that the reduced test case is complete without the reproducer object.
+     *
+     * @return a human-readable description, or null if the reproducer does not provide one
+     */
+    default String getBugInformation() {
+        return null;
+    }
 }

--- a/src/sqlancer/StateToReproduce.java
+++ b/src/sqlancer/StateToReproduce.java
@@ -128,6 +128,10 @@ public class StateToReproduce implements Serializable {
             statements.add(databaseProvider.getLoggableFactory().getQueryForStateToReproduce(s));
         }
 
+        public List<Query<?>> getStatements() {
+            return Collections.unmodifiableList(statements);
+        }
+
         @Override
         public void close() {
             if (!success) {

--- a/src/sqlancer/StatementReducer.java
+++ b/src/sqlancer/StatementReducer.java
@@ -77,7 +77,8 @@ public class StatementReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpec
         // System.out.println("Reduced query:");
         // printQueries(knownToReproduceBugStatements);
         newGlobalState.getState().setStatements(new ArrayList<>(knownToReproduceBugStatements));
-        newGlobalState.getLogger().logReduced(newGlobalState.getState());
+        newGlobalState.getLogger().logReduced(newGlobalState.getState(),
+                "Statement reduction finished; the following statements remain");
 
     }
 

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -1,7 +1,6 @@
 package sqlancer.common.oracle;
 
 import java.sql.SQLException;
-import java.util.Objects;
 import java.util.function.Function;
 
 import sqlancer.IgnoreMeException;
@@ -42,7 +41,20 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
 
         @Override
         public boolean bugStillTriggers(G globalState) {
-            return !Objects.equals(optimizedQuery.apply(globalState), unoptimizedQuery.apply(globalState));
+            int optimizedCount;
+            int unoptimizedCount;
+            try {
+                optimizedCount = optimizedQuery.apply(globalState);
+                unoptimizedCount = unoptimizedQuery.apply(globalState);
+            } catch (RuntimeException | AssertionError e) {
+                // the queries could not be executed on the reduced database (e.g., a statement they
+                // depend on was removed), which is not the count mismatch that is being reduced
+                return false;
+            }
+            if (optimizedCount == -1 || unoptimizedCount == -1) {
+                return false;
+            }
+            return optimizedCount != unoptimizedCount;
         }
     }
 

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -33,10 +33,19 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
     private static class NoRECReproducer<G extends SQLGlobalState<?, ?>> implements Reproducer<G> {
         private final Function<G, Integer> optimizedQuery;
         private final Function<G, Integer> unoptimizedQuery;
+        private final String optimizedQueryString;
+        private final String unoptimizedQueryString;
+        // null if the original bug is a count mismatch; otherwise, the message of the unexpected
+        // DBMS error that the original queries triggered
+        private final String expectedErrorMessage;
 
-        NoRECReproducer(Function<G, Integer> optimizedQuery, Function<G, Integer> unoptimizedQuery) {
+        NoRECReproducer(Function<G, Integer> optimizedQuery, Function<G, Integer> unoptimizedQuery,
+                String optimizedQueryString, String unoptimizedQueryString, String expectedErrorMessage) {
             this.optimizedQuery = optimizedQuery;
             this.unoptimizedQuery = unoptimizedQuery;
+            this.optimizedQueryString = optimizedQueryString;
+            this.unoptimizedQueryString = unoptimizedQueryString;
+            this.expectedErrorMessage = expectedErrorMessage;
         }
 
         @Override
@@ -46,15 +55,38 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
             try {
                 optimizedCount = optimizedQuery.apply(globalState);
                 unoptimizedCount = unoptimizedQuery.apply(globalState);
-            } catch (RuntimeException | AssertionError e) {
-                // the queries could not be executed on the reduced database (e.g., a statement they
-                // depend on was removed), which is not the count mismatch that is being reduced
+            } catch (AssertionError unexpectedError) {
+                // a DBMS error reproduces the bug only if the original failure was the same error;
+                // other errors are artifacts of the reduction (e.g., a removed CREATE TABLE)
+                return expectedErrorMessage != null
+                        && expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+            } catch (RuntimeException e) {
+                return false;
+            }
+            if (expectedErrorMessage != null) {
+                // the original bug was a DBMS error, which no longer occurs
                 return false;
             }
             if (optimizedCount == -1 || unoptimizedCount == -1) {
                 return false;
             }
             return optimizedCount != unoptimizedCount;
+        }
+
+        @Override
+        public String getBugInformation() {
+            StringBuilder sb = new StringBuilder();
+            if (expectedErrorMessage == null) {
+                sb.append("-- On the database set up by the statements above, the row counts of the following"
+                        + " queries mismatch:").append(System.lineSeparator());
+            } else {
+                sb.append("-- On the database set up by the statements above, the following queries trigger an"
+                        + " unexpected error with message: ").append(expectedErrorMessage)
+                        .append(System.lineSeparator());
+            }
+            sb.append("-- optimized: ").append(optimizedQueryString).append(';').append(System.lineSeparator());
+            sb.append("-- unoptimized: ").append(unoptimizedQueryString).append(';').append(System.lineSeparator());
+            return sb.toString();
         }
     }
 
@@ -94,21 +126,28 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
             state.getLogger().writeCurrent(unoptimizedQueryString);
         }
 
-        int optimizedCount = shouldUseAggregate ? extractCounts(optimizedQueryString, errors, state)
-                : countRows(optimizedQueryString, errors, state);
-        int unoptimizedCount = extractCounts(unoptimizedQueryString, errors, state);
+        Function<G, Integer> optimizedQuery = state -> shouldUseAggregate
+                ? extractCounts(optimizedQueryString, errors, state) : countRows(optimizedQueryString, errors, state);
+        Function<G, Integer> unoptimizedQuery = state -> extractCounts(unoptimizedQueryString, errors, state);
+
+        int optimizedCount;
+        int unoptimizedCount;
+        try {
+            optimizedCount = optimizedQuery.apply(state);
+            unoptimizedCount = unoptimizedQuery.apply(state);
+        } catch (AssertionError unexpectedError) {
+            reproducer = new NoRECReproducer<>(optimizedQuery, unoptimizedQuery, optimizedQueryString,
+                    unoptimizedQueryString, TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+            throw unexpectedError;
+        }
 
         if (optimizedCount == -1 || unoptimizedCount == -1) {
             throw new IgnoreMeException();
         }
 
         if (unoptimizedCount != optimizedCount) {
-            Function<G, Integer> optimizedQuery = state -> shouldUseAggregate
-                    ? extractCounts(optimizedQueryString, errors, state)
-                    : countRows(optimizedQueryString, errors, state);
-
-            Function<G, Integer> unoptimizedQuery = state -> extractCounts(unoptimizedQueryString, errors, state);
-            reproducer = new NoRECReproducer<>(optimizedQuery, unoptimizedQuery);
+            reproducer = new NoRECReproducer<>(optimizedQuery, unoptimizedQuery, optimizedQueryString,
+                    unoptimizedQueryString, null);
 
             String queryFormatString = "-- %s;\n-- count: %d";
             String firstQueryStringWithCount = String.format(queryFormatString, optimizedQueryString, optimizedCount);

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -104,8 +104,7 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
                     sb.append("-- ").append(thirdQueryString).append(';').append(System.lineSeparator());
                 } else {
                     sb.append("-- ").append(firstQueryString).append(" UNION ALL ").append(secondQueryString)
-                            .append(" UNION ALL ").append(thirdQueryString).append(';')
-                            .append(System.lineSeparator());
+                            .append(" UNION ALL ").append(thirdQueryString).append(';').append(System.lineSeparator());
                 }
             }
             return sb.toString();

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -106,15 +106,15 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         select.setWhereClause(predicates.isNullPredicate);
         String thirdQueryString = select.asString();
 
+        reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString, originalQueryString,
+                firstResultSet, orderBy);
+
         List<String> combinedString = new ArrayList<>();
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                 thirdQueryString, combinedString, !orderBy, state, errors);
 
         ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString, combinedString,
                 state);
-
-        reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString, originalQueryString,
-                firstResultSet, orderBy);
     }
 
     @Override

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -34,30 +34,37 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         final String secondQueryString;
         final String thirdQueryString;
         final String originalQueryString;
-        final List<String> resultSet;
         final boolean orderBy;
 
         TLPWhereReproducer(String firstQueryString, String secondQueryString, String thirdQueryString,
-                String originalQueryString, List<String> resultSet, boolean orderBy) {
+                String originalQueryString, boolean orderBy) {
             this.firstQueryString = firstQueryString;
             this.secondQueryString = secondQueryString;
             this.thirdQueryString = thirdQueryString;
             this.originalQueryString = originalQueryString;
-            this.resultSet = resultSet;
             this.orderBy = orderBy;
         }
 
         @Override
         public boolean bugStillTriggers(G globalState) {
+            List<String> firstResultSet;
+            List<String> combinedString = new ArrayList<>();
+            List<String> secondResultSet;
             try {
-                List<String> combinedString1 = new ArrayList<>();
-                List<String> secondResultSet1 = ComparatorHelper.getCombinedResultSet(firstQueryString,
-                        secondQueryString, thirdQueryString, combinedString1, !orderBy, globalState, errors);
-                ComparatorHelper.assumeResultSetsAreEqual(resultSet, secondResultSet1, originalQueryString,
-                        combinedString1, globalState);
-            } catch (AssertionError triggeredError) {
+                firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
+                        globalState);
+                secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                        thirdQueryString, combinedString, !orderBy, globalState, errors);
+            } catch (SQLException | RuntimeException | AssertionError e) {
+                // the queries could not be executed on the reduced database (e.g., a statement they
+                // depend on was removed), which is not the result set mismatch that is being reduced
+                return false;
+            }
+            try {
+                ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString,
+                        combinedString, globalState);
+            } catch (AssertionError resultSetMismatch) {
                 return true;
-            } catch (SQLException ignored) {
             }
             return false;
         }
@@ -107,7 +114,7 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         String thirdQueryString = select.asString();
 
         reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString, originalQueryString,
-                firstResultSet, orderBy);
+                orderBy);
 
         List<String> combinedString = new ArrayList<>();
         List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -35,14 +35,18 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         final String thirdQueryString;
         final String originalQueryString;
         final boolean orderBy;
+        // null if the original bug is a result set mismatch; otherwise, the message of the
+        // unexpected DBMS error that the original queries triggered
+        final String expectedErrorMessage;
 
         TLPWhereReproducer(String firstQueryString, String secondQueryString, String thirdQueryString,
-                String originalQueryString, boolean orderBy) {
+                String originalQueryString, boolean orderBy, String expectedErrorMessage) {
             this.firstQueryString = firstQueryString;
             this.secondQueryString = secondQueryString;
             this.thirdQueryString = thirdQueryString;
             this.originalQueryString = originalQueryString;
             this.orderBy = orderBy;
+            this.expectedErrorMessage = expectedErrorMessage;
         }
 
         @Override
@@ -53,11 +57,23 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
             try {
                 firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
                         globalState);
+                if (firstQueryString == null) {
+                    // the original bug was a DBMS error on the original query alone, which no
+                    // longer occurs
+                    return false;
+                }
                 secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                         thirdQueryString, combinedString, !orderBy, globalState, errors);
-            } catch (SQLException | RuntimeException | AssertionError e) {
-                // the queries could not be executed on the reduced database (e.g., a statement they
-                // depend on was removed), which is not the result set mismatch that is being reduced
+            } catch (AssertionError unexpectedError) {
+                // a DBMS error reproduces the bug only if the original failure was the same error;
+                // other errors are artifacts of the reduction (e.g., a removed CREATE TABLE)
+                return expectedErrorMessage != null
+                        && expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+            } catch (SQLException | RuntimeException e) {
+                return false;
+            }
+            if (expectedErrorMessage != null) {
+                // the original bug was a DBMS error, which no longer occurs
                 return false;
             }
             try {
@@ -67,6 +83,32 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
                 return true;
             }
             return false;
+        }
+
+        @Override
+        public String getBugInformation() {
+            StringBuilder sb = new StringBuilder();
+            if (expectedErrorMessage == null) {
+                sb.append("-- On the database set up by the statements above, the result sets of the following"
+                        + " queries mismatch:").append(System.lineSeparator());
+            } else {
+                sb.append("-- On the database set up by the statements above, the following queries trigger an"
+                        + " unexpected error with message: ").append(expectedErrorMessage)
+                        .append(System.lineSeparator());
+            }
+            sb.append("-- ").append(originalQueryString).append(';').append(System.lineSeparator());
+            if (firstQueryString != null) {
+                if (orderBy) {
+                    sb.append("-- ").append(firstQueryString).append(';').append(System.lineSeparator());
+                    sb.append("-- ").append(secondQueryString).append(';').append(System.lineSeparator());
+                    sb.append("-- ").append(thirdQueryString).append(';').append(System.lineSeparator());
+                } else {
+                    sb.append("-- ").append(firstQueryString).append(" UNION ALL ").append(secondQueryString)
+                            .append(" UNION ALL ").append(thirdQueryString).append(';')
+                            .append(System.lineSeparator());
+                }
+            }
+            return sb.toString();
         }
     }
 
@@ -96,8 +138,14 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
 
         String originalQueryString = select.asString();
         generatedQueryString = originalQueryString;
-        List<String> firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
-                state);
+        List<String> firstResultSet;
+        try {
+            firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
+        } catch (AssertionError unexpectedError) {
+            reproducer = new TLPWhereReproducer(null, null, null, originalQueryString, false,
+                    TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+            throw unexpectedError;
+        }
 
         boolean orderBy = Randomly.getBooleanWithSmallProbability();
         if (orderBy) {
@@ -113,13 +161,19 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         select.setWhereClause(predicates.isNullPredicate);
         String thirdQueryString = select.asString();
 
-        reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString, originalQueryString,
-                orderBy);
-
         List<String> combinedString = new ArrayList<>();
-        List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
-                thirdQueryString, combinedString, !orderBy, state, errors);
+        List<String> secondResultSet;
+        try {
+            secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                    thirdQueryString, combinedString, !orderBy, state, errors);
+        } catch (AssertionError unexpectedError) {
+            reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString,
+                    originalQueryString, orderBy, TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+            throw unexpectedError;
+        }
 
+        reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString, originalQueryString,
+                orderBy, null);
         ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString, combinedString,
                 state);
     }

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -34,6 +34,29 @@ public final class TestOracleUtils {
         return new AbstractTables<>(Randomly.nonEmptySubset(schema.getDatabaseTables()));
     }
 
+    /**
+     * Extracts the message of the DBMS error that caused an oracle query to fail unexpectedly, from the
+     * AssertionError that wraps it (see, e.g., ComparatorHelper#getResultSetFirstColumnAsString). Reproducers use it
+     * to check that a reduced test case still triggers the same error, rather than an unrelated one introduced by the
+     * reduction itself.
+     *
+     * @param error
+     *            the AssertionError wrapping the DBMS error
+     *
+     * @return the message of the innermost cause that has one, or the error's own message
+     */
+    public static String getUnexpectedErrorMessage(AssertionError error) {
+        String message = error.getMessage();
+        Throwable current = error.getCause();
+        while (current != null) {
+            if (current.getMessage() != null) {
+                message = current.getMessage();
+            }
+            current = current.getCause();
+        }
+        return message;
+    }
+
     public static <E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> PredicateVariants<E, C> initializeTernaryPredicateVariants(
             PartitionGenerator<E, C> gen, E predicate) {
         if (gen == null) {

--- a/src/sqlancer/common/oracle/TestOracleUtils.java
+++ b/src/sqlancer/common/oracle/TestOracleUtils.java
@@ -35,10 +35,9 @@ public final class TestOracleUtils {
     }
 
     /**
-     * Extracts the message of the DBMS error that caused an oracle query to fail unexpectedly, from the
-     * AssertionError that wraps it (see, e.g., ComparatorHelper#getResultSetFirstColumnAsString). Reproducers use it
-     * to check that a reduced test case still triggers the same error, rather than an unrelated one introduced by the
-     * reduction itself.
+     * Extracts the message of the DBMS error that caused an oracle query to fail unexpectedly, from the AssertionError
+     * that wraps it (see, e.g., ComparatorHelper#getResultSetFirstColumnAsString). Reproducers use it to check that a
+     * reduced test case still triggers the same error, rather than an unrelated one introduced by the reduction itself.
      *
      * @param error
      *            the AssertionError wrapping the DBMS error


### PR DESCRIPTION
## Bug 1

`TLPWhereOracle.check()` assigned the `TLPWhereReproducer` after calling
`ComparatorHelper.assumeResultSetsAreEqual`:

```java
ComparatorHelper.assumeResultSetsAreEqual(...); // throws AssertionError on mismatch
reproducer = new TLPWhereReproducer(...);  // only reached if error not thrown
```

`check()` also resets `reproducer = null` at its very start, so when `ProviderAdapter`
caught the `AssertionError` and called `oracle.getLastReproducer()`, it always received
`null` for a bug-finding invocation.

So, `--use-reducer` did nothing for `TLPWhereOracle`.

### Fix

Moved the `TLPWhereReproducer` construction to before `assumeResultSetsAreEqual`. All the
data it captures is already computed at that point, so the reproducer is populated regardless
of whether the comparison throws:

```java
reproducer = new TLPWhereReproducer(...);  // set before comparison
ComparatorHelper.assumeResultSetsAreEqual(...);
```

This matches the pattern already used correctly by `NoRECOracle`, which constructs its
`NoRECReproducer` inside the failure branch before throwing.

## Bug 2

Even after fixing bug 1, logs always ended up empty.

Two `StateLogger` instances point at the same reduce file: the executor's `logger`, and a
second logger created for `newGlobalState`, which is the one the reducers actually write
through. `StateLogger.getReduceFileWriter()` opens the file lazily and in truncate mode
(`new FileWriter(reduceFile, false)`).

After reduction finished, the cleanup code in `Main.run()` called:

```java
try {
    logger.getReduceFileWriter().close();
    logger.reduceFileWriter = null;
} catch (IOException e) {
    throw new AssertionError(e);
}
```

`logger` had never opened its reduce writer, so `getReduceFileWriter()`
opened the file, truncating everything the reducers had just written through
`newGlobalState`'s logger.

### Fix

Check the field instead of calling the lazy getter, so a writer is never opened purely to
be closed:

```java
if (logger.reduceFileWriter != null) {
    try {
        logger.reduceFileWriter.close();
        logger.reduceFileWriter = null;
    } catch (IOException e) {
        throw new AssertionError(e);
    }
}
```

Note, as part of Bug 5's fix, `logger` in this block was ultimately changed to `reduceLogger`.

## Bug 3

Reductions collapsed to a single statement (e.g. a lone `INSERT` statement) that did not
reproduce the original bug.

This was because the reproducers did not distinguish which failure a reduced candidate triggers. Any
failure counted as "bug still triggers":

- `TLPWhereReproducer.bugStillTriggers` wrapped both query execution and the result-set
  comparison in one `catch (AssertionError) { return true; }`. But
  `ComparatorHelper.getResultSetFirstColumnAsString` also wrapped every unexpected SQL
  error in an `AssertionError`. So when the reducer deleted the `CREATE TABLE`, the oracle
  queries failed with "no such table", which was caught and reported as the bug still
  triggering. The reducer therefore kept deleting statements until nothing meaningful was
  left.
- `NoRECReproducer` had a milder variant: `countRows`/`extractCounts` returned `-1` when a
  query fails or returns no result set, and the reproducer compared raw counts, so
  `-1 != <real count>` was accepted as a count mismatch.

### Fix

Reproducers are now category-aware: they record which failure `check()` originally
observed and accept a reduced candidate only if it triggers the same category.

- If the original bug was a result-set mismatch, the queries must execute
  successfully on the reduced database and then disagree. Any execution error
  (`SQLException`, `IgnoreMeException`, or the `AssertionError` wrapping an unexpected
  DBMS error) means the candidate is rejected. A `-1` count in NoREC is likewise rejected,
  mirroring `check()`, which throws `IgnoreMeException` in that case.
- If the original bug was an unexpected DBMS error, the reproducer stores the error's
  message (extracted from the wrapping `AssertionError`'s cause chain by the new
  `TestOracleUtils.getUnexpectedErrorMessage`) and accepts a candidate only if the queries
  fail with the identical message.

This also extends reducer support: previously, a DBMS-error bug produced no reproducer
at all in `NoRECOracle` (its reproducer was only constructed in the count-mismatch branch)
and in `TLPWhereOracle` when the error occurred on the original (no-WHERE) query. Both
paths now construct a reproducer tagged with the expected error message, so those bugs are
reducible too.

## Bug 4

`TLPWhereReproducer` compared against a stale baseline. It stored the result set of the
original query as captured on the original database, and compared it with the combined
TLP result set computed on the reduced database. Removing a legitimate statement (e.g.
an `INSERT`) changes both result sets on the reduced database, so the stale-vs-fresh
comparison reported a "mismatch" even on a bug-free DBMS.

### Fix

`bugStillTriggers` now re-executes the original query on the reduced database and compares fresh against fresh.

## Problem 5 - lack of clarity in main log

With `--use-reducer`, the main log (outside the `reduce/` folder) was not reproducible: it
contained only the reduced generation statements; it omitted the database setup
(`DROP DATABASE IF EXISTS ...; CREATE DATABASE ...; USE ...;`) and queries.

### Fix

`Main.run()` now partitions the statement list before reduction and reassembles it after:

- The setup-statement count is snapshotted right after `createDatabase`, and the oracle query comments are identified via the oracle run's local state (new `OracleRunReproductionState.getStatements()` accessor).
- Only the generation statements are handed to the reducers, so the setup and queries remain as-is.
- Afterwards the list is reassembled as: setup + reduced generation statements + the original commented oracle queries + the reproducer's bug description.

The main log now has similar information to one produced without `--use-reducer`, the only difference being that the generation statements are a final reduced batch. It therefore contains enough information to fully reproduce the bug, while the reduce-folder log shows the reduction steps in detail.

## Problem 6 - lack of clarity in reduce-folder log

The reduce-folder log was an unseparated stream of attempts, which made it hard to tell attempts apart.

### Fix

Each successful reduction attempt is now logged as a delimited block. E.g.:

```
-- Reduction attempt 3: the bug was still triggered with the following statements:
DROP DATABASE IF EXISTS database0;
CREATE DATABASE database0;
USE database0;
CREATE TABLE t0 (...);
...
-- On the database set up by the statements above, the following queries trigger an unexpected error with message: <message>
-- SELECT ...;

-- Reduction attempt 4: ...
```

This better reflects what actually happens on every attempt.

# Impact

With these fixes, `--use-reducer` produces usable results for `TLPWhereOracle` and
`NoRECOracle` (and the oracles that delegate to them, e.g. Presto's and YugabyteDB's TLP
WHERE oracles):

- a reduced test case is guaranteed to trigger the same category of failure as the original bug
- DBMS-error bugs, as opposed to only oracle logic bugs, are now reducible (previously they either had no reproducer or were reduced against the wrong criterion)
- when using --use-reducer, the main log now contains sufficient information to reproduce the bug, just like it does when --use-reducer is not activated.
- the detailed log in the reduce subfolder is now more readable and clearly shows the reduction process.