### PR TITLE
Factor out comparison-based oracle reproducers to share common base

### DIFF
--- a/src/sqlancer/common/oracle/AbstractComparisonReproducer.java
+++ b/src/sqlancer/common/oracle/AbstractComparisonReproducer.java
@@ -1,0 +1,142 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+
+import sqlancer.Reproducer;
+import sqlancer.SQLGlobalState;
+
+/**
+ * Shared skeleton for the {@link Reproducer}s of oracles that detect a bug by comparing two evaluations of a
+ * semantically-equivalent pair (e.g. {@link EETOracle}, {@link NoRECOracle}, {@link TLPWhereOracle}. All of these
+ * reduce the bug the same way: re-evaluate both sides against the reduced database and report whether they still
+ * disagree (or, when the original bug was an unexpected DBMS error, whether that same error still fires).
+ *
+ * <p>
+ * This class owns that control flow (including distinguishing a still-reproducing error from an unrelated one
+ * introduced by the reduction) and the {@link #getBugInformation()} header. Subclasses supply the parts specific to
+ * their oracle: how each side is evaluated, how the two are compared, and how the failing queries are rendered in the
+ * reduced test case.
+ *
+ * @param <G>
+ *            the DBMS-specific global state class
+ * @param <R>
+ *            the type each side evaluates to (e.g. a result set as a list of strings, a row count, a post-image)
+ */
+public abstract class AbstractComparisonReproducer<G extends SQLGlobalState<?, ?>, R> implements Reproducer<G> {
+
+    /**
+     * The message of the unexpected DBMS error the original bug was, or {@code null} if the original bug was a
+     * comparison mismatch rather than an error.
+     */
+    protected final String expectedErrorMessage;
+
+    protected AbstractComparisonReproducer(String expectedErrorMessage) {
+        this.expectedErrorMessage = expectedErrorMessage;
+    }
+
+    /**
+     * Whether the recorded bug has a transformed (second) side. It does not when the bug was a DBMS error triggered by
+     * the original query alone, in which case there is no second side to evaluate or compare.
+     *
+     * @return {@code true} if {@link #evaluateTransformed} should be called
+     */
+    protected abstract boolean hasTransformedSide();
+
+    /**
+     * Evaluates the original side against the (reduced) database.
+     *
+     * @param globalState
+     *            the state whose connection points at the reduced database
+     *
+     * @return the original side's value
+     *
+     * @throws SQLException
+     *             if a DBMS interaction fails
+     */
+    protected abstract R evaluateOriginal(G globalState) throws SQLException;
+
+    /**
+     * Evaluates the transformed side against the (reduced) database. Only called when {@link #hasTransformedSide()} is
+     * {@code true}.
+     *
+     * @param globalState
+     *            the state whose connection points at the reduced database
+     *
+     * @return the transformed side's value
+     *
+     * @throws SQLException
+     *             if a DBMS interaction fails
+     */
+    protected abstract R evaluateTransformed(G globalState) throws SQLException;
+
+    /**
+     * Whether the two evaluated sides disagree in the way that constitutes the bug.
+     *
+     * @param original
+     *            the original side's value
+     * @param transformed
+     *            the transformed side's value
+     * @param globalState
+     *            the state the sides were evaluated against
+     *
+     * @return {@code true} if the sides differ (i.e. the bug still triggers)
+     */
+    protected abstract boolean sidesDiffer(R original, R transformed, G globalState);
+
+    @Override
+    public final boolean bugStillTriggers(G globalState) {
+        R original;
+        R transformed;
+        try {
+            original = evaluateOriginal(globalState);
+            if (!hasTransformedSide()) {
+                // the original bug was a DBMS error on the original query alone, which no longer occurs
+                return false;
+            }
+            transformed = evaluateTransformed(globalState);
+        } catch (AssertionError unexpectedError) {
+            // a DBMS error reproduces the bug only if the original failure was the same error;
+            // other errors are artifacts of the reduction (e.g., a removed CREATE TABLE)
+            return expectedErrorMessage != null
+                    && expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+        } catch (SQLException | RuntimeException e) {
+            return false;
+        }
+        if (expectedErrorMessage != null) {
+            // the original bug was a DBMS error, which no longer occurs
+            return false;
+        }
+        return sidesDiffer(original, transformed, globalState);
+    }
+
+    @Override
+    public final String getBugInformation() {
+        StringBuilder sb = new StringBuilder();
+        if (expectedErrorMessage != null) {
+            sb.append("-- On the database set up by the statements above, the following queries trigger an"
+                    + " unexpected error with message: ").append(expectedErrorMessage).append(System.lineSeparator());
+        } else {
+            sb.append(mismatchHeaderLine()).append(System.lineSeparator());
+        }
+        appendQueryLines(sb);
+        return sb.toString();
+    }
+
+    /**
+     * The header line (without trailing line separator) describing the mismatch, used when the original bug was a
+     * comparison mismatch rather than an error. For example, "-- On the database set up by the statements above, the
+     * result sets of the following queries mismatch:".
+     *
+     * @return the mismatch header line
+     */
+    protected abstract String mismatchHeaderLine();
+
+    /**
+     * Appends the failing queries (or statements) to {@code sb}, one commented line each, so the reduced test case is
+     * self-contained. Called for both the mismatch and the error case, after the header.
+     *
+     * @param sb
+     *            the builder to append to
+     */
+    protected abstract void appendQueryLines(StringBuilder sb);
+}

--- a/src/sqlancer/common/oracle/AbstractComparisonReproducer.java
+++ b/src/sqlancer/common/oracle/AbstractComparisonReproducer.java
@@ -7,43 +7,28 @@ import sqlancer.SQLGlobalState;
 
 /**
  * Shared skeleton for the {@link Reproducer}s of oracles that detect a bug by comparing two evaluations of a
- * semantically-equivalent pair (e.g. {@link EETOracle}, {@link NoRECOracle}, {@link TLPWhereOracle}. All of these
- * reduce the bug the same way: re-evaluate both sides against the reduced database and report whether they still
- * disagree (or, when the original bug was an unexpected DBMS error, whether that same error still fires).
+ * semantically-equivalent pair (e.g. {@link EETOracle}, {@link NoRECOracle}, {@link TLPWhereOracle}). Reduction re-runs
+ * both sides against the reduced database and reports whether they still disagree.
  *
  * <p>
- * This class owns that control flow (including distinguishing a still-reproducing error from an unrelated one
- * introduced by the reduction) and the {@link #getBugInformation()} header. Subclasses supply the parts specific to
- * their oracle: how each side is evaluated, how the two are compared, and how the failing queries are rendered in the
- * reduced test case.
+ * The separate case where the original bug was an unexpected DBMS error rather than a mismatch is handled by
+ * {@link UnexpectedErrorReproducer}, so a subclass here deals only with comparing two sides and never with error
+ * handling.
+ *
+ * <p>
+ * This class owns the compare-and-report control flow and the {@link #getBugInformation()} header. Subclasses supply
+ * how each side is evaluated, how the two are compared, and how the failing queries are rendered in the reduced test
+ * case.
  *
  * @param <G>
  *            the DBMS-specific global state class
  * @param <R>
- *            the type each side evaluates to (e.g. a result set as a list of strings, a row count, a post-image)
+ *            the type each side evaluates to (e.g. a result set as a list of strings, a row count)
  */
 public abstract class AbstractComparisonReproducer<G extends SQLGlobalState<?, ?>, R> implements Reproducer<G> {
 
     /**
-     * The message of the unexpected DBMS error the original bug was, or {@code null} if the original bug was a
-     * comparison mismatch rather than an error.
-     */
-    protected final String expectedErrorMessage;
-
-    protected AbstractComparisonReproducer(String expectedErrorMessage) {
-        this.expectedErrorMessage = expectedErrorMessage;
-    }
-
-    /**
-     * Whether the recorded bug has a transformed (second) side. It does not when the bug was a DBMS error triggered by
-     * the original query alone, in which case there is no second side to evaluate or compare.
-     *
-     * @return {@code true} if {@link #evaluateTransformed} should be called
-     */
-    protected abstract boolean hasTransformedSide();
-
-    /**
-     * Evaluates the original side against the (reduced) database.
+     * Evaluates the original side against the reduced database.
      *
      * @param globalState
      *            the state whose connection points at the reduced database
@@ -56,8 +41,7 @@ public abstract class AbstractComparisonReproducer<G extends SQLGlobalState<?, ?
     protected abstract R evaluateOriginal(G globalState) throws SQLException;
 
     /**
-     * Evaluates the transformed side against the (reduced) database. Only called when {@link #hasTransformedSide()} is
-     * {@code true}.
+     * Evaluates the transformed side against the reduced database.
      *
      * @param globalState
      *            the state whose connection points at the reduced database
@@ -89,21 +73,9 @@ public abstract class AbstractComparisonReproducer<G extends SQLGlobalState<?, ?
         R transformed;
         try {
             original = evaluateOriginal(globalState);
-            if (!hasTransformedSide()) {
-                // the original bug was a DBMS error on the original query alone, which no longer occurs
-                return false;
-            }
             transformed = evaluateTransformed(globalState);
-        } catch (AssertionError unexpectedError) {
-            // a DBMS error reproduces the bug only if the original failure was the same error;
-            // other errors are artifacts of the reduction (e.g., a removed CREATE TABLE)
-            return expectedErrorMessage != null
-                    && expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
-        } catch (SQLException | RuntimeException e) {
-            return false;
-        }
-        if (expectedErrorMessage != null) {
-            // the original bug was a DBMS error, which no longer occurs
+        } catch (AssertionError | SQLException | RuntimeException e) {
+            // any failure re-running the two sides means this reduced database no longer shows the mismatch
             return false;
         }
         return sidesDiffer(original, transformed, globalState);
@@ -112,28 +84,21 @@ public abstract class AbstractComparisonReproducer<G extends SQLGlobalState<?, ?
     @Override
     public final String getBugInformation() {
         StringBuilder sb = new StringBuilder();
-        if (expectedErrorMessage != null) {
-            sb.append("-- On the database set up by the statements above, the following queries trigger an"
-                    + " unexpected error with message: ").append(expectedErrorMessage).append(System.lineSeparator());
-        } else {
-            sb.append(mismatchHeaderLine()).append(System.lineSeparator());
-        }
+        sb.append(mismatchHeaderLine()).append(System.lineSeparator());
         appendQueryLines(sb);
         return sb.toString();
     }
 
     /**
-     * The header line (without trailing line separator) describing the mismatch, used when the original bug was a
-     * comparison mismatch rather than an error. For example, "-- On the database set up by the statements above, the
-     * result sets of the following queries mismatch:".
+     * The header line (without trailing line separator) describing the mismatch. For example, "-- On the database set
+     * up by the statements above, the result sets of the following queries mismatch:".
      *
      * @return the mismatch header line
      */
     protected abstract String mismatchHeaderLine();
 
     /**
-     * Appends the failing queries (or statements) to {@code sb}, one commented line each, so the reduced test case is
-     * self-contained. Called for both the mismatch and the error case, after the header.
+     * Appends the failing queries to {@code sb}, one commented line each, so the reduced test case is self-contained.
      *
      * @param sb
      *            the builder to append to

--- a/src/sqlancer/common/oracle/EETOracle.java
+++ b/src/sqlancer/common/oracle/EETOracle.java
@@ -55,18 +55,11 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
 
     private final class EETReproducer extends AbstractComparisonReproducer<G, List<String>> {
         private final String originalQueryString;
-        // null if the original bug was a DBMS error on the original query alone
         private final String transformedQueryString;
 
-        EETReproducer(String originalQueryString, String transformedQueryString, String expectedErrorMessage) {
-            super(expectedErrorMessage);
+        EETReproducer(String originalQueryString, String transformedQueryString) {
             this.originalQueryString = originalQueryString;
             this.transformedQueryString = transformedQueryString;
-        }
-
-        @Override
-        protected boolean hasTransformedSide() {
-            return transformedQueryString != null;
         }
 
         @Override
@@ -100,11 +93,32 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
 
         @Override
         protected void appendQueryLines(StringBuilder sb) {
-            sb.append("-- original: ").append(originalQueryString).append(';').append(System.lineSeparator());
-            if (transformedQueryString != null) {
-                sb.append("-- transformed: ").append(transformedQueryString).append(';').append(System.lineSeparator());
-            }
+            renderQueryLines(sb, originalQueryString, transformedQueryString);
         }
+    }
+
+    // Renders the failing queries as commented lines, shared by the mismatch and the unexpected-error reproducers.
+    // transformedQueryString is null when the error struck the original query before any transformation existed.
+    private static void renderQueryLines(StringBuilder sb, String originalQueryString, String transformedQueryString) {
+        sb.append("-- original: ").append(originalQueryString).append(';').append(System.lineSeparator());
+        if (transformedQueryString != null) {
+            sb.append("-- transformed: ").append(transformedQueryString).append(';').append(System.lineSeparator());
+        }
+    }
+
+    // Builds the reproducer for an unexpected DBMS error, which re-runs the query (or both queries) and checks the same
+    // error still fires. transformedQueryString is null when only the original query ran before the error.
+    private UnexpectedErrorReproducer<G> errorReproducer(String originalQueryString, String transformedQueryString,
+            String expectedErrorMessage) {
+        UnexpectedErrorReproducer.Execution<G> execution = globalState -> {
+            ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, globalState);
+            if (transformedQueryString != null) {
+                ComparatorHelper.getResultSetFirstColumnAsString(transformedQueryString, errors, globalState);
+            }
+        };
+        StringBuilder sb = new StringBuilder();
+        renderQueryLines(sb, originalQueryString, transformedQueryString);
+        return new UnexpectedErrorReproducer<>(execution, expectedErrorMessage, sb.toString());
     }
 
     public EETOracle(G state, EETGenerator<Z, J, E, T, C> gen, ExpectedErrors expectedErrors) {
@@ -139,8 +153,8 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
             originalResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
         } catch (AssertionError unexpectedError) {
             // an unexpected DBMS error on the original query alone is itself a bug worth reducing;
-            // transformedQueryString is null because no transformed query is involved
-            reproducer = new EETReproducer(originalQueryString, null,
+            // there is no transformed query yet, so only the original is replayed
+            reproducer = errorReproducer(originalQueryString, null,
                     TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
             throw unexpectedError;
         }
@@ -160,14 +174,14 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
         } catch (AssertionError unexpectedError) {
             // the semantics-preserving transformation made the query trigger a DBMS error that the
             // original did not, which is a bug worth reducing
-            reproducer = new EETReproducer(originalQueryString, transformedQueryString,
+            reproducer = errorReproducer(originalQueryString, transformedQueryString,
                     TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
             throw unexpectedError;
         }
 
         // Set the reproducer before the assertion: assumeResultSetsAreEqual throws when the bug is
         // detected, so creating the reproducer afterwards would leave it null and prevent any reduction.
-        reproducer = new EETReproducer(originalQueryString, transformedQueryString, null);
+        reproducer = new EETReproducer(originalQueryString, transformedQueryString);
 
         ComparatorHelper.assumeResultSetsAreEqual(originalResultSet, transformedResultSet, originalQueryString,
                 List.of(transformedQueryString), state);

--- a/src/sqlancer/common/oracle/EETOracle.java
+++ b/src/sqlancer/common/oracle/EETOracle.java
@@ -53,50 +53,38 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
     private Reproducer<G> reproducer;
     private String generatedQueryString;
 
-    private final class EETReproducer implements Reproducer<G> {
+    private final class EETReproducer extends AbstractComparisonReproducer<G, List<String>> {
         private final String originalQueryString;
         // null if the original bug was a DBMS error on the original query alone
         private final String transformedQueryString;
-        // null if the original bug is a result set mismatch; otherwise, the message of the
-        // unexpected DBMS error that the original or transformed query triggered
-        private final String expectedErrorMessage;
 
         EETReproducer(String originalQueryString, String transformedQueryString, String expectedErrorMessage) {
+            super(expectedErrorMessage);
             this.originalQueryString = originalQueryString;
             this.transformedQueryString = transformedQueryString;
-            this.expectedErrorMessage = expectedErrorMessage;
         }
 
         @Override
-        public boolean bugStillTriggers(G globalState) {
-            List<String> originalResultSet;
-            List<String> transformedResultSet;
+        protected boolean hasTransformedSide() {
+            return transformedQueryString != null;
+        }
+
+        @Override
+        protected List<String> evaluateOriginal(G globalState) throws SQLException {
+            // Re-execute against the current (reduced) database instead of comparing against a cached result set,
+            // which would be stale once statements have been removed.
+            return ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, globalState);
+        }
+
+        @Override
+        protected List<String> evaluateTransformed(G globalState) throws SQLException {
+            return ComparatorHelper.getResultSetFirstColumnAsString(transformedQueryString, errors, globalState);
+        }
+
+        @Override
+        protected boolean sidesDiffer(List<String> original, List<String> transformed, G globalState) {
             try {
-                // Re-execute both queries against the current (reduced) database instead of comparing
-                // against a cached result set, which would be stale once statements have been removed.
-                originalResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
-                        globalState);
-                if (transformedQueryString == null) {
-                    // the original bug was a DBMS error on the original query alone, which no
-                    // longer occurs
-                    return false;
-                }
-                transformedResultSet = ComparatorHelper.getResultSetFirstColumnAsString(transformedQueryString, errors,
-                        globalState);
-            } catch (AssertionError unexpectedError) {
-                // a DBMS error reproduces the bug only if the original failure was the same error;
-                // other errors are artifacts of the reduction (e.g., a removed CREATE TABLE)
-                return expectedErrorMessage != null
-                        && expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
-            } catch (SQLException | RuntimeException e) {
-                return false;
-            }
-            if (expectedErrorMessage != null) {
-                // the original bug was a DBMS error, which no longer occurs
-                return false;
-            }
-            try {
-                ComparatorHelper.assumeResultSetsAreEqual(originalResultSet, transformedResultSet, originalQueryString,
+                ComparatorHelper.assumeResultSetsAreEqual(original, transformed, originalQueryString,
                         List.of(transformedQueryString), globalState);
             } catch (AssertionError resultSetMismatch) {
                 return true;
@@ -105,21 +93,17 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
         }
 
         @Override
-        public String getBugInformation() {
-            StringBuilder sb = new StringBuilder();
-            if (expectedErrorMessage == null) {
-                sb.append("-- On the database set up by the statements above, the result sets of the following"
-                        + " queries mismatch:").append(System.lineSeparator());
-            } else {
-                sb.append("-- On the database set up by the statements above, the following queries trigger an"
-                        + " unexpected error with message: ").append(expectedErrorMessage)
-                        .append(System.lineSeparator());
-            }
+        protected String mismatchHeaderLine() {
+            return "-- On the database set up by the statements above, the result sets of the following"
+                    + " queries mismatch:";
+        }
+
+        @Override
+        protected void appendQueryLines(StringBuilder sb) {
             sb.append("-- original: ").append(originalQueryString).append(';').append(System.lineSeparator());
             if (transformedQueryString != null) {
                 sb.append("-- transformed: ").append(transformedQueryString).append(';').append(System.lineSeparator());
             }
-            return sb.toString();
         }
     }
 

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -38,17 +38,11 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
         private final String unoptimizedQueryString;
 
         NoRECReproducer(Function<G, Integer> optimizedQuery, Function<G, Integer> unoptimizedQuery,
-                String optimizedQueryString, String unoptimizedQueryString, String expectedErrorMessage) {
-            super(expectedErrorMessage);
+                String optimizedQueryString, String unoptimizedQueryString) {
             this.optimizedQuery = optimizedQuery;
             this.unoptimizedQuery = unoptimizedQuery;
             this.optimizedQueryString = optimizedQueryString;
             this.unoptimizedQueryString = unoptimizedQueryString;
-        }
-
-        @Override
-        protected boolean hasTransformedSide() {
-            return true;
         }
 
         @Override
@@ -77,9 +71,27 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
 
         @Override
         protected void appendQueryLines(StringBuilder sb) {
-            sb.append("-- optimized: ").append(optimizedQueryString).append(';').append(System.lineSeparator());
-            sb.append("-- unoptimized: ").append(unoptimizedQueryString).append(';').append(System.lineSeparator());
+            renderQueryLines(sb, optimizedQueryString, unoptimizedQueryString);
         }
+    }
+
+    // Renders the failing queries as commented lines, shared by the mismatch and the unexpected-error reproducers.
+    private static void renderQueryLines(StringBuilder sb, String optimizedQueryString, String unoptimizedQueryString) {
+        sb.append("-- optimized: ").append(optimizedQueryString).append(';').append(System.lineSeparator());
+        sb.append("-- unoptimized: ").append(unoptimizedQueryString).append(';').append(System.lineSeparator());
+    }
+
+    // Builds the reproducer for an unexpected DBMS error, which re-runs both queries and checks the same error fires.
+    private static <G extends SQLGlobalState<?, ?>> UnexpectedErrorReproducer<G> errorReproducer(
+            Function<G, Integer> optimizedQuery, Function<G, Integer> unoptimizedQuery, String optimizedQueryString,
+            String unoptimizedQueryString, String expectedErrorMessage) {
+        UnexpectedErrorReproducer.Execution<G> execution = globalState -> {
+            optimizedQuery.apply(globalState);
+            unoptimizedQuery.apply(globalState);
+        };
+        StringBuilder sb = new StringBuilder();
+        renderQueryLines(sb, optimizedQueryString, unoptimizedQueryString);
+        return new UnexpectedErrorReproducer<>(execution, expectedErrorMessage, sb.toString());
     }
 
     public NoRECOracle(G state, NoRECGenerator<Z, J, E, T, C> gen, ExpectedErrors expectedErrors) {
@@ -128,8 +140,8 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
             optimizedCount = optimizedQuery.apply(state);
             unoptimizedCount = unoptimizedQuery.apply(state);
         } catch (AssertionError unexpectedError) {
-            reproducer = new NoRECReproducer<>(optimizedQuery, unoptimizedQuery, optimizedQueryString,
-                    unoptimizedQueryString, TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+            reproducer = errorReproducer(optimizedQuery, unoptimizedQuery, optimizedQueryString, unoptimizedQueryString,
+                    TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
             throw unexpectedError;
         }
 
@@ -139,7 +151,7 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
 
         if (unoptimizedCount != optimizedCount) {
             reproducer = new NoRECReproducer<>(optimizedQuery, unoptimizedQuery, optimizedQueryString,
-                    unoptimizedQueryString, null);
+                    unoptimizedQueryString);
 
             String queryFormatString = "-- %s;\n-- count: %d";
             String firstQueryStringWithCount = String.format(queryFormatString, optimizedQueryString, optimizedCount);

--- a/src/sqlancer/common/oracle/NoRECOracle.java
+++ b/src/sqlancer/common/oracle/NoRECOracle.java
@@ -30,63 +30,55 @@ public class NoRECOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, 
     private Reproducer<G> reproducer;
     private String lastQueryString;
 
-    private static class NoRECReproducer<G extends SQLGlobalState<?, ?>> implements Reproducer<G> {
+    private static class NoRECReproducer<G extends SQLGlobalState<?, ?>>
+            extends AbstractComparisonReproducer<G, Integer> {
         private final Function<G, Integer> optimizedQuery;
         private final Function<G, Integer> unoptimizedQuery;
         private final String optimizedQueryString;
         private final String unoptimizedQueryString;
-        // null if the original bug is a count mismatch; otherwise, the message of the unexpected
-        // DBMS error that the original queries triggered
-        private final String expectedErrorMessage;
 
         NoRECReproducer(Function<G, Integer> optimizedQuery, Function<G, Integer> unoptimizedQuery,
                 String optimizedQueryString, String unoptimizedQueryString, String expectedErrorMessage) {
+            super(expectedErrorMessage);
             this.optimizedQuery = optimizedQuery;
             this.unoptimizedQuery = unoptimizedQuery;
             this.optimizedQueryString = optimizedQueryString;
             this.unoptimizedQueryString = unoptimizedQueryString;
-            this.expectedErrorMessage = expectedErrorMessage;
         }
 
         @Override
-        public boolean bugStillTriggers(G globalState) {
-            int optimizedCount;
-            int unoptimizedCount;
-            try {
-                optimizedCount = optimizedQuery.apply(globalState);
-                unoptimizedCount = unoptimizedQuery.apply(globalState);
-            } catch (AssertionError unexpectedError) {
-                // a DBMS error reproduces the bug only if the original failure was the same error;
-                // other errors are artifacts of the reduction (e.g., a removed CREATE TABLE)
-                return expectedErrorMessage != null
-                        && expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
-            } catch (RuntimeException e) {
-                return false;
-            }
-            if (expectedErrorMessage != null) {
-                // the original bug was a DBMS error, which no longer occurs
-                return false;
-            }
+        protected boolean hasTransformedSide() {
+            return true;
+        }
+
+        @Override
+        protected Integer evaluateOriginal(G globalState) {
+            return optimizedQuery.apply(globalState);
+        }
+
+        @Override
+        protected Integer evaluateTransformed(G globalState) {
+            return unoptimizedQuery.apply(globalState);
+        }
+
+        @Override
+        protected boolean sidesDiffer(Integer optimizedCount, Integer unoptimizedCount, G globalState) {
             if (optimizedCount == -1 || unoptimizedCount == -1) {
                 return false;
             }
-            return optimizedCount != unoptimizedCount;
+            return optimizedCount.intValue() != unoptimizedCount.intValue();
         }
 
         @Override
-        public String getBugInformation() {
-            StringBuilder sb = new StringBuilder();
-            if (expectedErrorMessage == null) {
-                sb.append("-- On the database set up by the statements above, the row counts of the following"
-                        + " queries mismatch:").append(System.lineSeparator());
-            } else {
-                sb.append("-- On the database set up by the statements above, the following queries trigger an"
-                        + " unexpected error with message: ").append(expectedErrorMessage)
-                        .append(System.lineSeparator());
-            }
+        protected String mismatchHeaderLine() {
+            return "-- On the database set up by the statements above, the row counts of the following"
+                    + " queries mismatch:";
+        }
+
+        @Override
+        protected void appendQueryLines(StringBuilder sb) {
             sb.append("-- optimized: ").append(optimizedQueryString).append(';').append(System.lineSeparator());
             sb.append("-- unoptimized: ").append(unoptimizedQueryString).append(';').append(System.lineSeparator());
-            return sb.toString();
         }
     }
 

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -49,18 +49,12 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         final boolean orderBy;
 
         TLPWhereReproducer(String firstQueryString, String secondQueryString, String thirdQueryString,
-                String originalQueryString, boolean orderBy, String expectedErrorMessage) {
-            super(expectedErrorMessage);
+                String originalQueryString, boolean orderBy) {
             this.firstQueryString = firstQueryString;
             this.secondQueryString = secondQueryString;
             this.thirdQueryString = thirdQueryString;
             this.originalQueryString = originalQueryString;
             this.orderBy = orderBy;
-        }
-
-        @Override
-        protected boolean hasTransformedSide() {
-            return firstQueryString != null;
         }
 
         @Override
@@ -96,18 +90,42 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
 
         @Override
         protected void appendQueryLines(StringBuilder sb) {
-            sb.append("-- ").append(originalQueryString).append(';').append(System.lineSeparator());
-            if (firstQueryString != null) {
-                if (orderBy) {
-                    sb.append("-- ").append(firstQueryString).append(';').append(System.lineSeparator());
-                    sb.append("-- ").append(secondQueryString).append(';').append(System.lineSeparator());
-                    sb.append("-- ").append(thirdQueryString).append(';').append(System.lineSeparator());
-                } else {
-                    sb.append("-- ").append(firstQueryString).append(" UNION ALL ").append(secondQueryString)
-                            .append(" UNION ALL ").append(thirdQueryString).append(';').append(System.lineSeparator());
-                }
+            renderQueryLines(sb, originalQueryString, firstQueryString, secondQueryString, thirdQueryString, orderBy);
+        }
+    }
+
+    // Renders the failing queries as commented lines, shared by the mismatch and the unexpected-error reproducers. The
+    // partition queries are null when the error struck the original query before they were built.
+    private static void renderQueryLines(StringBuilder sb, String originalQueryString, String firstQueryString,
+            String secondQueryString, String thirdQueryString, boolean orderBy) {
+        sb.append("-- ").append(originalQueryString).append(';').append(System.lineSeparator());
+        if (firstQueryString != null) {
+            if (orderBy) {
+                sb.append("-- ").append(firstQueryString).append(';').append(System.lineSeparator());
+                sb.append("-- ").append(secondQueryString).append(';').append(System.lineSeparator());
+                sb.append("-- ").append(thirdQueryString).append(';').append(System.lineSeparator());
+            } else {
+                sb.append("-- ").append(firstQueryString).append(" UNION ALL ").append(secondQueryString)
+                        .append(" UNION ALL ").append(thirdQueryString).append(';').append(System.lineSeparator());
             }
         }
+    }
+
+    // Builds the reproducer for an unexpected DBMS error, which re-runs the query (or the whole-table query plus the
+    // three partition queries) and checks the same error still fires. The partition queries are null when the error
+    // struck the original query before they were built.
+    private UnexpectedErrorReproducer<G> errorReproducer(String originalQueryString, String firstQueryString,
+            String secondQueryString, String thirdQueryString, boolean orderBy, String expectedErrorMessage) {
+        UnexpectedErrorReproducer.Execution<G> execution = globalState -> {
+            ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, globalState);
+            if (firstQueryString != null) {
+                ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString, thirdQueryString,
+                        new ArrayList<>(), !orderBy, globalState, errors);
+            }
+        };
+        StringBuilder sb = new StringBuilder();
+        renderQueryLines(sb, originalQueryString, firstQueryString, secondQueryString, thirdQueryString, orderBy);
+        return new UnexpectedErrorReproducer<>(execution, expectedErrorMessage, sb.toString());
     }
 
     public TLPWhereOracle(G state, TLPWhereGenerator<Z, J, E, T, C> gen, ExpectedErrors expectedErrors) {
@@ -140,7 +158,7 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         try {
             firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, state);
         } catch (AssertionError unexpectedError) {
-            reproducer = new TLPWhereReproducer(null, null, null, originalQueryString, false,
+            reproducer = errorReproducer(originalQueryString, null, null, null, false,
                     TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
             throw unexpectedError;
         }
@@ -165,13 +183,13 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
             secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
                     thirdQueryString, combinedString, !orderBy, state, errors);
         } catch (AssertionError unexpectedError) {
-            reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString,
-                    originalQueryString, orderBy, TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+            reproducer = errorReproducer(originalQueryString, firstQueryString, secondQueryString, thirdQueryString,
+                    orderBy, TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
             throw unexpectedError;
         }
 
         reproducer = new TLPWhereReproducer(firstQueryString, secondQueryString, thirdQueryString, originalQueryString,
-                orderBy, null);
+                orderBy);
         ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString, combinedString,
                 state);
     }

--- a/src/sqlancer/common/oracle/TLPWhereOracle.java
+++ b/src/sqlancer/common/oracle/TLPWhereOracle.java
@@ -29,56 +29,59 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
     private Reproducer<G> reproducer;
     private String generatedQueryString;
 
-    private class TLPWhereReproducer implements Reproducer<G> {
+    // A side's result set, together with the human-readable combined-query strings that
+    // getCombinedResultSet fills in for the transformed side (unused, and null, for the original side)
+    private static final class TLPResultSet {
+        final List<String> resultSet;
+        final List<String> combinedString;
+
+        TLPResultSet(List<String> resultSet, List<String> combinedString) {
+            this.resultSet = resultSet;
+            this.combinedString = combinedString;
+        }
+    }
+
+    private class TLPWhereReproducer extends AbstractComparisonReproducer<G, TLPResultSet> {
         final String firstQueryString;
         final String secondQueryString;
         final String thirdQueryString;
         final String originalQueryString;
         final boolean orderBy;
-        // null if the original bug is a result set mismatch; otherwise, the message of the
-        // unexpected DBMS error that the original queries triggered
-        final String expectedErrorMessage;
 
         TLPWhereReproducer(String firstQueryString, String secondQueryString, String thirdQueryString,
                 String originalQueryString, boolean orderBy, String expectedErrorMessage) {
+            super(expectedErrorMessage);
             this.firstQueryString = firstQueryString;
             this.secondQueryString = secondQueryString;
             this.thirdQueryString = thirdQueryString;
             this.originalQueryString = originalQueryString;
             this.orderBy = orderBy;
-            this.expectedErrorMessage = expectedErrorMessage;
         }
 
         @Override
-        public boolean bugStillTriggers(G globalState) {
-            List<String> firstResultSet;
+        protected boolean hasTransformedSide() {
+            return firstQueryString != null;
+        }
+
+        @Override
+        protected TLPResultSet evaluateOriginal(G globalState) throws SQLException {
+            return new TLPResultSet(
+                    ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors, globalState), null);
+        }
+
+        @Override
+        protected TLPResultSet evaluateTransformed(G globalState) throws SQLException {
             List<String> combinedString = new ArrayList<>();
-            List<String> secondResultSet;
+            List<String> secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
+                    thirdQueryString, combinedString, !orderBy, globalState, errors);
+            return new TLPResultSet(secondResultSet, combinedString);
+        }
+
+        @Override
+        protected boolean sidesDiffer(TLPResultSet original, TLPResultSet transformed, G globalState) {
             try {
-                firstResultSet = ComparatorHelper.getResultSetFirstColumnAsString(originalQueryString, errors,
-                        globalState);
-                if (firstQueryString == null) {
-                    // the original bug was a DBMS error on the original query alone, which no
-                    // longer occurs
-                    return false;
-                }
-                secondResultSet = ComparatorHelper.getCombinedResultSet(firstQueryString, secondQueryString,
-                        thirdQueryString, combinedString, !orderBy, globalState, errors);
-            } catch (AssertionError unexpectedError) {
-                // a DBMS error reproduces the bug only if the original failure was the same error;
-                // other errors are artifacts of the reduction (e.g., a removed CREATE TABLE)
-                return expectedErrorMessage != null
-                        && expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
-            } catch (SQLException | RuntimeException e) {
-                return false;
-            }
-            if (expectedErrorMessage != null) {
-                // the original bug was a DBMS error, which no longer occurs
-                return false;
-            }
-            try {
-                ComparatorHelper.assumeResultSetsAreEqual(firstResultSet, secondResultSet, originalQueryString,
-                        combinedString, globalState);
+                ComparatorHelper.assumeResultSetsAreEqual(original.resultSet, transformed.resultSet,
+                        originalQueryString, transformed.combinedString, globalState);
             } catch (AssertionError resultSetMismatch) {
                 return true;
             }
@@ -86,16 +89,13 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
         }
 
         @Override
-        public String getBugInformation() {
-            StringBuilder sb = new StringBuilder();
-            if (expectedErrorMessage == null) {
-                sb.append("-- On the database set up by the statements above, the result sets of the following"
-                        + " queries mismatch:").append(System.lineSeparator());
-            } else {
-                sb.append("-- On the database set up by the statements above, the following queries trigger an"
-                        + " unexpected error with message: ").append(expectedErrorMessage)
-                        .append(System.lineSeparator());
-            }
+        protected String mismatchHeaderLine() {
+            return "-- On the database set up by the statements above, the result sets of the following"
+                    + " queries mismatch:";
+        }
+
+        @Override
+        protected void appendQueryLines(StringBuilder sb) {
             sb.append("-- ").append(originalQueryString).append(';').append(System.lineSeparator());
             if (firstQueryString != null) {
                 if (orderBy) {
@@ -107,7 +107,6 @@ public class TLPWhereOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C
                             .append(" UNION ALL ").append(thirdQueryString).append(';').append(System.lineSeparator());
                 }
             }
-            return sb.toString();
         }
     }
 

--- a/src/sqlancer/common/oracle/UnexpectedErrorReproducer.java
+++ b/src/sqlancer/common/oracle/UnexpectedErrorReproducer.java
@@ -1,0 +1,79 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+
+import sqlancer.Reproducer;
+import sqlancer.SQLGlobalState;
+
+/**
+ * Reproducer for a bug that is an unexpected DBMS error, rather than a violation of oracle logic. When a statement run
+ * by the oracle raises an error the oracle did not expect, the bug is that error. Reduction re-runs the statement
+ * execution against the reduced database and reports whether the same error still fires. The oracle supplies how to
+ * re-run its execution as an {@link Execution} functional interface.
+ *
+ * <p>
+ * For an oracle to use this reproducer on its unexpected errors, they must surface as {@link AssertionError}s, even
+ * though they likely originated as {@link SQLException}s. This is because
+ * {@link UnexpectedErrorReproducer#bugStillTriggers} treats a {@link SQLException} as a replay failure that means "bug
+ * does not trigger" (e.g. dropped connection, removed table).
+ *
+ * @param <G>
+ *            the DBMS-specific global state class
+ */
+public final class UnexpectedErrorReproducer<G extends SQLGlobalState<?, ?>> implements Reproducer<G> {
+
+    private final Execution<G> execution;
+    private final String expectedErrorMessage;
+    private final String queryLines;
+
+    @FunctionalInterface
+    public interface Execution<G> {
+        /**
+         * Re-runs the oracle's execution against the reduced database. The bug is treated as still present if the run
+         * continues to raise an {@link AssertionError} with the same message.
+         *
+         * @param globalState
+         *            the state whose connection points at the reduced database
+         *
+         * @throws SQLException
+         *             if a DBMS interaction fails for a reason other than the recorded bug (e.g. a connection or setup
+         *             failure during replay), which counts as the bug no longer triggering
+         */
+        void execute(G globalState) throws SQLException;
+    }
+
+    /**
+     * @param execution
+     *            re-runs the oracle's execution against the reduced database
+     * @param expectedErrorMessage
+     *            the message of the error the original bug was. The bug is treated as still present if the
+     *            {@link Execution} continues to raise an {@link AssertionError} with the same message.
+     * @param queryLines
+     *            the failing queries as commented lines (each ending in a line separator), for the reduced test case
+     */
+    public UnexpectedErrorReproducer(Execution<G> execution, String expectedErrorMessage, String queryLines) {
+        this.execution = execution;
+        this.expectedErrorMessage = expectedErrorMessage;
+        this.queryLines = queryLines;
+    }
+
+    @Override
+    public boolean bugStillTriggers(G globalState) {
+        try {
+            execution.execute(globalState);
+        } catch (AssertionError unexpectedError) {
+            // the same error reproduces the bug; a different one is an artifact of the reduction (e.g. a removed table)
+            return expectedErrorMessage.equals(TestOracleUtils.getUnexpectedErrorMessage(unexpectedError));
+        } catch (SQLException | RuntimeException e) {
+            return false;
+        }
+        // the error no longer fires
+        return false;
+    }
+
+    @Override
+    public String getBugInformation() {
+        return "-- On the database set up by the statements above, the following queries trigger an unexpected error"
+                + " with message: " + expectedErrorMessage + System.lineSeparator() + queryLines;
+    }
+}


### PR DESCRIPTION
## Summary

The EET, TLP-WHERE and NoREC oracles all detect a bug the same way. Each evaluates two things that should agree and compares them. When they disagree (or when one triggers an unexpected database error), the oracle produces a `Reproducer` that re-runs the comparison against the reduced database during test case reduction.

The three `Reproducer` implementations had shared logic. Each decided whether a reduced database still shows the bug, took care to distinguish the original failure from an unrelated error introduced by the reduction itself, and formatted the failing queries into the reduced test case. This PR moves that shared logic into a new abstract class and rewrites the three reproducers on top of it. There is no change in behaviour.

## Changes

### New base class (`common/oracle/AbstractComparisonReproducer.java`)

Holds the `bugStillTriggers` control flow and the `getBugInformation` formatting that the three oracles previously duplicated. This covers re-evaluating both sides, treating an unexpected error as a reproduction only when it is the same error the original failure reported, and writing the header that introduces the failing queries.

A subclass supplies only the parts that differ between oracles. This includes how each side is evaluated against the database, how the two sides are compared, and how the failing queries are written out.

### `common/oracle/EETOracle.java`

`EETReproducer` now extends the base class. A side is evaluated by reading the first column of a query's result set, and the two are compared with `assumeResultSetsAreEqual`.

### `common/oracle/TLPWhereOracle.java`

`TLPWhereReproducer` now extends the base class. The original side is a plain result set and the transformed side is the combined result of the three partition queries. Because the comparison also needs the human-readable combined query strings that `getCombinedResultSet` fills in, a small value class carries them alongside the result set for the transformed side.

### `common/oracle/NoRECOracle.java`

`NoRECReproducer` now extends the base class. The two sides are integer row counts compared for inequality, keeping the existing guard that treats a failed count (`-1`) on either side as no reproduction.