### PR TITLE
Implement EET DML oracle (initially for DELETE statements only)

### DIFF
--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -77,7 +77,7 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
 
     /**
      * SQL that assigns every existing row of {@code table} a distinct, stable identifier in the {@link #ROW_ID_COLUMN}
-     * column. DBMS-specific because it names the DBMS's UUID-generating function.
+     * column. For example, a 36-character UUID string.
      *
      * @param table
      *            the table whose rows are stamped
@@ -86,10 +86,19 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      */
     String stampRowIdsStatement(T table);
 
+    /**
+     * The SQL type of the auxiliary {@link #ROW_ID_COLUMN} column. It must be able to hold the identifiers that
+     * {@link #stampRowIdsStatement} produces, so it belongs with that statement as the other half of the row-id
+     * representation. For example, {@code VARCHAR(36)} would fit a 36-character UUID string.
+     *
+     * @return the column type
+     */
+    String rowIdColumnType();
+
     // --- Standard-SQL statements (override only where the DBMS's dialect differs) ---
 
     /**
-     * SQL that adds the auxiliary {@link #ROW_ID_COLUMN} column to {@code table}.
+     * SQL that adds the auxiliary {@link #ROW_ID_COLUMN} column to {@code table}, typed as {@link #rowIdColumnType}.
      *
      * @param table
      *            the table to add the column to
@@ -97,7 +106,7 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      * @return the SQL statement
      */
     default String addRowIdColumnStatement(T table) {
-        return "ALTER TABLE " + table.getName() + " ADD COLUMN " + ROW_ID_COLUMN + " VARCHAR(36)";
+        return "ALTER TABLE " + table.getName() + " ADD COLUMN " + ROW_ID_COLUMN + " " + rowIdColumnType();
     }
 
     /**

--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -1,5 +1,8 @@
 package sqlancer.common.gen;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.oracle.EETTransformer;
 import sqlancer.common.schema.AbstractTable;
@@ -122,17 +125,40 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
     }
 
     /**
-     * SQL that deletes the rows of {@code table} matching {@code predicate}.
+     * SQL that deletes the rows of {@code table} matching {@code predicate}, optionally limited to the first
+     * {@code limit} rows.
+     *
+     * <p>
+     * When {@code limit} is non-null, the statement is ordered by {@code orderByColumns} followed by
+     * {@link #ROW_ID_COLUMN} as a tiebreaker. Because the identifiers are unique, this is always a total order (even when
+     * the ordering columns tie), so the "first {@code limit}" rows are identical for the original and
+     * transformed statements. Varying the ordering columns exercises more access
+     * paths than the row id alone would. The caller must pass the same {@code orderByColumns} and {@code limit}
+     * to both statements; neither is transformed.
      *
      * @param table
      *            the table to delete from
      * @param predicate
      *            the WHERE predicate; rendered via {@link #asString}
+     * @param orderByColumns
+     *            the columns to order by before the row-id tiebreaker (may be empty); only used when {@code limit} is
+     *            non-null
+     * @param limit
+     *            the maximum number of rows to delete, or {@code null} for no limit
      *
      * @return the SQL statement
      */
-    default String deleteStatement(T table, E predicate) {
-        return "DELETE FROM " + table.getName() + " WHERE " + asString(predicate);
+    default String deleteStatement(T table, E predicate, List<C> orderByColumns, Integer limit) {
+        String statement = "DELETE FROM " + table.getName() + " WHERE " + asString(predicate);
+        if (limit != null) {
+            List<String> orderBy = new ArrayList<>();
+            for (C column : orderByColumns) {
+                orderBy.add(column.getName());
+            }
+            orderBy.add(ROW_ID_COLUMN); // unique tiebreaker: guarantees a total order regardless of the columns above
+            statement += " ORDER BY " + String.join(", ", orderBy) + " LIMIT " + limit;
+        }
+        return statement;
     }
 
     /**

--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -130,11 +130,10 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      *
      * <p>
      * When {@code limit} is non-null, the statement is ordered by {@code orderByColumns} followed by
-     * {@link #ROW_ID_COLUMN} as a tiebreaker. Because the identifiers are unique, this is always a total order (even when
-     * the ordering columns tie), so the "first {@code limit}" rows are identical for the original and
-     * transformed statements. Varying the ordering columns exercises more access
-     * paths than the row id alone would. The caller must pass the same {@code orderByColumns} and {@code limit}
-     * to both statements; neither is transformed.
+     * {@link #ROW_ID_COLUMN} as a tiebreaker. Because the identifiers are unique, this is always a total order (even
+     * when the ordering columns tie), so the "first {@code limit}" rows are identical for the original and transformed
+     * statements. Varying the ordering columns exercises more access paths than the row id alone would. The caller must
+     * pass the same {@code orderByColumns} and {@code limit} to both statements; neither is transformed.
      *
      * @param table
      *            the table to delete from

--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -1,0 +1,155 @@
+package sqlancer.common.gen;
+
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.oracle.EETTransformer;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+/**
+ * Generator interface used by {@link sqlancer.common.oracle.EETDMLOracle}, the DML counterpart of {@link EETGenerator}.
+ * It supplies methods which generate the transformable expressions, create the DBMS-specific {@link EETTransformer}
+ * that rewrites them, and produce the SQL of the statements the oracle uses to observe the database state a statement
+ * produces (an approach drawn from the DQE oracle).
+ *
+ * <p>
+ * Adapted from the DQE oracle, state is observed with an auxiliary column ({@link EETDMLGenerator#ROW_ID_COLUMN}) which
+ * uniquely identifies each row. The rows are stamped with identifiers once, before both executions of the statement run
+ * (each in a rolled-back transaction), so both executions observe the same identifiers regardless of how they are
+ * produced.
+ *
+ * <p>
+ * Most of these statements are standard SQL, likely common to most DBMSs, so are provided as {@code default} methods.
+ *
+ * @param <E>
+ *            the DBMS-specific expression class
+ * @param <T>
+ *            the DBMS-specific table class
+ * @param <C>
+ *            the DBMS-specific column class
+ */
+public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>> {
+
+    /** Name of the auxiliary column that uniquely identifies each row. */
+    String ROW_ID_COLUMN = "rowid";
+
+    /**
+     * Restricts this generator to the given tables (a single table, for the DML statement under test) and their
+     * columns.
+     *
+     * @param tables
+     *            the tables (and, implicitly, columns) the generated statement operates on
+     *
+     * @return this generator
+     */
+    EETDMLGenerator<E, T, C> setTablesAndColumns(AbstractTables<T, C> tables);
+
+    /**
+     * Generates a fresh random boolean expression over the current tables' columns, used as the DML statement's WHERE
+     * predicate.
+     *
+     * @return a fresh random boolean expression
+     */
+    E generateBooleanExpression();
+
+    /**
+     * Creates a DBMS-specific {@link EETTransformer} backed by this generator, used to rewrite the statement's
+     * expressions into semantically equivalent ones.
+     *
+     * @return a DBMS-specific {@link EETTransformer}
+     */
+    EETTransformer<E, ?> createTransformer();
+
+    // --- DBMS-specific primitives ---
+
+    /**
+     * Renders an expression to its DBMS-specific SQL string.
+     *
+     * @param expr
+     *            the expression to render
+     *
+     * @return the SQL text of {@code expr}
+     */
+    String asString(E expr);
+
+    /**
+     * SQL that assigns every existing row of {@code table} a distinct, stable identifier in the {@link #ROW_ID_COLUMN}
+     * column. DBMS-specific because it names the DBMS's UUID-generating function.
+     *
+     * @param table
+     *            the table whose rows are stamped
+     *
+     * @return the SQL statement
+     */
+    String stampRowIdsStatement(T table);
+
+    // --- Standard-SQL statements (override only where the DBMS's dialect differs) ---
+
+    /**
+     * SQL that adds the auxiliary {@link #ROW_ID_COLUMN} column to {@code table}.
+     *
+     * @param table
+     *            the table to add the column to
+     *
+     * @return the SQL statement
+     */
+    default String addRowIdColumnStatement(T table) {
+        return "ALTER TABLE " + table.getName() + " ADD COLUMN " + ROW_ID_COLUMN + " VARCHAR(36)";
+    }
+
+    /**
+     * SQL that drops the auxiliary {@link #ROW_ID_COLUMN} column from {@code table}.
+     *
+     * @param table
+     *            the table to drop the column from
+     *
+     * @return the SQL statement
+     */
+    default String dropRowIdColumnStatement(T table) {
+        return "ALTER TABLE " + table.getName() + " DROP COLUMN " + ROW_ID_COLUMN;
+    }
+
+    /**
+     * SQL that selects the {@link #ROW_ID_COLUMN} of every row of {@code table} (the surviving-row snapshot).
+     *
+     * @param table
+     *            the table to snapshot
+     *
+     * @return the SQL statement; its first result column must be the identifiers
+     */
+    default String selectRowIdsStatement(T table) {
+        return "SELECT " + ROW_ID_COLUMN + " FROM " + table.getName();
+    }
+
+    /**
+     * SQL that deletes the rows of {@code table} matching {@code predicate}.
+     *
+     * @param table
+     *            the table to delete from
+     * @param predicate
+     *            the WHERE predicate; rendered via {@link #asString}
+     *
+     * @return the SQL statement
+     */
+    default String deleteStatement(T table, E predicate) {
+        return "DELETE FROM " + table.getName() + " WHERE " + asString(predicate);
+    }
+
+    /**
+     * SQL that starts a transaction, so a statement's effect can be observed and then undone.
+     *
+     * @return the SQL statement
+     */
+    default String beginTransactionStatement() {
+        return "BEGIN";
+    }
+
+    /**
+     * SQL that rolls the current transaction back, undoing the statement's effect.
+     *
+     * @return the SQL statement
+     */
+    default String rollbackTransactionStatement() {
+        return "ROLLBACK";
+    }
+}

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -1,0 +1,158 @@
+package sqlancer.common.oracle;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import sqlancer.ComparatorHelper;
+import sqlancer.IgnoreMeException;
+import sqlancer.Randomly;
+import sqlancer.SQLGlobalState;
+import sqlancer.common.ast.newast.Expression;
+import sqlancer.common.gen.EETDMLGenerator;
+import sqlancer.common.query.ExpectedErrors;
+import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.schema.AbstractSchema;
+import sqlancer.common.schema.AbstractTable;
+import sqlancer.common.schema.AbstractTableColumn;
+import sqlancer.common.schema.AbstractTables;
+
+/**
+ * EET (Equivalent Expression Transformation) oracle for DML statements, based on "Detecting Logic Bugs in Database
+ * Engines via Equivalent Expression Transformation" (Jiang &amp; Su, OSDI'24).
+ *
+ * <p>
+ * Whereas {@link EETOracle} transforms a SELECT and compares the two result sets, this oracle transforms a DML
+ * statement and compares the two database states produced.
+ *
+ * <p>
+ * Adapted from the DQE oracle, state is observed with an auxiliary column ({@link EETDMLGenerator#ROW_ID_COLUMN}) which
+ * uniquely identifies each row, and each statement is executed inside a transaction that is rolled back, so the two
+ * statements can be compared against the same starting state without permanently modifying the database. For a DELETE,
+ * the state is captured as the set of surviving row identifiers. Because rolling back a statement requires a
+ * transactional storage engine, the DBMS-specific setup must ensure only such engines are used while this oracle is
+ * active.
+ *
+ * <p>
+ * Only DELETE is currently supported. Statement reduction is not yet implemented (there is no
+ * {@link sqlancer.Reproducer Reproducer}), so the finding is reported without database reduction.
+ *
+ * @param <E>
+ *            the DBMS-specific expression class
+ * @param <S>
+ *            the DBMS-specific schema class
+ * @param <T>
+ *            the DBMS-specific table class
+ * @param <C>
+ *            the DBMS-specific column class
+ * @param <G>
+ *            the DBMS-specific global state class
+ */
+public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T>, T extends AbstractTable<C, ?, ?>, C extends AbstractTableColumn<?, ?>, G extends SQLGlobalState<?, S>>
+        implements TestOracle<G> {
+
+    private final G state;
+    private EETDMLGenerator<E, T, C> gen;
+    private final EETTransformer<E, ?> transformer;
+    private final ExpectedErrors errors;
+
+    private String generatedQueryString;
+
+    public EETDMLOracle(G state, EETDMLGenerator<E, T, C> gen, ExpectedErrors expectedErrors) {
+        if (state == null || gen == null || expectedErrors == null) {
+            throw new IllegalArgumentException("Null variables used to initialize test oracle.");
+        }
+        this.state = state;
+        this.gen = gen;
+        this.transformer = gen.createTransformer();
+        this.errors = expectedErrors;
+    }
+
+    @Override
+    public void check() throws SQLException {
+        List<T> tables = state.getSchema().getDatabaseTables();
+        if (tables.isEmpty()) {
+            throw new IgnoreMeException();
+        }
+        // DELETE targets a single table, so operate on exactly one; confining the generator to it keeps the predicate
+        // from referencing another table's columns (which would render invalid single-table DML).
+        T table = Randomly.fromList(tables);
+        gen = gen.setTablesAndColumns(new AbstractTables<>(List.of(table)));
+
+        E predicate = gen.generateBooleanExpression();
+        // The WHERE predicate is evaluated in a boolean context.
+        E transformedPredicate = transformer.transform(predicate, true);
+
+        String originalDelete = gen.deleteStatement(table, predicate);
+        String transformedDelete = gen.deleteStatement(table, transformedPredicate);
+        generatedQueryString = originalDelete;
+
+        // Add the auxiliary column outside the try, then guard everything after it with the finally that drops it:
+        // the ALTER auto-commits (it is not undone by ROLLBACK), so a failure between adding and dropping would leak
+        // the column into the next iteration and cause cascading duplicate-column failures.
+        new SQLQueryAdapter(gen.addRowIdColumnStatement(table), true).execute(state);
+        try {
+            // Stamp identifiers once, in autocommit mode, before both DELETEs run: both then observe the same rows.
+            new SQLQueryAdapter(gen.stampRowIdsStatement(table)).execute(state);
+
+            Set<String> originalSurvivors = executeDeleteAndSnapshot(table, originalDelete);
+            Set<String> transformedSurvivors = executeDeleteAndSnapshot(table, transformedDelete);
+
+            if (!originalSurvivors.equals(transformedSurvivors)) {
+                throw new AssertionError(
+                        mismatchMessage(originalDelete, transformedDelete, originalSurvivors, transformedSurvivors));
+            }
+        } finally {
+            new SQLQueryAdapter(gen.dropRowIdColumnStatement(table), true).execute(state);
+        }
+    }
+
+    /**
+     * Executes {@code deleteStatement} inside a transaction that is always rolled back, and returns the set of row
+     * identifiers surviving the DELETE (the resulting database state). A DBMS error expected by the oracle aborts the
+     * whole check ({@link IgnoreMeException}) rather than being reported, matching {@link EETOracle}'s handling; an
+     * unexpected error surfaces as a bug ({@link AssertionError}, thrown by the query adapter).
+     *
+     * @param table
+     *            the table being deleted from
+     * @param deleteStatement
+     *            the DELETE statement to execute
+     *
+     * @return the set of row identifiers surviving the DELETE
+     *
+     * @throws SQLException
+     *             if a DBMS interaction fails
+     */
+    private Set<String> executeDeleteAndSnapshot(T table, String deleteStatement) throws SQLException {
+        new SQLQueryAdapter(gen.beginTransactionStatement()).execute(state);
+        try {
+            // execute reports (throws AssertionError for) unexpected errors and returns false for expected ones.
+            boolean succeeded = new SQLQueryAdapter(deleteStatement, errors).execute(state);
+            if (!succeeded) {
+                // The DELETE hit an error the oracle tolerates; do not compare states (as EETOracle does for SELECT).
+                throw new IgnoreMeException();
+            }
+            return new HashSet<>(
+                    ComparatorHelper.getResultSetFirstColumnAsString(gen.selectRowIdsStatement(table), errors, state));
+        } finally {
+            new SQLQueryAdapter(gen.rollbackTransactionStatement()).execute(state);
+        }
+    }
+
+    private static String mismatchMessage(String originalDelete, String transformedDelete,
+            Set<String> originalSurvivors, Set<String> transformedSurvivors) {
+        return new StringBuilder()
+                .append("-- The original and transformed DELETE statements left the database in different states")
+                .append(" (different sets of surviving rows):").append(System.lineSeparator()).append("-- original (")
+                .append(originalSurvivors.size()).append(" rows survive): ").append(originalDelete).append(';')
+                .append(System.lineSeparator()).append("-- transformed (").append(transformedSurvivors.size())
+                .append(" rows survive): ").append(transformedDelete).append(';').append(System.lineSeparator())
+                .toString();
+    }
+
+    @Override
+    public String getLastQueryString() {
+        return generatedQueryString;
+    }
+}

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -84,8 +84,17 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         // The WHERE predicate is evaluated in a boolean context.
         E transformedPredicate = transformer.transform(predicate, true);
 
-        String originalDelete = gen.deleteStatement(table, predicate);
-        String transformedDelete = gen.deleteStatement(table, transformedPredicate);
+        // Optionally cap the DELETE with a LIMIT. The limit and its ordering (a random column subset, made a total
+        // order by the row-id tiebreaker) are decided once and applied identically to both statements, so the capped
+        // row set is deterministic and equal across the runs while still exercising varied orderings.
+        Integer limit = null;
+        List<C> orderByColumns = List.of();
+        if (Randomly.getBoolean()) {
+            limit = (int) Randomly.getNotCachedInteger(0, 10);
+            orderByColumns = Randomly.subset(table.getColumns());
+        }
+        String originalDelete = gen.deleteStatement(table, predicate, orderByColumns, limit);
+        String transformedDelete = gen.deleteStatement(table, transformedPredicate, orderByColumns, limit);
         generatedQueryString = originalDelete;
 
         // Add the auxiliary column outside the try, then guard everything after it with the finally that drops it:

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -99,11 +99,17 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
 
         // Add the auxiliary column outside the try, then guard everything after it with the finally that drops it:
         // the ALTER auto-commits (it is not undone by ROLLBACK), so a failure between adding and dropping would leak
-        // the column into the next iteration and cause cascading duplicate-column failures.
-        new SQLQueryAdapter(gen.addRowIdColumnStatement(table), true).execute(state);
+        // the column into the next iteration and cause cascading duplicate-column failures. The row-identity setup
+        // touches rows, so — like the DELETE itself — it can raise tolerated errors (e.g. functional-index maintenance
+        // truncation); such an error aborts the iteration (IgnoreMeException) rather than being reported as a bug.
+        if (!new SQLQueryAdapter(gen.addRowIdColumnStatement(table), errors, true).execute(state)) {
+            throw new IgnoreMeException();
+        }
         try {
             // Stamp identifiers once, in autocommit mode, before both DELETEs run: both then observe the same rows.
-            new SQLQueryAdapter(gen.stampRowIdsStatement(table)).execute(state);
+            if (!new SQLQueryAdapter(gen.stampRowIdsStatement(table), errors).execute(state)) {
+                throw new IgnoreMeException();
+            }
 
             Set<String> originalSurvivors = executeDeleteAndSnapshot(table, originalDelete);
             Set<String> transformedSurvivors = executeDeleteAndSnapshot(table, transformedDelete);
@@ -113,7 +119,7 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
                         mismatchMessage(originalDelete, transformedDelete, originalSurvivors, transformedSurvivors));
             }
         } finally {
-            new SQLQueryAdapter(gen.dropRowIdColumnStatement(table), true).execute(state);
+            new SQLQueryAdapter(gen.dropRowIdColumnStatement(table), errors, true).execute(state);
         }
     }
 

--- a/src/sqlancer/mysql/MySQLErrors.java
+++ b/src/sqlancer/mysql/MySQLErrors.java
@@ -66,7 +66,7 @@ public final class MySQLErrors {
     }
 
     public static List<String> getDMLErrors() {
-        ArrayList<String> errors = new ArrayList<>();
+        ArrayList<String> errors = new ArrayList<>(getInsertUpdateErrors());
 
         // WHERE-clause type coercion (e.g. string -> number) is only a warning in SELECT but a hard error in
         // DELETE/UPDATE under strict sql_mode (MySQL 1292). A semantics-preserving transform may benignly change

--- a/src/sqlancer/mysql/MySQLErrors.java
+++ b/src/sqlancer/mysql/MySQLErrors.java
@@ -65,4 +65,21 @@ public final class MySQLErrors {
         errors.addAll(getInsertUpdateErrors());
     }
 
+    public static List<String> getDMLErrors() {
+        ArrayList<String> errors = new ArrayList<>();
+
+        // WHERE-clause type coercion (e.g. string -> number) is only a warning in SELECT but a hard error in
+        // DELETE/UPDATE under strict sql_mode (MySQL 1292). A semantics-preserving transform may benignly change
+        // whether it fires, so it is tolerated rather than flagged.
+        errors.add("Truncated incorrect");
+        // Foreign key constraint failure when deleting/updating a referenced row.
+        errors.add("a foreign key constraint fails");
+
+        return errors;
+    }
+
+    public static void addDMLErrors(ExpectedErrors errors) {
+        errors.addAll(getDMLErrors());
+    }
+
 }

--- a/src/sqlancer/mysql/MySQLGlobalState.java
+++ b/src/sqlancer/mysql/MySQLGlobalState.java
@@ -16,4 +16,13 @@ public class MySQLGlobalState extends SQLGlobalState<MySQLOptions, MySQLSchema> 
         return getDbmsSpecificOptions().oracles.stream().anyMatch(o -> o == MySQLOracleFactory.PQS);
     }
 
+    public boolean usesEET() {
+        return getDbmsSpecificOptions().getTestOracleFactory().stream()
+                .anyMatch(o -> o == MySQLOracleFactory.EET || o == MySQLOracleFactory.EET_DML);
+    }
+
+    public boolean usesEETDML() {
+        return getDbmsSpecificOptions().getTestOracleFactory().stream().anyMatch(o -> o == MySQLOracleFactory.EET_DML);
+    }
+
 }

--- a/src/sqlancer/mysql/MySQLOracleFactory.java
+++ b/src/sqlancer/mysql/MySQLOracleFactory.java
@@ -99,7 +99,11 @@ public enum MySQLOracleFactory implements OracleFactory<MySQLGlobalState> {
         public TestOracle<MySQLGlobalState> create(MySQLGlobalState globalState) throws SQLException {
             MySQLExpressionGenerator gen = new MySQLExpressionGenerator(globalState);
             ExpectedErrors expectedErrors = ExpectedErrors.newErrors().with(MySQLErrors.getExpressionErrors())
-                    .withRegex(MySQLErrors.getExpressionRegexErrors()).with(MySQLErrors.getDMLErrors()).build();
+                    .withRegex(MySQLErrors.getExpressionRegexErrors())
+                    // The DML statements and the row-identity setup (adding/stamping the auxiliary column) touch rows,
+                    // so they can raise the full range of DML errors — e.g. functional-index maintenance truncation —
+                    // beyond the SELECT-based expression errors.
+                    .with(MySQLErrors.getDMLErrors()).build();
             return new EETDMLOracle<>(globalState, gen, expectedErrors);
         }
     };

--- a/src/sqlancer/mysql/MySQLOracleFactory.java
+++ b/src/sqlancer/mysql/MySQLOracleFactory.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import sqlancer.OracleFactory;
 import sqlancer.common.oracle.CERTOracle;
+import sqlancer.common.oracle.EETDMLOracle;
 import sqlancer.common.oracle.EETOracle;
 import sqlancer.common.oracle.TLPWhereOracle;
 import sqlancer.common.oracle.TestOracle;
@@ -91,6 +92,15 @@ public enum MySQLOracleFactory implements OracleFactory<MySQLGlobalState> {
             ExpectedErrors expectedErrors = ExpectedErrors.newErrors().with(MySQLErrors.getExpressionErrors())
                     .withRegex(MySQLErrors.getExpressionRegexErrors()).build();
             return new EETOracle<>(globalState, gen, expectedErrors);
+        }
+    },
+    EET_DML {
+        @Override
+        public TestOracle<MySQLGlobalState> create(MySQLGlobalState globalState) throws SQLException {
+            MySQLExpressionGenerator gen = new MySQLExpressionGenerator(globalState);
+            ExpectedErrors expectedErrors = ExpectedErrors.newErrors().with(MySQLErrors.getExpressionErrors())
+                    .withRegex(MySQLErrors.getExpressionRegexErrors()).with(MySQLErrors.getDMLErrors()).build();
+            return new EETDMLOracle<>(globalState, gen, expectedErrors);
         }
     };
 }

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -388,4 +388,10 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
         // column, delete, snapshot, transaction control) use EETDMLGenerator's defaults.
         return String.format("UPDATE %s SET %s = UUID()", table.getName(), ROW_ID_COLUMN);
     }
+
+    @Override
+    public String rowIdColumnType() {
+        // Holds a 36-character UUID string produced by stampRowIdsStatement.
+        return "VARCHAR(36)";
+    }
 }

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -9,6 +9,7 @@ import java.util.stream.IntStream;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.common.gen.CERTGenerator;
+import sqlancer.common.gen.EETDMLGenerator;
 import sqlancer.common.gen.EETGenerator;
 import sqlancer.common.gen.TLPWhereGenerator;
 import sqlancer.common.gen.UntypedExpressionGenerator;
@@ -19,6 +20,7 @@ import sqlancer.mysql.MySQLGlobalState;
 import sqlancer.mysql.MySQLSchema.MySQLColumn;
 import sqlancer.mysql.MySQLSchema.MySQLRowValue;
 import sqlancer.mysql.MySQLSchema.MySQLTable;
+import sqlancer.mysql.MySQLVisitor;
 import sqlancer.mysql.ast.MySQLAggregate;
 import sqlancer.mysql.ast.MySQLAggregate.MySQLAggregateFunction;
 import sqlancer.mysql.ast.MySQLBetweenOperation;
@@ -52,7 +54,8 @@ import sqlancer.mysql.oracle.MySQLEETTransformer;
 public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLExpression, MySQLColumn>
         implements TLPWhereGenerator<MySQLSelect, MySQLJoin, MySQLExpression, MySQLTable, MySQLColumn>,
         CERTGenerator<MySQLSelect, MySQLJoin, MySQLExpression, MySQLTable, MySQLColumn>,
-        EETGenerator<MySQLSelect, MySQLJoin, MySQLExpression, MySQLTable, MySQLColumn> {
+        EETGenerator<MySQLSelect, MySQLJoin, MySQLExpression, MySQLTable, MySQLColumn>,
+        EETDMLGenerator<MySQLExpression, MySQLTable, MySQLColumn> {
 
     private final MySQLGlobalState state;
     private MySQLRowValue rowVal;
@@ -364,10 +367,25 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
         }
     }
 
-    // --- EET oracle ---
+    // --- EET oracle (including DML) ---
 
     @Override
     public EETTransformer<MySQLExpression, ?> createTransformer() {
         return new MySQLEETTransformer(this);
+    }
+
+    // --- EET DML only ---
+
+    @Override
+    public String asString(MySQLExpression expr) {
+        return MySQLVisitor.asString(expr);
+    }
+
+    @Override
+    public String stampRowIdsStatement(MySQLTable table) {
+        // MySQL's UUID() gives each existing row a distinct value in a single statement. Stamping happens once, before
+        // both rolled-back DELETE runs, so both observe identical identifiers; the standard-SQL statements (add/drop
+        // column, delete, snapshot, transaction control) use EETDMLGenerator's defaults.
+        return String.format("UPDATE %s SET %s = UUID()", table.getName(), ROW_ID_COLUMN);
     }
 }

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -198,7 +198,10 @@ public class MySQLTableGenerator {
                 // "NDB": java.sql.SQLSyntaxErrorException: Unknown storage engine 'NDB'
                 // "EXAMPLE": java.sql.SQLSyntaxErrorException: Unknown storage engine 'EXAMPLE'
                 // "MERGE": java.sql.SQLException: Table 't0' is read only
-                String fromOptions = Randomly.fromOptions("InnoDB", "MyISAM", "MEMORY", "HEAP", "CSV", "ARCHIVE");
+                // The EET DML oracle rolls back each statement to compare database states, which requires a
+                // transactional engine, so only InnoDB is used while it is active.
+                String fromOptions = globalState.usesEETDML() ? "InnoDB"
+                        : Randomly.fromOptions("InnoDB", "MyISAM", "MEMORY", "HEAP", "CSV", "ARCHIVE");
                 this.engine = MySQLEngine.get(fromOptions);
                 sb.append("ENGINE = ");
                 sb.append(fromOptions);
@@ -362,7 +365,8 @@ public class MySQLTableGenerator {
             }
             if (Randomly.getBoolean() && !globalState.getDbmsSpecificOptions().getTestOracleFactory().stream()
                     .anyMatch(o -> o == MySQLOracleFactory.TLP_WHERE || o == MySQLOracleFactory.PQS
-                            || o == MySQLOracleFactory.DQP || o == MySQLOracleFactory.EET)) {
+                            || o == MySQLOracleFactory.DQP || o == MySQLOracleFactory.EET
+                            || o == MySQLOracleFactory.EET_DML)) {
                 sb.append(" ZEROFILL");
             }
         }
@@ -373,9 +377,9 @@ public class MySQLTableGenerator {
     // it is therefore omitted while EET is active. DECIMAL(M, D) has no such restriction: the EET oracle tracks its
     // (M, D) and reproduces it via CAST(... AS DECIMAL(M, D)), so it keeps using optionallyAddPrecisionAndScale.
     private void optionallyAddFloatingPointPrecisionAndScale(StringBuilder sb) {
-        boolean eetActive = globalState.getDbmsSpecificOptions().getTestOracleFactory().stream()
-                .anyMatch(o -> o == MySQLOracleFactory.EET);
-        if (!eetActive) {
+        // Both EET oracles rely on the same type inference (MySQLEETTransformer), so both omit FLOAT(M, D)/DOUBLE(M,
+        // D).
+        if (!globalState.usesEET()) {
             optionallyAddPrecisionAndScale(sb);
         }
     }


### PR DESCRIPTION
## Summary

The EET oracle previously only transformed `SELECT` queries and compared the two result sets. This PR adds a DML variant, `EETDMLOracle`, that transforms a DML statement's expressions and compares the two database states the original and transformed statements leave behind.

To observe the database state, a similar approach to the DQE oracle is used: add an auxiliary column that uniquely identifies each row, and run each statement inside a transaction that is rolled back. This way, the original and transformed statements can each be measured against the same starting state without permanently mutating the database.

Only `DELETE` is implemented in this PR, as it is the simplest (its only transformable site is the `WHERE` predicate, and row identity alone is a sufficient comparison surface). The generic infrastructure is designed so `UPDATE` and `INSERT` can be added later without rework. MySQL is included as a specific DBMS implementation.

The expression transformer (`EETTransformer` / `MySQLEETTransformer`) is statement-agnostic and remains unchanged.

## Changes

### Dedicated new oracle (`common/oracle/EETDMLOracle.java`)

`check()`:
1. Pick a single target table from the schema and confine the generator's column pool to it.
2. Generate the `WHERE` predicate `p`; transform it in a boolean context (`transformer.transform(p, true)`).
3. Assemble the original and transformed `DELETE` strings via the generator.
4. `ADD COLUMN rowid`; then, inside a `try` whose `finally` drops the column, stamp every row once with a unique id.
5. For each `DELETE` (original, then transformed): `BEGIN`; run it; snapshot the surviving `rowid`s; `ROLLBACK` (rollback in a `finally`).
6. Compare the two surviving-`rowid` sets; on mismatch throw an `AssertionError` whose message embeds both statement strings.

Error handling mirrors the SELECT oracle: an expected DBMS error (on the `ExpectedErrors` allow-list) aborts the iteration via `IgnoreMeException`, while an unexpected error surfaces as a reported bug.

Test case reduction will be implemented at a later stage.

### New generator interface (`common/gen/EETDMLGenerator.java`)

A sibling of `EETGenerator`, supplying the DBMS-specific pieces the DML oracle needs.

- Abstract methods: `generateBooleanExpression()` (the predicate), `createTransformer()`, `setTablesAndColumns(...)`, `asString(E)` (render an expression), and `stampRowIdsStatement(T)` (assign every existing row a unique id).
- Default methods: `addRowIdColumnStatement` / `dropRowIdColumnStatement` / `selectRowIdsStatement` / `deleteStatement` / `beginTransactionStatement` / `rollbackTransactionStatement`.

### MySQL generator (`mysql/gen/MySQLExpressionGenerator.java`)

Now also implements `EETDMLGenerator<MySQLExpression, MySQLTable, MySQLColumn>`. It reuses the existing `generateBooleanExpression` / `createTransformer` / `setTablesAndColumns` and adds only `asString` and `stampRowIdsStatement`.

### Oracle registration (`mysql/MySQLOracleFactory.java`)

New `EET_DML` enum entry that constructs an `EETDMLOracle` with existing expected errors plus a couple of extra ones encountered.

### Table generation (`mysql/gen/MySQLTableGenerator.java`)

The `ENGINE` table option is forced to `InnoDB` if EET DML is being used (checked with `usesEETDML()` method). This is because it is the only transactional engine, and the test procedure relies on transactions.

## Follow-ups (to be integrated into same oracle)

- `UPDATE` support
- `INSERT` support
- Test case reduction, modelled on `EETReproducer` used for the SELECT oracle.