### PR TITLE
Add support for DECIMAL(M, D) columns in MySQL EET

### DIFF
--- a/src/sqlancer/mysql/MySQLSchema.java
+++ b/src/sqlancer/mysql/MySQLSchema.java
@@ -57,6 +57,7 @@ public class MySQLSchema extends AbstractSchema<MySQLGlobalState, MySQLTable> {
 
         private final boolean isPrimaryKey;
         private final int precision;
+        private final int scale;
 
         public enum CollateSequence {
             NOCASE, RTRIM, BINARY;
@@ -66,14 +67,19 @@ public class MySQLSchema extends AbstractSchema<MySQLGlobalState, MySQLTable> {
             }
         }
 
-        public MySQLColumn(String name, MySQLDataType columnType, boolean isPrimaryKey, int precision) {
+        public MySQLColumn(String name, MySQLDataType columnType, boolean isPrimaryKey, int precision, int scale) {
             super(name, null, columnType);
             this.isPrimaryKey = isPrimaryKey;
             this.precision = precision;
+            this.scale = scale;
         }
 
         public int getPrecision() {
             return precision;
+        }
+
+        public int getScale() {
+            return scale;
         }
 
         @Override
@@ -276,8 +282,10 @@ public class MySQLSchema extends AbstractSchema<MySQLGlobalState, MySQLTable> {
                     String columnName = rs.getString("COLUMN_NAME");
                     String dataType = rs.getString("DATA_TYPE");
                     int precision = rs.getInt("NUMERIC_PRECISION");
+                    int scale = rs.getInt("NUMERIC_SCALE");
                     boolean isPrimaryKey = rs.getString("COLUMN_KEY").equals("PRI");
-                    MySQLColumn c = new MySQLColumn(columnName, getColumnType(dataType), isPrimaryKey, precision);
+                    MySQLColumn c = new MySQLColumn(columnName, getColumnType(dataType), isPrimaryKey, precision,
+                            scale);
                     columns.add(c);
                 }
             }

--- a/src/sqlancer/mysql/ast/MySQLCastOperation.java
+++ b/src/sqlancer/mysql/ast/MySQLCastOperation.java
@@ -1,19 +1,89 @@
 package sqlancer.mysql.ast;
 
+import java.util.Objects;
+
 public class MySQLCastOperation implements MySQLExpression {
 
     private final MySQLExpression expr;
     private final CastType type;
 
-    public enum CastType {
-        SIGNED, UNSIGNED,
-        // CHAR, FLOAT, DOUBLE and DECIMAL are used only by the EET oracle's type-pinning casts and are never
-        // evaluated, so MySQLConstant.castAs does not support them; they must not be returned by getRandom().
-        CHAR, FLOAT, DOUBLE, DECIMAL;
+    /**
+     * A MySQL {@code CAST} target type. The non-{@code DECIMAL} kinds are interned singletons; {@code DECIMAL} may
+     * additionally carry an {@code (M, D)} precision/scale (via {@link #decimal}) so that a
+     * {@code CAST(... AS DECIMAL(M, D))} can reproduce a column's exact type. This is relied on by the EET oracle's
+     * type-pinning casts (see {@code MySQLEETTransformer}).
+     */
+    public static final class CastType {
+
+        // CHAR, FLOAT, DOUBLE and DECIMAL are used only by the EET oracle's type-pinning casts and are never evaluated,
+        // so MySQLConstant.castAs does not support them; they must not be returned by getRandom().
+        public static final CastType SIGNED = new CastType(Kind.SIGNED);
+        public static final CastType UNSIGNED = new CastType(Kind.UNSIGNED);
+        public static final CastType CHAR = new CastType(Kind.CHAR);
+        public static final CastType FLOAT = new CastType(Kind.FLOAT);
+        public static final CastType DOUBLE = new CastType(Kind.DOUBLE);
+        public static final CastType DECIMAL = new CastType(Kind.DECIMAL);
+
+        private enum Kind {
+            SIGNED, UNSIGNED, CHAR, FLOAT, DOUBLE, DECIMAL
+        }
+
+        private final Kind kind;
+        private final Integer precision; // DECIMAL only, otherwise null
+        private final Integer scale; // DECIMAL only, otherwise null
+
+        private CastType(Kind kind) {
+            this(kind, null, null);
+        }
+
+        private CastType(Kind kind, Integer precision, Integer scale) {
+            this.kind = kind;
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        // A DECIMAL(precision, scale) cast target.
+        public static CastType decimal(int precision, int scale) {
+            return new CastType(Kind.DECIMAL, precision, scale);
+        }
 
         public static CastType getRandom() {
             return SIGNED;
             // return Randomly.fromOptions(CastType.SIGNED, CastType.UNSIGNED);
+        }
+
+        public Integer getPrecision() {
+            return precision;
+        }
+
+        public Integer getScale() {
+            return scale;
+        }
+
+        @Override
+        public String toString() {
+            if (precision == null) {
+                return kind.name();
+            }
+            return kind.name() + "(" + precision + ", " + scale + ")";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof CastType)) {
+                return false;
+            }
+            CastType other = (CastType) obj;
+            return kind == other.kind && Objects.equals(precision, other.precision)
+                    && Objects.equals(scale, other.scale);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(kind, precision, scale);
         }
 
     }

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -347,11 +347,11 @@ public class MySQLTableGenerator {
             break;
         case FLOAT:
             sb.append("FLOAT");
-            optionallyAddPrecisionAndScale(sb);
+            optionallyAddFloatingPointPrecisionAndScale(sb);
             break;
         case DOUBLE:
             sb.append(Randomly.fromOptions("DOUBLE", "FLOAT"));
-            optionallyAddPrecisionAndScale(sb);
+            optionallyAddFloatingPointPrecisionAndScale(sb);
             break;
         default:
             throw new AssertionError();
@@ -368,13 +368,20 @@ public class MySQLTableGenerator {
         }
     }
 
-    private void optionallyAddPrecisionAndScale(StringBuilder sb) {
-        // The EET oracle's type inference assumes FLOAT/DOUBLE/DECIMAL columns are created without (M, D) (see
-        // MySQLEETTransformer#inferColumnType), so precision/scale is omitted while EET is active. This restriction can
-        // be lifted once (M, D) is tracked through the codebase and reflected in the CAST target types.
+    // FLOAT(M, D)/DOUBLE(M, D) is deprecated and cannot be reproduced as a CAST target, so the EET oracle's type
+    // inference relies on FLOAT/DOUBLE columns being created without (M, D) (see MySQLEETTransformer#inferColumnType);
+    // it is therefore omitted while EET is active. DECIMAL(M, D) has no such restriction: the EET oracle tracks its
+    // (M, D) and reproduces it via CAST(... AS DECIMAL(M, D)), so it keeps using optionallyAddPrecisionAndScale.
+    private void optionallyAddFloatingPointPrecisionAndScale(StringBuilder sb) {
         boolean eetActive = globalState.getDbmsSpecificOptions().getTestOracleFactory().stream()
                 .anyMatch(o -> o == MySQLOracleFactory.EET);
-        if (Randomly.getBoolean() && !MySQLBugs.bug99183 && !eetActive) {
+        if (!eetActive) {
+            optionallyAddPrecisionAndScale(sb);
+        }
+    }
+
+    private void optionallyAddPrecisionAndScale(StringBuilder sb) {
+        if (Randomly.getBoolean() && !MySQLBugs.bug99183) {
             sb.append("(");
             // The maximum number of digits (M) for DECIMAL is 65
             long m = Randomly.getNotCachedInteger(1, 65);

--- a/src/sqlancer/mysql/oracle/MySQLEETTransformer.java
+++ b/src/sqlancer/mysql/oracle/MySQLEETTransformer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import sqlancer.common.oracle.EETTransformer;
+import sqlancer.mysql.MySQLSchema.MySQLColumn;
 import sqlancer.mysql.ast.MySQLAggregate;
 import sqlancer.mysql.ast.MySQLBetweenOperation;
 import sqlancer.mysql.ast.MySQLBinaryComparisonOperation;
@@ -33,11 +34,11 @@ import sqlancer.mysql.gen.MySQLExpressionGenerator;
  *
  * <p>
  * MySQL's expression generator is untyped, so type inference/generation works with a subset of MySQL's CAST target
- * types ({@link CastType}): {@link #inferType} conservatively classifies AST nodes into that domain (returning
- * {@code null} when uncertain), and {@link #generateExpressionOfType} pins the type of a random expression by wrapping
- * it in a CAST.
+ * types ({@link CastType}, which carries {@code (M, D)} for DECIMAL): {@link #inferType} conservatively classifies AST
+ * nodes into that domain (returning {@code null} when uncertain), and {@link #generateExpressionOfType} pins the type
+ * of a random expression by wrapping it in a CAST.
  */
-public class MySQLEETTransformer extends EETTransformer<MySQLExpression, MySQLCastOperation.CastType> {
+public class MySQLEETTransformer extends EETTransformer<MySQLExpression, CastType> {
 
     private static final boolean BOOLEAN = true;
     private static final boolean SCALAR = false;
@@ -212,20 +213,22 @@ public class MySQLEETTransformer extends EETTransformer<MySQLExpression, MySQLCa
     }
 
     private CastType inferColumnType(MySQLColumnReference ref) {
-        switch (ref.getColumn().getType()) {
+        MySQLColumn column = ref.getColumn();
+        switch (column.getType()) {
         case INT:
             return CastType.SIGNED; // the table generator never creates UNSIGNED INT columns
         case VARCHAR:
             return CastType.CHAR;
-        // FLOAT/DOUBLE/DECIMAL columns are created without (M, D) while EET is active, so the plain
-        // CAST target below matches the column's type. Reintroducing (M, D) for better coverage would
-        // require tracking it here and emitting the exact precision/scale in the CAST.
         case FLOAT:
+            // FLOAT/DOUBLE columns are created without (M, D) while EET is active (the (M, D) form is deprecated and
+            // not a valid CAST target), so the plain CAST target matches the column's type.
             return CastType.FLOAT;
         case DOUBLE:
             return CastType.DOUBLE;
         case DECIMAL:
-            return CastType.DECIMAL;
+            // DECIMAL columns may carry (M, D); CAST(... AS DECIMAL(M, D)) reproduces the column's exact type. The
+            // schema reports (M, D) even for a plain DECIMAL column (defaulting to (10, 0)).
+            return CastType.decimal(column.getPrecision(), column.getScale());
         default:
             return null;
         }
@@ -259,7 +262,8 @@ public class MySQLEETTransformer extends EETTransformer<MySQLExpression, MySQLCa
 
     /**
      * The common type of several result-type-determining subexpressions, or {@code null} if they do not have the same
-     * inferrable type (a conservative under-approximation of MySQL's aggregation rules).
+     * inferrable type (a conservative under-approximation of MySQL's aggregation rules). Two DECIMAL subexpressions
+     * with differing {@code (M, D)} therefore yield {@code null} rather than a guessed aggregate.
      *
      * @param exprs
      *            the result-type-determining subexpressions
@@ -270,7 +274,8 @@ public class MySQLEETTransformer extends EETTransformer<MySQLExpression, MySQLCa
         CastType common = null;
         for (MySQLExpression expr : exprs) {
             CastType type = inferType(expr);
-            if (type == null || common != null && type != common) {
+            // equals (not ==) so two DECIMAL types with matching (M, D) but distinct instances compare as equal.
+            if (type == null || common != null && !type.equals(common)) {
                 return null;
             }
             common = type;

--- a/test/sqlancer/mysql/MySQLToStringVisitorTest.java
+++ b/test/sqlancer/mysql/MySQLToStringVisitorTest.java
@@ -17,7 +17,7 @@ public class MySQLToStringVisitorTest {
 
     @Test
     void visitAggregateToString() {
-        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0);
+        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0, 0);
         MySQLColumnReference aRef = new MySQLColumnReference(aCol, MySQLConstant.createNullConstant());
 
         MySQLAggregate aggrCount = new MySQLAggregate(List.of(aRef), MySQLAggregate.MySQLAggregateFunction.COUNT);
@@ -35,7 +35,7 @@ public class MySQLToStringVisitorTest {
 
     @Test
     void visitAggregateWithDistinctToString() {
-        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0);
+        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0, 0);
         MySQLColumnReference aRef = new MySQLColumnReference(aCol, MySQLConstant.createNullConstant());
 
         MySQLAggregate aggrCountDistinct = new MySQLAggregate(List.of(aRef),
@@ -57,7 +57,7 @@ public class MySQLToStringVisitorTest {
 
     @Test
     void visitCaseWhenToString() {
-        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0);
+        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0, 0);
         MySQLColumnReference switchExpr = new MySQLColumnReference(aCol, MySQLConstant.createNullConstant());
         List<MySQLExpression> whenExprs = List.of(MySQLIntConstant.createIntConstant(1),
                 MySQLIntConstant.createIntConstant(2));

--- a/test/sqlancer/mysql/ast/MySQLCaseOperatorTest.java
+++ b/test/sqlancer/mysql/ast/MySQLCaseOperatorTest.java
@@ -14,7 +14,7 @@ public class MySQLCaseOperatorTest {
 
     @Test
     void getExpectedValue_switchConditionMatchesWhen_ReturnsThen() {
-        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0);
+        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0, 0);
         MySQLColumnReference switchExpr = new MySQLColumnReference(aCol, MySQLIntConstant.createIntConstant(1));
         List<MySQLExpression> whenExprs = List.of(MySQLIntConstant.createIntConstant(1),
                 MySQLIntConstant.createIntConstant(2));
@@ -29,7 +29,7 @@ public class MySQLCaseOperatorTest {
 
     @Test
     void getExpectedValue_switchConditionHasNoMatches_ReturnsElse() {
-        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0);
+        MySQLSchema.MySQLColumn aCol = new MySQLSchema.MySQLColumn("a", MySQLSchema.MySQLDataType.INT, false, 0, 0);
         MySQLColumnReference switchExpr = new MySQLColumnReference(aCol, MySQLIntConstant.createNullConstant());
         List<MySQLExpression> whenExprs = List.of(MySQLIntConstant.createIntConstant(1),
                 MySQLIntConstant.createIntConstant(2));


### PR DESCRIPTION
## Summary

The EET oracle's type inference previously required `FLOAT`/`DOUBLE`/`DECIMAL` columns to be created without an `(M, D)` precision/scale specifier, because its type-pinning `CAST` (used for the redundant branch of transformation rules No. 3–4) could only target the bare types.

This PR removes the exclusion for `DECIMAL` by tracking a column's exact `(M, D)` end-to-end and reproducing it as `CAST(... AS DECIMAL(M, D))`. `FLOAT`/`DOUBLE` remain excluded under EET. This is because `FLOAT(M, D)`/`DOUBLE(M, D)` is not a valid `CAST` target, so there is no way to reproduce such a column's exact type in a type-pinning cast (also note `FLOAT(M, D)`/`DOUBLE(M, D)` columns are deprecated anyway, but they still remain supported for all other oracles).

## Changes

### Schema — track scale (`MySQLSchema.java`)
- Added a `scale` field (+ `getScale()`) to `MySQLColumn`, read from `information_schema.columns.NUMERIC_SCALE`, alongside the already-read `NUMERIC_PRECISION`.
- The `MySQLColumn` constructor and its single call site now thread `scale` through. `information_schema` always reports a concrete `(M, D)` for a `DECIMAL` column, defaulting to `(10, 0)` when the column was declared without one.

### Type domain — enrich `CastType` (`MySQLCastOperation.java`)
- `MySQLCastOperation.CastType` was changed from a plain `enum` into a small final value class. Its keyword kinds (`SIGNED`, `UNSIGNED`, `CHAR`, `FLOAT`, `DOUBLE`, `DECIMAL`) remain `public static final` singletons (so existing e.g. `== CastType.SIGNED` comparisons are unaffected), while `CastType.decimal(m, d)` produces `DECIMAL` instances carrying `(M, D)`.
- Added `getPrecision`/`getScale`, `equals`/`hashCode` (over kind + `(M, D)`), and a `toString` that renders `DECIMAL(M, D)`.

### Transformer (`MySQLEETTransformer.java`)
- `inferColumnType` maps a `DECIMAL` column to `CastType.decimal(column.getPrecision(), column.getScale())`.
- `commonType` compares with `.equals()` instead of `==`, so two `DECIMAL` subexpressions with matching `(M, D)` (distinct instances) share a type. If `(M, D)` differs, `commonType` conservatively returns `null`, as MySQL's precise aggregation rule in this case is not known.

### Table generation (`MySQLTableGenerator.java`)
- `DECIMAL` has now been reverted to the original behaviour of calling `optionallyAddPrecisionAndScale` (i.e. `(M, D)` is now allowed under EET).
- `FLOAT`/`DOUBLE` route through a new `optionallyAddFloatingPointPrecisionAndScale`, which omits `(M, D)` only while EET is active.