### PR TITLE
Extend the EET DML oracle to UPDATE support

### DIFF
--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -2,6 +2,7 @@ package sqlancer.common.gen;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.oracle.EETTransformer;
@@ -19,7 +20,8 @@ import sqlancer.common.schema.AbstractTables;
  * Adapted from the DQE oracle, state is observed with an auxiliary column ({@link EETDMLGenerator#ROW_ID_COLUMN}) which
  * uniquely identifies each row. The rows are stamped with identifiers once, before both executions of the statement run
  * (each in a rolled-back transaction), so both executions observe the same identifiers regardless of how they are
- * produced.
+ * produced. The resulting state is compared as a full post-image (each surviving row's identifier and content column
+ * values), which covers every DML statement: a DELETE removes rows from it, an UPDATE changes values in it.
  *
  * <p>
  * Most of these statements are standard SQL, likely common to most DBMSs, so are provided as {@code default} methods.
@@ -54,6 +56,15 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      * @return a fresh random boolean expression
      */
     E generateBooleanExpression();
+
+    /**
+     * Generates a fresh set of {@code column = value} assignments over the current tables' columns, used as an UPDATE
+     * statement's SET clause. The columns are a random non-empty subset and each value is a fresh random expression;
+     * both the columns and their assigned expressions are transformed by the oracle.
+     *
+     * @return the assignments, as {@code (column, value expression)} pairs (at least one)
+     */
+    List<Map.Entry<C, E>> generateSetAssignments();
 
     /**
      * Creates a DBMS-specific {@link EETTransformer} backed by this generator, used to rewrite the statement's
@@ -122,27 +133,32 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
     }
 
     /**
-     * SQL that selects the {@link #ROW_ID_COLUMN} of every row of {@code table} (the surviving-row snapshot).
+     * SQL that reads back the full post-image of {@code table}: the {@link #ROW_ID_COLUMN} identifier and every content
+     * column of every surviving row, ordered by the (unique) identifier so the two statements' snapshots align
+     * row-for-row.
+     *
+     * <p>
+     * This single value-level snapshot is the comparison surface for all DML statements: a DELETE removes rows from it,
+     * an UPDATE changes column values in it. Row identity alone (which the identifier already captures) would suffice
+     * for DELETE, but not for UPDATE, where the two runs could touch the same rows yet write different values.
      *
      * @param table
      *            the table to snapshot
      *
-     * @return the SQL statement; its first result column must be the identifiers
+     * @return the SQL statement; its first result column is the identifier, followed by {@code table}'s content columns
      */
-    default String selectRowIdsStatement(T table) {
-        return "SELECT " + ROW_ID_COLUMN + " FROM " + table.getName();
+    default String selectPostImageStatement(T table) {
+        List<String> selected = new ArrayList<>();
+        selected.add(ROW_ID_COLUMN);
+        for (C column : table.getColumns()) {
+            selected.add(column.getName());
+        }
+        return "SELECT " + String.join(", ", selected) + " FROM " + table.getName() + " ORDER BY " + ROW_ID_COLUMN;
     }
 
     /**
      * SQL that deletes the rows of {@code table} matching {@code predicate}, optionally limited to the first
-     * {@code limit} rows.
-     *
-     * <p>
-     * When {@code limit} is non-null, the statement is ordered by {@code orderByColumns} followed by
-     * {@link #ROW_ID_COLUMN} as a tiebreaker. Because the identifiers are unique, this is always a total order (even
-     * when the ordering columns tie), so the "first {@code limit}" rows are identical for the original and transformed
-     * statements. Varying the ordering columns exercises more access paths than the row id alone would. The caller must
-     * pass the same {@code orderByColumns} and {@code limit} to both statements; neither is transformed.
+     * {@code limit} rows (see {@link #orderByLimitClause}).
      *
      * @param table
      *            the table to delete from
@@ -157,16 +173,67 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      * @return the SQL statement
      */
     default String deleteStatement(T table, E predicate, List<C> orderByColumns, Integer limit) {
-        String statement = "DELETE FROM " + table.getName() + " WHERE " + asString(predicate);
-        if (limit != null) {
-            List<String> orderBy = new ArrayList<>();
-            for (C column : orderByColumns) {
-                orderBy.add(column.getName());
-            }
-            orderBy.add(ROW_ID_COLUMN); // unique tiebreaker: guarantees a total order regardless of the columns above
-            statement += " ORDER BY " + String.join(", ", orderBy) + " LIMIT " + limit;
+        return "DELETE FROM " + table.getName() + " WHERE " + asString(predicate)
+                + orderByLimitClause(orderByColumns, limit);
+    }
+
+    /**
+     * SQL that updates the rows of {@code table} matching {@code predicate}, setting each column in {@code assignments}
+     * to its assigned value expression, optionally limited to the first {@code limit} rows (see
+     * {@link #orderByLimitClause}).
+     *
+     * @param table
+     *            the table to update
+     * @param assignments
+     *            the {@code (column, value expression)} pairs to assign; each value is rendered via {@link #asString}
+     * @param predicate
+     *            the WHERE predicate; rendered via {@link #asString}
+     * @param orderByColumns
+     *            the columns to order by before the row-id tiebreaker (may be empty); only used when {@code limit} is
+     *            non-null
+     * @param limit
+     *            the maximum number of rows to update, or {@code null} for no limit
+     *
+     * @return the SQL statement
+     */
+    default String updateStatement(T table, List<Map.Entry<C, E>> assignments, E predicate, List<C> orderByColumns,
+            Integer limit) {
+        List<String> setClauses = new ArrayList<>();
+        for (Map.Entry<C, E> assignment : assignments) {
+            setClauses.add(assignment.getKey().getName() + " = " + asString(assignment.getValue()));
         }
-        return statement;
+        return "UPDATE " + table.getName() + " SET " + String.join(", ", setClauses) + " WHERE " + asString(predicate)
+                + orderByLimitClause(orderByColumns, limit);
+    }
+
+    /**
+     * Renders the trailing {@code ORDER BY ... LIMIT n} clause shared by {@link #deleteStatement} and
+     * {@link #updateStatement}, or the empty string when {@code limit} is null.
+     *
+     * <p>
+     * The rows are ordered by {@code orderByColumns} followed by {@link #ROW_ID_COLUMN} as a tiebreaker. Because the
+     * identifiers are unique, this is always a total order (even when the ordering columns tie), so the "first
+     * {@code limit}" rows are identical for the original and transformed statements. Varying the ordering columns
+     * exercises more access paths than the row id alone would. The caller must pass the same {@code orderByColumns} and
+     * {@code limit} to both statements; neither is transformed.
+     *
+     * @param orderByColumns
+     *            the columns to order by before the row-id tiebreaker (may be empty)
+     * @param limit
+     *            the maximum number of rows, or {@code null} for no limit (yielding an empty clause)
+     *
+     * @return the {@code ORDER BY ... LIMIT n} clause, or the empty string when {@code limit} is null
+     */
+    default String orderByLimitClause(List<C> orderByColumns, Integer limit) {
+        if (limit == null) {
+            return "";
+        }
+        List<String> orderBy = new ArrayList<>();
+        for (C column : orderByColumns) {
+            orderBy.add(column.getName());
+        }
+        orderBy.add(ROW_ID_COLUMN); // unique tiebreaker: guarantees a total order regardless of the columns above
+        return " ORDER BY " + String.join(", ", orderBy) + " LIMIT " + limit;
     }
 
     /**

--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -145,15 +145,31 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      * @param table
      *            the table to snapshot
      *
-     * @return the SQL statement; its first result column is the identifier, followed by {@code table}'s content columns
+     * @return the SQL statement; its result columns are those of {@link #postImageColumns}, in that order
      */
     default String selectPostImageStatement(T table) {
-        List<String> selected = new ArrayList<>();
-        selected.add(ROW_ID_COLUMN);
+        return "SELECT " + String.join(", ", postImageColumns(table)) + " FROM " + table.getName() + " ORDER BY "
+                + ROW_ID_COLUMN;
+    }
+
+    /**
+     * The columns a post-image row consists of, in the order {@link #selectPostImageStatement} returns them: the
+     * {@link #ROW_ID_COLUMN} identifier followed by {@code table}'s content columns. This is the sole definition of the
+     * post-image layout, so a consumer can find the identifier's position by looking up {@link #ROW_ID_COLUMN} here
+     * rather than assuming one.
+     *
+     * @param table
+     *            the table being snapshot
+     *
+     * @return the post-image column names, in order
+     */
+    default List<String> postImageColumns(T table) {
+        List<String> columns = new ArrayList<>();
+        columns.add(ROW_ID_COLUMN);
         for (C column : table.getColumns()) {
-            selected.add(column.getName());
+            columns.add(column.getName());
         }
-        return "SELECT " + String.join(", ", selected) + " FROM " + table.getName() + " ORDER BY " + ROW_ID_COLUMN;
+        return columns;
     }
 
     /**

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -104,23 +104,11 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
             orderByColumns = Randomly.subset(table.getColumns());
         }
 
-        String originalStatement;
-        String transformedStatement;
-        if (Randomly.getBoolean()) {
-            // UPDATE also transforms the written values: each SET value expression is transformed in a scalar context.
-            List<Map.Entry<C, E>> assignments = gen.generateSetAssignments();
-            List<Map.Entry<C, E>> transformedAssignments = new ArrayList<>();
-            for (Map.Entry<C, E> assignment : assignments) {
-                E transformedValue = transformer.transform(assignment.getValue(), false);
-                transformedAssignments.add(new AbstractMap.SimpleEntry<>(assignment.getKey(), transformedValue));
-            }
-            originalStatement = gen.updateStatement(table, assignments, predicate, orderByColumns, limit);
-            transformedStatement = gen.updateStatement(table, transformedAssignments, transformedPredicate,
-                    orderByColumns, limit);
-        } else {
-            originalStatement = gen.deleteStatement(table, predicate, orderByColumns, limit);
-            transformedStatement = gen.deleteStatement(table, transformedPredicate, orderByColumns, limit);
-        }
+        StatementPair statements = Randomly.getBoolean()
+                ? generateUpdateStatements(table, predicate, transformedPredicate, orderByColumns, limit)
+                : generateDeleteStatements(table, predicate, transformedPredicate, orderByColumns, limit);
+        String originalStatement = statements.original;
+        String transformedStatement = statements.transformed;
         generatedQueryString = originalStatement;
 
         int columnCount = gen.postImageColumns(table).size();
@@ -147,6 +135,70 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         } finally {
             new SQLQueryAdapter(gen.dropRowIdColumnStatement(table), errors, true).execute(state);
         }
+    }
+
+    /**
+     * A DML statement and its transformed counterpart, which must leave the database in the same state.
+     */
+    private static final class StatementPair {
+        private final String original;
+        private final String transformed;
+
+        StatementPair(String original, String transformed) {
+            this.original = original;
+            this.transformed = transformed;
+        }
+    }
+
+    /**
+     * Generates an UPDATE and its transformed counterpart. Besides the WHERE predicate, UPDATE also transforms the
+     * written values: each SET value expression is transformed in a scalar context.
+     *
+     * @param table
+     *            the table being modified
+     * @param predicate
+     *            the WHERE predicate of the original statement
+     * @param transformedPredicate
+     *            the transformed WHERE predicate, used by the transformed statement
+     * @param orderByColumns
+     *            the columns ordering the statement, empty if it is not capped by a limit
+     * @param limit
+     *            the maximum number of rows to modify, or {@code null} for no limit
+     *
+     * @return the original statement together with its transformed counterpart
+     */
+    private StatementPair generateUpdateStatements(T table, E predicate, E transformedPredicate, List<C> orderByColumns,
+            Integer limit) {
+        List<Map.Entry<C, E>> assignments = gen.generateSetAssignments();
+        List<Map.Entry<C, E>> transformedAssignments = new ArrayList<>();
+        for (Map.Entry<C, E> assignment : assignments) {
+            E transformedValue = transformer.transform(assignment.getValue(), false);
+            transformedAssignments.add(new AbstractMap.SimpleEntry<>(assignment.getKey(), transformedValue));
+        }
+        return new StatementPair(gen.updateStatement(table, assignments, predicate, orderByColumns, limit),
+                gen.updateStatement(table, transformedAssignments, transformedPredicate, orderByColumns, limit));
+    }
+
+    /**
+     * Generates a DELETE and its transformed counterpart, which differ only in their WHERE predicate.
+     *
+     * @param table
+     *            the table being modified
+     * @param predicate
+     *            the WHERE predicate of the original statement
+     * @param transformedPredicate
+     *            the transformed WHERE predicate, used by the transformed statement
+     * @param orderByColumns
+     *            the columns ordering the statement, empty if it is not capped by a limit
+     * @param limit
+     *            the maximum number of rows to modify, or {@code null} for no limit
+     *
+     * @return the original statement together with its transformed counterpart
+     */
+    private StatementPair generateDeleteStatements(T table, E predicate, E transformedPredicate, List<C> orderByColumns,
+            Integer limit) {
+        return new StatementPair(gen.deleteStatement(table, predicate, orderByColumns, limit),
+                gen.deleteStatement(table, transformedPredicate, orderByColumns, limit));
     }
 
     /**

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -1,11 +1,11 @@
 package sqlancer.common.oracle;
 
 import java.sql.SQLException;
-import java.util.HashSet;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
-import sqlancer.ComparatorHelper;
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
 import sqlancer.SQLGlobalState;
@@ -13,6 +13,7 @@ import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.gen.EETDMLGenerator;
 import sqlancer.common.query.ExpectedErrors;
 import sqlancer.common.query.SQLQueryAdapter;
+import sqlancer.common.query.SQLancerResultSet;
 import sqlancer.common.schema.AbstractSchema;
 import sqlancer.common.schema.AbstractTable;
 import sqlancer.common.schema.AbstractTableColumn;
@@ -29,14 +30,17 @@ import sqlancer.common.schema.AbstractTables;
  * <p>
  * Adapted from the DQE oracle, state is observed with an auxiliary column ({@link EETDMLGenerator#ROW_ID_COLUMN}) which
  * uniquely identifies each row, and each statement is executed inside a transaction that is rolled back, so the two
- * statements can be compared against the same starting state without permanently modifying the database. For a DELETE,
- * the state is captured as the set of surviving row identifiers. Because rolling back a statement requires a
- * transactional storage engine, the DBMS-specific setup must ensure only such engines are used while this oracle is
- * active.
+ * statements can be compared against the same starting state without permanently modifying the database. The state is
+ * captured as a full post-image: each surviving row's identifier together with its content column values, ordered by
+ * the identifier. This single value-level surface covers every DML statement — a DELETE removes rows from it, an UPDATE
+ * changes values in it (row identity alone would suffice for DELETE, but not for UPDATE, which also transforms the
+ * written values). Because rolling back a statement requires a transactional storage engine, the DBMS-specific setup
+ * must ensure only such engines are used while this oracle is active.
  *
  * <p>
- * Only DELETE is currently supported. Statement reduction is not yet implemented (there is no
- * {@link sqlancer.Reproducer Reproducer}), so the finding is reported without database reduction.
+ * DELETE and UPDATE are currently supported (one is chosen at random per check). Statement reduction is not yet
+ * implemented (there is no {@link sqlancer.Reproducer Reproducer}), so the finding is reported without database
+ * reduction.
  *
  * @param <E>
  *            the DBMS-specific expression class
@@ -75,8 +79,9 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         if (tables.isEmpty()) {
             throw new IgnoreMeException();
         }
-        // DELETE targets a single table, so operate on exactly one; confining the generator to it keeps the predicate
-        // from referencing another table's columns (which would render invalid single-table DML).
+        // A DML statement targets a single table, so operate on exactly one; confining the generator to it keeps the
+        // predicate and value expressions from referencing another table's columns (which would render invalid
+        // single-table DML).
         T table = Randomly.fromList(tables);
         gen = gen.setTablesAndColumns(new AbstractTables<>(List.of(table)));
 
@@ -84,7 +89,7 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         // The WHERE predicate is evaluated in a boolean context.
         E transformedPredicate = transformer.transform(predicate, true);
 
-        // Optionally cap the DELETE with a LIMIT. The limit and its ordering (a random column subset, made a total
+        // Optionally cap the statement with a LIMIT. The limit and its ordering (a random column subset, made a total
         // order by the row-id tiebreaker) are decided once and applied identically to both statements, so the capped
         // row set is deterministic and equal across the runs while still exercising varied orderings.
         Integer limit = null;
@@ -93,30 +98,47 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
             limit = (int) Randomly.getNotCachedInteger(0, 10);
             orderByColumns = Randomly.subset(table.getColumns());
         }
-        String originalDelete = gen.deleteStatement(table, predicate, orderByColumns, limit);
-        String transformedDelete = gen.deleteStatement(table, transformedPredicate, orderByColumns, limit);
-        generatedQueryString = originalDelete;
 
-        // Add the auxiliary column outside the try, then guard everything after it with the finally that drops it:
-        // the ALTER auto-commits (it is not undone by ROLLBACK), so a failure between adding and dropping would leak
-        // the column into the next iteration and cause cascading duplicate-column failures. The row-identity setup
-        // touches rows, so — like the DELETE itself — it can raise tolerated errors (e.g. functional-index maintenance
-        // truncation); such an error aborts the iteration (IgnoreMeException) rather than being reported as a bug.
+        String originalStatement;
+        String transformedStatement;
+        if (Randomly.getBoolean()) {
+            // UPDATE also transforms the written values: each SET value expression is transformed in a scalar context.
+            List<Map.Entry<C, E>> assignments = gen.generateSetAssignments();
+            List<Map.Entry<C, E>> transformedAssignments = new ArrayList<>();
+            for (Map.Entry<C, E> assignment : assignments) {
+                E transformedValue = transformer.transform(assignment.getValue(), false);
+                transformedAssignments.add(new AbstractMap.SimpleEntry<>(assignment.getKey(), transformedValue));
+            }
+            originalStatement = gen.updateStatement(table, assignments, predicate, orderByColumns, limit);
+            transformedStatement = gen.updateStatement(table, transformedAssignments, transformedPredicate,
+                    orderByColumns, limit);
+        } else {
+            originalStatement = gen.deleteStatement(table, predicate, orderByColumns, limit);
+            transformedStatement = gen.deleteStatement(table, transformedPredicate, orderByColumns, limit);
+        }
+        generatedQueryString = originalStatement;
+
+        // The post-image select reads the identifier plus every content column of the table, in that order.
+        int columnCount = table.getColumns().size() + 1;
+
+        // Add the auxiliary column outside the try, then guard everything after it with the finally that drops it: the
+        // ALTER auto-commits (it is not undone by ROLLBACK), so a failure between adding and dropping would leak the
+        // column and cause cascading duplicate-column failures
         if (!new SQLQueryAdapter(gen.addRowIdColumnStatement(table), errors, true).execute(state)) {
             throw new IgnoreMeException();
         }
         try {
-            // Stamp identifiers once, in autocommit mode, before both DELETEs run: both then observe the same rows.
+            // Stamp identifiers once, in autocommit mode, before both runs: both then observe the same rows.
             if (!new SQLQueryAdapter(gen.stampRowIdsStatement(table), errors).execute(state)) {
                 throw new IgnoreMeException();
             }
 
-            Set<String> originalSurvivors = executeDeleteAndSnapshot(table, originalDelete);
-            Set<String> transformedSurvivors = executeDeleteAndSnapshot(table, transformedDelete);
+            List<List<String>> originalImage = executeAndSnapshotPostImage(table, originalStatement, columnCount);
+            List<List<String>> transformedImage = executeAndSnapshotPostImage(table, transformedStatement, columnCount);
 
-            if (!originalSurvivors.equals(transformedSurvivors)) {
+            if (!originalImage.equals(transformedImage)) {
                 throw new AssertionError(
-                        mismatchMessage(originalDelete, transformedDelete, originalSurvivors, transformedSurvivors));
+                        mismatchMessage(originalStatement, transformedStatement, originalImage, transformedImage));
             }
         } finally {
             new SQLQueryAdapter(gen.dropRowIdColumnStatement(table), errors, true).execute(state);
@@ -124,46 +146,102 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
     }
 
     /**
-     * Executes {@code deleteStatement} inside a transaction that is always rolled back, and returns the set of row
-     * identifiers surviving the DELETE (the resulting database state). A DBMS error expected by the oracle aborts the
-     * whole check ({@link IgnoreMeException}) rather than being reported, matching {@link EETOracle}'s handling; an
-     * unexpected error surfaces as a bug ({@link AssertionError}, thrown by the query adapter).
+     * Executes {@code statement} inside a transaction that is always rolled back, and returns the resulting post-image:
+     * the surviving rows' identifier and content column values, ordered by identifier (the resulting database state). A
+     * DBMS error the oracle tolerates aborts with {@link IgnoreMeException}; an oracle logic bug or unexpected error
+     * surfaces as {@link AssertionError}.
      *
      * @param table
-     *            the table being deleted from
-     * @param deleteStatement
-     *            the DELETE statement to execute
+     *            the table being modified
+     * @param statement
+     *            the DML statement to execute
+     * @param columnCount
+     *            the number of columns the post-image select returns (identifier plus content columns)
      *
-     * @return the set of row identifiers surviving the DELETE
+     * @return the post-image, as one string list (identifier followed by content column values) per surviving row
      *
      * @throws SQLException
-     *             if a DBMS interaction fails
+     *             if a DBMS interaction other than running {@code statement} fails; an error from {@code statement}
+     *             itself instead surfaces as {@link IgnoreMeException} or {@link AssertionError}
      */
-    private Set<String> executeDeleteAndSnapshot(T table, String deleteStatement) throws SQLException {
+    private List<List<String>> executeAndSnapshotPostImage(T table, String statement, int columnCount)
+            throws SQLException {
         new SQLQueryAdapter(gen.beginTransactionStatement()).execute(state);
         try {
             // execute reports (throws AssertionError for) unexpected errors and returns false for expected ones.
-            boolean succeeded = new SQLQueryAdapter(deleteStatement, errors).execute(state);
+            boolean succeeded = new SQLQueryAdapter(statement, errors).execute(state);
             if (!succeeded) {
-                // The DELETE hit an error the oracle tolerates; do not compare states (as EETOracle does for SELECT).
+                // The statement hit an error the oracle tolerates; do not compare states (as EETOracle does for
+                // SELECT).
                 throw new IgnoreMeException();
             }
-            return new HashSet<>(
-                    ComparatorHelper.getResultSetFirstColumnAsString(gen.selectRowIdsStatement(table), errors, state));
+            return snapshotPostImage(gen.selectPostImageStatement(table), columnCount);
         } finally {
             new SQLQueryAdapter(gen.rollbackTransactionStatement()).execute(state);
         }
     }
 
-    private static String mismatchMessage(String originalDelete, String transformedDelete,
-            Set<String> originalSurvivors, Set<String> transformedSurvivors) {
+    /**
+     * Reads the post-image produced by {@code selectStatement} into one string list per row (each column via
+     * {@code getString}). A DBMS error the oracle tolerates aborts with {@link IgnoreMeException}; an oracle logic bug
+     * or unexpected error surfaces as {@link AssertionError}.
+     *
+     * @param selectStatement
+     *            the post-image select to read; its columns are the identifier followed by the content columns
+     * @param columnCount
+     *            the number of columns to read from each row
+     *
+     * @return the read rows, in the select's order
+     *
+     * @throws SQLException
+     *             if cleanup fails (errors thrown elsewhere will always be rethrown as {@link IgnoreMeException} or
+     *             {@link AssertionError})
+     */
+    private List<List<String>> snapshotPostImage(String selectStatement, int columnCount) throws SQLException {
+        List<List<String>> rows = new ArrayList<>();
+        SQLQueryAdapter q = new SQLQueryAdapter(selectStatement, errors, true,
+                state.getOptions().canonicalizeSqlString());
+        SQLancerResultSet result = null;
+        try {
+            result = q.executeAndGet(state);
+            if (result == null) {
+                throw new IgnoreMeException();
+            }
+            while (result.next()) {
+                List<String> row = new ArrayList<>(columnCount);
+                for (int i = 1; i <= columnCount; i++) {
+                    row.add(result.getString(i));
+                }
+                rows.add(row);
+            }
+        } catch (Exception e) {
+            if (e instanceof IgnoreMeException) {
+                throw e;
+            }
+            Throwable current = e;
+            while (current != null) {
+                if (current.getMessage() != null && errors.errorIsExpected(current.getMessage())) {
+                    throw new IgnoreMeException();
+                }
+                current = current.getCause();
+            }
+            throw new AssertionError(selectStatement, e);
+        } finally {
+            if (result != null && !result.isClosed()) {
+                result.close();
+            }
+        }
+        return rows;
+    }
+
+    private static String mismatchMessage(String originalStatement, String transformedStatement,
+            List<List<String>> originalImage, List<List<String>> transformedImage) {
         return new StringBuilder()
-                .append("-- The original and transformed DELETE statements left the database in different states")
-                .append(" (different sets of surviving rows):").append(System.lineSeparator()).append("-- original (")
-                .append(originalSurvivors.size()).append(" rows survive): ").append(originalDelete).append(';')
-                .append(System.lineSeparator()).append("-- transformed (").append(transformedSurvivors.size())
-                .append(" rows survive): ").append(transformedDelete).append(';').append(System.lineSeparator())
-                .toString();
+                .append("-- The original and transformed statements left the database in different states")
+                .append(" (different post-images):").append(System.lineSeparator()).append("-- original (")
+                .append(originalImage.size()).append(" rows): ").append(originalStatement).append(';')
+                .append(System.lineSeparator()).append("-- transformed (").append(transformedImage.size())
+                .append(" rows): ").append(transformedStatement).append(';').append(System.lineSeparator()).toString();
     }
 
     @Override

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -123,8 +123,7 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         }
         generatedQueryString = originalStatement;
 
-        // The post-image select reads the identifier plus every content column of the table, in that order.
-        int columnCount = table.getColumns().size() + 1;
+        int columnCount = gen.postImageColumns(table).size();
 
         // Add the auxiliary column outside the try, then guard everything after it with the finally that drops it: the
         // ALTER auto-commits (it is not undone by ROLLBACK), so a failure between adding and dropping would leak the
@@ -241,14 +240,12 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
 
     private String mismatchMessage(T table, String originalStatement, String transformedStatement,
             List<List<String>> originalImage, List<List<String>> transformedImage) {
-        List<String> header = new ArrayList<>();
-        header.add(EETDMLGenerator.ROW_ID_COLUMN);
-        for (C column : table.getColumns()) {
-            header.add(column.getName());
-        }
+        List<String> header = gen.postImageColumns(table);
+        // Where the identifier sits within a post-image row, per the layout the generator defines
+        int rowIdIndex = header.indexOf(EETDMLGenerator.ROW_ID_COLUMN);
 
-        Map<String, List<String>> originalByRowId = indexByRowId(originalImage);
-        Map<String, List<String>> transformedByRowId = indexByRowId(transformedImage);
+        Map<String, List<String>> originalByRowId = indexByRowId(originalImage, rowIdIndex);
+        Map<String, List<String>> transformedByRowId = indexByRowId(transformedImage, rowIdIndex);
         Set<String> allRowIds = new TreeSet<>();
         allRowIds.addAll(originalByRowId.keySet());
         allRowIds.addAll(transformedByRowId.keySet());
@@ -277,11 +274,11 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         return message.toString();
     }
 
-    // Indexes a post-image by its row identifier (the first column of each row)
-    private static Map<String, List<String>> indexByRowId(List<List<String>> image) {
+    // Indexes a post-image by its row identifier, which each row holds at rowIdIndex
+    private static Map<String, List<String>> indexByRowId(List<List<String>> image, int rowIdIndex) {
         Map<String, List<String>> byRowId = new LinkedHashMap<>();
         for (List<String> row : image) {
-            byRowId.put(row.get(0), row);
+            byRowId.put(row.get(rowIdIndex), row);
         }
         return byRowId;
     }

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -3,8 +3,12 @@ package sqlancer.common.oracle;
 import java.sql.SQLException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
@@ -61,6 +65,7 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
     private final EETTransformer<E, ?> transformer;
     private final ExpectedErrors errors;
 
+    private static final int MAX_DIFF_ROWS_REPORTED = 10; // max differing post-image rows displayed in report log
     private String generatedQueryString;
 
     public EETDMLOracle(G state, EETDMLGenerator<E, T, C> gen, ExpectedErrors expectedErrors) {
@@ -137,8 +142,8 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
             List<List<String>> transformedImage = executeAndSnapshotPostImage(table, transformedStatement, columnCount);
 
             if (!originalImage.equals(transformedImage)) {
-                throw new AssertionError(
-                        mismatchMessage(originalStatement, transformedStatement, originalImage, transformedImage));
+                throw new AssertionError(mismatchMessage(table, originalStatement, transformedStatement, originalImage,
+                        transformedImage));
             }
         } finally {
             new SQLQueryAdapter(gen.dropRowIdColumnStatement(table), errors, true).execute(state);
@@ -234,14 +239,56 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         return rows;
     }
 
-    private static String mismatchMessage(String originalStatement, String transformedStatement,
+    private String mismatchMessage(T table, String originalStatement, String transformedStatement,
             List<List<String>> originalImage, List<List<String>> transformedImage) {
-        return new StringBuilder()
-                .append("-- The original and transformed statements left the database in different states")
-                .append(" (different post-images):").append(System.lineSeparator()).append("-- original (")
-                .append(originalImage.size()).append(" rows): ").append(originalStatement).append(';')
-                .append(System.lineSeparator()).append("-- transformed (").append(transformedImage.size())
-                .append(" rows): ").append(transformedStatement).append(';').append(System.lineSeparator()).toString();
+        List<String> header = new ArrayList<>();
+        header.add(EETDMLGenerator.ROW_ID_COLUMN);
+        for (C column : table.getColumns()) {
+            header.add(column.getName());
+        }
+
+        Map<String, List<String>> originalByRowId = indexByRowId(originalImage);
+        Map<String, List<String>> transformedByRowId = indexByRowId(transformedImage);
+        Set<String> allRowIds = new TreeSet<>();
+        allRowIds.addAll(originalByRowId.keySet());
+        allRowIds.addAll(transformedByRowId.keySet());
+
+        String nl = System.lineSeparator();
+        StringBuilder message = new StringBuilder()
+                .append("-- The original and transformed statements left the database in different states.").append(nl)
+                .append("-- original:    ").append(originalStatement).append(';').append(nl).append("-- transformed: ")
+                .append(transformedStatement).append(';').append(nl).append("-- differing post-image rows (")
+                .append(String.join(", ", header)).append("):").append(nl);
+        int shown = 0;
+        for (String rowId : allRowIds) {
+            List<String> originalRow = originalByRowId.get(rowId);
+            List<String> transformedRow = transformedByRowId.get(rowId);
+            if (Objects.equals(originalRow, transformedRow)) {
+                continue;
+            }
+            if (shown == MAX_DIFF_ROWS_REPORTED) {
+                message.append("--   ... (further differences omitted)").append(nl);
+                break;
+            }
+            message.append("--   original:    ").append(renderRow(originalRow)).append(nl);
+            message.append("--   transformed: ").append(renderRow(transformedRow)).append(nl);
+            shown++;
+        }
+        return message.toString();
+    }
+
+    // Indexes a post-image by its row identifier (the first column of each row)
+    private static Map<String, List<String>> indexByRowId(List<List<String>> image) {
+        Map<String, List<String>> byRowId = new LinkedHashMap<>();
+        for (List<String> row : image) {
+            byRowId.put(row.get(0), row);
+        }
+        return byRowId;
+    }
+
+    // Renders a post-image row for the finding message, or "(row absent)" when the row is missing on that side
+    private static String renderRow(List<String> row) {
+        return row == null ? "(row absent)" : row.toString();
     }
 
     @Override

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -1,7 +1,9 @@
 package sqlancer.mysql.gen;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -255,6 +257,18 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
     }
 
     @Override
+    public List<Map.Entry<MySQLColumn, MySQLExpression>> generateSetAssignments() {
+        List<Map.Entry<MySQLColumn, MySQLExpression>> assignments = new ArrayList<>();
+        for (MySQLColumn column : Randomly.nonEmptySubset(columns)) {
+            // As with the normal UPDATE workload, the value is an arbitrary expression (not type-matched to the
+            // column);
+            // any resulting type/range error is on the oracle's expected-error allow-list.
+            assignments.add(new AbstractMap.SimpleEntry<>(column, generateExpression()));
+        }
+        return assignments;
+    }
+
+    @Override
     public MySQLSelect generateSelect() {
         return new MySQLSelect();
     }
@@ -384,8 +398,8 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
     @Override
     public String stampRowIdsStatement(MySQLTable table) {
         // MySQL's UUID() gives each existing row a distinct value in a single statement. Stamping happens once, before
-        // both rolled-back DELETE runs, so both observe identical identifiers; the standard-SQL statements (add/drop
-        // column, delete, snapshot, transaction control) use EETDMLGenerator's defaults.
+        // both rolled-back statement runs, so both observe identical identifiers; the standard-SQL statements (add/drop
+        // column, delete/update, snapshot, transaction control) use EETDMLGenerator's defaults.
         return String.format("UPDATE %s SET %s = UUID()", table.getName(), ROW_ID_COLUMN);
     }
 


### PR DESCRIPTION
The EET DML oracle (`EETDMLOracle`) previously transformed only `DELETE` statements. This PR adds `UPDATE` to the same oracle. The key difference from `DELETE` is that `UPDATE` has two kinds of transformable expression (the `WHERE` predicate and each `SET` value expression) rather than one.

Comparing which rows are affected is no longer enough (two runs could change the same rows but write different values, which we would want to flag as a bug). The comparison is therefore upgraded to a full **post-image** (for each surviving row, its identifier together with every content column's value). This covers both `UPDATE` and `DELETE` statements, subsuming `DELETE`'s previous surviving-row-set comparison. It will also, with small additions, be able to cover `INSERT` statements, which will be added next.

Effort has been made to make the logs for reported bugs clear, showing the post-image discrepancy of the relevant rows. Test case reduction is left to a later PR.