### PR TITLE
Expect the to_char error for RN combined with other formats

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresCommon.java
+++ b/src/sqlancer/postgres/gen/PostgresCommon.java
@@ -123,6 +123,7 @@ public final class PostgresCommon {
         errors.add("cannot use \"PR\" and \"S\"/\"PL\"/\"MI\"/\"SG\" together");
         errors.add("is not a number");
         errors.add("\"EEEE\" must be the last pattern used");
+        errors.add("is incompatible with other formats");
 
         return errors;
     }


### PR DESCRIPTION
## Summary

During a run against postgres:18, a randomly generated `to_char` call was reported as a bug, although PostgreSQL rejected it correctly:

```
postgres=# SELECT to_char(1.5, 'RN0');
ERROR:  "RN" is incompatible with other formats
DETAIL:  "RN" may only be used together with "FM".
```

The message was not registered as an expected error, so SQLancer stopped testing that database. This patch adds it to `getToCharFunctionErrors()`, without the pattern name, so that the entry does not depend on which pattern raises it.

Validating the format in the generator would mean reproducing the format parser of PostgreSQL, since the argument is built from concatenated expressions.

## Testing

`mvn package` passes. A 40 second `--oracle NOREC` run against postgres:18 executed 2814 queries with no thread shutting down.
