### PR TITLE
Do not schedule disabled PostgreSQL tablespaces

### DIFF
--- a/src/sqlancer/postgres/PostgresProvider.java
+++ b/src/sqlancer/postgres/PostgresProvider.java
@@ -194,7 +194,7 @@ public class PostgresProvider extends SQLProviderAdapter<PostgresGlobalState, Po
             nrPerformed = r.getInteger(0, 2);
             break;
         case CREATE_TABLESPACE:
-            nrPerformed = r.getInteger(0, 2);
+            nrPerformed = globalState.getDbmsSpecificOptions().isTestTablespaces() ? r.getInteger(0, 2) : 0;
             break;
         case UPDATE:
             nrPerformed = r.getInteger(0, 10);

--- a/test/sqlancer/postgres/TestPostgresProvider.java
+++ b/test/sqlancer/postgres/TestPostgresProvider.java
@@ -1,0 +1,21 @@
+package sqlancer.postgres;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TestPostgresProvider {
+
+    @Test
+    void createTablespaceIsNotScheduledWhenDisabled() {
+        PostgresGlobalState state = new PostgresGlobalState();
+        state.setDbmsSpecificOptions(new PostgresOptions() {
+            @Override
+            public boolean isTestTablespaces() {
+                return false;
+            }
+        });
+
+        assertEquals(0, PostgresProvider.mapActions(state, PostgresProvider.Action.CREATE_TABLESPACE));
+    }
+}


### PR DESCRIPTION
## Summary

When PostgreSQL tablespace testing is disabled, `PostgresProvider.mapActions()`
now assigns zero executions to `CREATE_TABLESPACE`. Consequently,
`StatementExecutor` never selects that action and never calls
`PostgresTableSpaceGenerator.generate()`.

Following the review feedback, this moves the guard up to the scheduling layer,
rather than handling an already-selected action inside the generator.

This removes the previous generator-level `IgnoreMeException` approach. The
generator is now skipped entirely when tablespace testing is disabled.

## Testing

- `mvn -Dtest=sqlancer.postgres.TestPostgresProvider test`
  - `TestPostgresProvider`: 1 test passed, 0 failures, 0 errors.


