### PR TITLE
Do not return null when PostgreSQL tablespaces are disabled

### DIFF
--- a/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
+++ b/src/sqlancer/postgres/gen/PostgresTableSpaceGenerator.java
@@ -1,5 +1,6 @@
 package sqlancer.postgres.gen;
 
+import sqlancer.IgnoreMeException;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
 import sqlancer.postgres.PostgresGlobalState;
@@ -19,10 +20,12 @@ public class PostgresTableSpaceGenerator {
     }
 
     public static SQLQueryAdapter generate(PostgresGlobalState globalState) {
-        // Skip tablespace generation if the option is disabled
+        // PostgresProvider.mapActions does not schedule this action when the option is disabled, but QPG
+        // selects actions by index without consulting the schedule, so the generator has to report that
+        // it has nothing to generate.
         PostgresOptions options = globalState.getDbmsSpecificOptions();
         if (!options.isTestTablespaces()) {
-            return null;
+            throw new IgnoreMeException();
         }
         return new PostgresTableSpaceGenerator(globalState).generateTableSpace();
     }

--- a/test/sqlancer/postgres/gen/TestPostgresTableSpaceGenerator.java
+++ b/test/sqlancer/postgres/gen/TestPostgresTableSpaceGenerator.java
@@ -1,0 +1,25 @@
+package sqlancer.postgres.gen;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import sqlancer.IgnoreMeException;
+import sqlancer.postgres.PostgresGlobalState;
+import sqlancer.postgres.PostgresOptions;
+
+class TestPostgresTableSpaceGenerator {
+
+    @Test
+    void generateIsSkippedWhenTablespacesAreDisabled() {
+        PostgresGlobalState state = new PostgresGlobalState();
+        state.setDbmsSpecificOptions(new PostgresOptions() {
+            @Override
+            public boolean isTestTablespaces() {
+                return false;
+            }
+        });
+
+        assertThrows(IgnoreMeException.class, () -> PostgresTableSpaceGenerator.generate(state));
+    }
+}


### PR DESCRIPTION
## Problem

#1350 stops `CREATE_TABLESPACE` from being scheduled when tablespace testing is disabled, which is the default on every platform other than Linux. QPG reaches the generator through a different path, so with `--qpg-enable true` every worker still dies with a `NullPointerException` on `Query.getLogString()` in `GlobalState.executePrologue`.

## Cause

`ProviderAdapter.mutateTables()` selects a mutation by reward and `PostgresProvider.executeMutator()` resolves it with `Action.values()[index]`. That path does not consult `mapActions()`, so the scheduling guard does not apply to it, `PostgresTableSpaceGenerator.generate()` returns `null`, and `executeStatement()` dereferences it.

`CREATE_TABLESPACE` is the only one of the 28 PostgreSQL actions whose generator can return `null`, so this is the only action affected.

## Reproduction

On macOS or Windows:

```
java -jar target/sqlancer-2.0.0.jar --num-threads 1 --num-queries 20 postgres --oracle NOREC --qpg-enable true --qpg-max-interval 1
```

With the default interval of 1000 the same failure needs a long run, and CI does not see it because it runs on Linux.

## Fix

Throw `IgnoreMeException` from the generator. `mutateTables()` already catches it, so the QPG framework needs no change. The scheduling guard from #1350 stays as it is and remains the reason the generator is never called during database generation.

## Testing

`mvn -Dtest=sqlancer.postgres.gen.TestPostgresTableSpaceGenerator test` passes. Verified on Windows with the reproduction command above: QPG runs to completion.
