### PR TITLE
Extend the EET DML oracle to INSERT support

### DIFF
--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -245,7 +245,8 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
 
     /**
      * SQL that inserts a new row into {@code table} for each source row (optionally filtered by {@code predicate}),
-     * setting each content column to its corresponding value in {@code values}.
+     * setting each content column to its corresponding value in {@code values}, optionally limited to the first
+     * {@code limit} source rows (see {@link #orderByLimitClause}).
      *
      * <p>
      * The {@code INSERT ... SELECT} form is used rather than {@code INSERT ... VALUES} because the transformed value
@@ -263,10 +264,15 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      * @param predicate
      *            the WHERE predicate filtering the source rows, or {@code null} to insert from every source row;
      *            rendered via {@link #asString}
+     * @param orderByColumns
+     *            the columns to order the source rows by before the row-id tiebreaker (may be empty); only used when
+     *            {@code limit} is non-null
+     * @param limit
+     *            the maximum number of source rows to insert from, or {@code null} for no limit
      *
      * @return the SQL statement
      */
-    default String insertStatement(T table, List<E> values, E predicate) {
+    default String insertStatement(T table, List<E> values, E predicate, List<C> orderByColumns, Integer limit) {
         List<String> columnNames = new ArrayList<>();
         columnNames.add(ROW_ID_COLUMN);
         List<String> selectItems = new ArrayList<>();
@@ -281,12 +287,12 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
         if (predicate != null) {
             statement += " WHERE " + asString(predicate);
         }
-        return statement;
+        return statement + orderByLimitClause(orderByColumns, limit);
     }
 
     /**
-     * Renders the trailing {@code ORDER BY ... LIMIT n} clause shared by {@link #deleteStatement} and
-     * {@link #updateStatement}, or the empty string when {@code limit} is null.
+     * Renders the trailing {@code ORDER BY ... LIMIT n} clause shared by {@link #deleteStatement},
+     * {@link #updateStatement} and {@link #insertStatement}, or the empty string when {@code limit} is null.
      *
      * <p>
      * The rows are ordered by {@code orderByColumns} followed by {@link #ROW_ID_COLUMN} as a tiebreaker. Because the

--- a/src/sqlancer/common/gen/EETDMLGenerator.java
+++ b/src/sqlancer/common/gen/EETDMLGenerator.java
@@ -19,9 +19,9 @@ import sqlancer.common.schema.AbstractTables;
  * <p>
  * Adapted from the DQE oracle, state is observed with an auxiliary column ({@link EETDMLGenerator#ROW_ID_COLUMN}) which
  * uniquely identifies each row. The rows are stamped with identifiers once, before both executions of the statement run
- * (each in a rolled-back transaction), so both executions observe the same identifiers regardless of how they are
- * produced. The resulting state is compared as a full post-image (each surviving row's identifier and content column
- * values), which covers every DML statement: a DELETE removes rows from it, an UPDATE changes values in it.
+ * (each in a rolled-back transaction), so both executions observe the same identifiers. The resulting state is compared
+ * as a full post-image (each surviving row's identifier and content column values), which covers any of the three DML
+ * statements (DELETE, UPDATE, INSERT).
  *
  * <p>
  * Most of these statements are standard SQL, likely common to most DBMSs, so are provided as {@code default} methods.
@@ -67,6 +67,15 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
     List<Map.Entry<C, E>> generateSetAssignments();
 
     /**
+     * Generates a fresh value expression for each content column of the current table, used as an INSERT statement's
+     * inserted values. The returned expressions are positionally aligned with {@link AbstractTable#getColumns()}, and
+     * each is transformed by the oracle.
+     *
+     * @return one fresh random value expression per content column, in {@link AbstractTable#getColumns()} order
+     */
+    List<E> generateInsertValues();
+
+    /**
      * Creates a DBMS-specific {@link EETTransformer} backed by this generator, used to rewrite the statement's
      * expressions into semantically equivalent ones.
      *
@@ -106,6 +115,17 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      */
     String rowIdColumnType();
 
+    /**
+     * A SQL expression, evaluated once per source row of an {@code INSERT ... SELECT}, that derives the inserted row's
+     * {@link #ROW_ID_COLUMN} value from the source row's identifier. It must be deterministic (so both the original and
+     * transformed statements assign the same identifiers), unique per source row, and distinct from every existing
+     * identifier (so an inserted row never collides with the source row it was derived from in the post-image). DBMS-
+     * specific because it names a suitable derivation function (e.g. a hash of the source identifier).
+     *
+     * @return the SQL expression deriving an inserted row's identifier from the source row's {@link #ROW_ID_COLUMN}
+     */
+    String insertedRowIdExpression();
+
     // --- Standard-SQL statements (override only where the DBMS's dialect differs) ---
 
     /**
@@ -139,8 +159,9 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
      *
      * <p>
      * This single value-level snapshot is the comparison surface for all DML statements: a DELETE removes rows from it,
-     * an UPDATE changes column values in it. Row identity alone (which the identifier already captures) would suffice
-     * for DELETE, but not for UPDATE, where the two runs could touch the same rows yet write different values.
+     * an UPDATE changes column values in it, an INSERT adds rows to it. Row identity alone (which the identifier
+     * already captures) would suffice for DELETE, but not for UPDATE, where the two runs could touch the same rows yet
+     * write different values.
      *
      * @param table
      *            the table to snapshot
@@ -220,6 +241,47 @@ public interface EETDMLGenerator<E extends Expression<C>, T extends AbstractTabl
         }
         return "UPDATE " + table.getName() + " SET " + String.join(", ", setClauses) + " WHERE " + asString(predicate)
                 + orderByLimitClause(orderByColumns, limit);
+    }
+
+    /**
+     * SQL that inserts a new row into {@code table} for each source row (optionally filtered by {@code predicate}),
+     * setting each content column to its corresponding value in {@code values}.
+     *
+     * <p>
+     * The {@code INSERT ... SELECT} form is used rather than {@code INSERT ... VALUES} because the transformed value
+     * expressions reference the table's columns (the transformer injects column references into its equivalent
+     * sub-expressions), which are legal in a {@code SELECT} but not in a {@code VALUES} clause. Each inserted row's
+     * {@link #ROW_ID_COLUMN} is derived from its source row via {@link #insertedRowIdExpression()}, giving it a
+     * deterministic identifier that is unique and distinct from every existing one, so the two statements' post-images
+     * align (and inserted rows never collide with their source rows).
+     *
+     * @param table
+     *            the table to insert into
+     * @param values
+     *            one value expression per content column, positionally aligned with {@link AbstractTable#getColumns()};
+     *            each is rendered via {@link #asString}
+     * @param predicate
+     *            the WHERE predicate filtering the source rows, or {@code null} to insert from every source row;
+     *            rendered via {@link #asString}
+     *
+     * @return the SQL statement
+     */
+    default String insertStatement(T table, List<E> values, E predicate) {
+        List<String> columnNames = new ArrayList<>();
+        columnNames.add(ROW_ID_COLUMN);
+        List<String> selectItems = new ArrayList<>();
+        selectItems.add(insertedRowIdExpression());
+        List<C> columns = table.getColumns();
+        for (int i = 0; i < columns.size(); i++) {
+            columnNames.add(columns.get(i).getName());
+            selectItems.add(asString(values.get(i)));
+        }
+        String statement = "INSERT INTO " + table.getName() + " (" + String.join(", ", columnNames) + ") SELECT "
+                + String.join(", ", selectItems) + " FROM " + table.getName();
+        if (predicate != null) {
+            statement += " WHERE " + asString(predicate);
+        }
+        return statement;
     }
 
     /**

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Supplier;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
@@ -100,16 +99,18 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         // Optionally cap the statement with a LIMIT. The limit and its ordering (a random column subset, made a total
         // order by the row-id tiebreaker) are decided once and applied identically to both statements, so the capped
         // row set is deterministic and equal across the runs while still exercising varied orderings.
-        boolean withLimit = Randomly.getBoolean();
-        Integer limit = withLimit ? (int) Randomly.getNotCachedInteger(0, 10) : null;
-        List<C> orderByColumns = withLimit ? Randomly.subset(table.getColumns()) : List.of();
+        Integer limit = null;
+        List<C> orderByColumns = List.of();
+        if (Randomly.getBoolean()) {
+            limit = (int) Randomly.getNotCachedInteger(0, 10);
+            orderByColumns = Randomly.subset(table.getColumns());
+        }
 
         // Generators for the different kinds of statement this oracle supports. One is chosen at random per check
-        List<Supplier<StatementPair>> statementGenerators = List.of(
-                () -> generateDeleteStatements(table, predicate, transformedPredicate, orderByColumns, limit),
-                () -> generateUpdateStatements(table, predicate, transformedPredicate, orderByColumns, limit),
-                () -> generateInsertStatements(table, predicate, transformedPredicate));
-        StatementPair statements = Randomly.fromList(statementGenerators).get();
+        List<DMLStatementGenerator<E, T, C>> statementGenerators = List.of(this::generateDeleteStatements,
+                this::generateUpdateStatements, this::generateInsertStatements);
+        StatementPair statements = Randomly.fromList(statementGenerators).generate(table, predicate,
+                transformedPredicate, orderByColumns, limit);
         String originalStatement = statements.original;
         String transformedStatement = statements.transformed;
         generatedQueryString = originalStatement;
@@ -138,6 +139,22 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         } finally {
             new SQLQueryAdapter(gen.dropRowIdColumnStatement(table), errors, true).execute(state);
         }
+    }
+
+    /**
+     * Generates a DML statement of one kind together with its transformed counterpart. The kinds share this signature
+     * so the oracle can pick one of them at random per check.
+     *
+     * @param <E>
+     *            the DBMS-specific expression class
+     * @param <T>
+     *            the DBMS-specific table class
+     * @param <C>
+     *            the DBMS-specific column class
+     */
+    @FunctionalInterface
+    private interface DMLStatementGenerator<E, T, C> {
+        StatementPair generate(T table, E predicate, E transformedPredicate, List<C> orderByColumns, Integer limit);
     }
 
     /**
@@ -209,10 +226,7 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
      * filters the source rows and is optional here, INSERT also transforms each inserted value in a scalar context.
      *
      * <p>
-     * Unlike DELETE and UPDATE, no limit is applied: {@link EETDMLGenerator#insertStatement} renders no ordering or
-     * limit, so one row is inserted per source row the predicate keeps. Nothing about INSERT rules a limit out — its
-     * source SELECT could carry the same ordering and limit the other statement kinds use, and the two runs would still
-     * read the same source rows — it is just not generated.
+     * The ordering and limit cap the source rows the statement reads, so it inserts one row per source row kept.
      *
      * @param table
      *            the table being modified
@@ -220,18 +234,25 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
      *            the WHERE predicate of the original statement
      * @param transformedPredicate
      *            the transformed WHERE predicate, used by the transformed statement
+     * @param orderByColumns
+     *            the columns ordering the source rows, empty if the statement is not capped by a limit
+     * @param limit
+     *            the maximum number of source rows to insert from, or {@code null} for no limit
      *
      * @return the original statement together with its transformed counterpart
      */
-    private StatementPair generateInsertStatements(T table, E predicate, E transformedPredicate) {
+    private StatementPair generateInsertStatements(T table, E predicate, E transformedPredicate, List<C> orderByColumns,
+            Integer limit) {
         List<E> values = gen.generateInsertValues();
         List<E> transformedValues = new ArrayList<>();
         for (E value : values) {
             transformedValues.add(transformer.transform(value, false));
         }
         boolean withPredicate = Randomly.getBoolean();
-        return new StatementPair(gen.insertStatement(table, values, withPredicate ? predicate : null),
-                gen.insertStatement(table, transformedValues, withPredicate ? transformedPredicate : null));
+        return new StatementPair(
+                gen.insertStatement(table, values, withPredicate ? predicate : null, orderByColumns, limit),
+                gen.insertStatement(table, transformedValues, withPredicate ? transformedPredicate : null,
+                        orderByColumns, limit));
     }
 
     /**

--- a/src/sqlancer/common/oracle/EETDMLOracle.java
+++ b/src/sqlancer/common/oracle/EETDMLOracle.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 
 import sqlancer.IgnoreMeException;
 import sqlancer.Randomly;
@@ -37,13 +38,15 @@ import sqlancer.common.schema.AbstractTables;
  * statements can be compared against the same starting state without permanently modifying the database. The state is
  * captured as a full post-image: each surviving row's identifier together with its content column values, ordered by
  * the identifier. This single value-level surface covers every DML statement — a DELETE removes rows from it, an UPDATE
- * changes values in it (row identity alone would suffice for DELETE, but not for UPDATE, which also transforms the
- * written values). Because rolling back a statement requires a transactional storage engine, the DBMS-specific setup
- * must ensure only such engines are used while this oracle is active.
+ * changes values in it, an INSERT adds rows to it (row identity alone would suffice for DELETE, but not for UPDATE,
+ * which also transforms the written values). Because rolling back a statement requires a transactional storage engine,
+ * the DBMS-specific setup must ensure only such engines are used while this oracle is active.
  *
  * <p>
- * DELETE and UPDATE are currently supported (one is chosen at random per check). Statement reduction is not yet
- * implemented (there is no {@link sqlancer.Reproducer Reproducer}), so the finding is reported without database
+ * DELETE, UPDATE and INSERT are currently supported (one is chosen at random per check). INSERT uses the
+ * {@code INSERT ... SELECT} form so its transformed value expressions may reference columns; each inserted row is given
+ * a deterministic identifier derived from its source row so the two runs' post-images align. Statement reduction is not
+ * yet implemented (there is no {@link sqlancer.Reproducer Reproducer}), so the finding is reported without database
  * reduction.
  *
  * @param <E>
@@ -97,16 +100,16 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
         // Optionally cap the statement with a LIMIT. The limit and its ordering (a random column subset, made a total
         // order by the row-id tiebreaker) are decided once and applied identically to both statements, so the capped
         // row set is deterministic and equal across the runs while still exercising varied orderings.
-        Integer limit = null;
-        List<C> orderByColumns = List.of();
-        if (Randomly.getBoolean()) {
-            limit = (int) Randomly.getNotCachedInteger(0, 10);
-            orderByColumns = Randomly.subset(table.getColumns());
-        }
+        boolean withLimit = Randomly.getBoolean();
+        Integer limit = withLimit ? (int) Randomly.getNotCachedInteger(0, 10) : null;
+        List<C> orderByColumns = withLimit ? Randomly.subset(table.getColumns()) : List.of();
 
-        StatementPair statements = Randomly.getBoolean()
-                ? generateUpdateStatements(table, predicate, transformedPredicate, orderByColumns, limit)
-                : generateDeleteStatements(table, predicate, transformedPredicate, orderByColumns, limit);
+        // Generators for the different kinds of statement this oracle supports. One is chosen at random per check
+        List<Supplier<StatementPair>> statementGenerators = List.of(
+                () -> generateDeleteStatements(table, predicate, transformedPredicate, orderByColumns, limit),
+                () -> generateUpdateStatements(table, predicate, transformedPredicate, orderByColumns, limit),
+                () -> generateInsertStatements(table, predicate, transformedPredicate));
+        StatementPair statements = Randomly.fromList(statementGenerators).get();
         String originalStatement = statements.original;
         String transformedStatement = statements.transformed;
         generatedQueryString = originalStatement;
@@ -199,6 +202,36 @@ public class EETDMLOracle<E extends Expression<C>, S extends AbstractSchema<?, T
             Integer limit) {
         return new StatementPair(gen.deleteStatement(table, predicate, orderByColumns, limit),
                 gen.deleteStatement(table, transformedPredicate, orderByColumns, limit));
+    }
+
+    /**
+     * Generates an {@code INSERT ... SELECT} and its transformed counterpart. Besides the WHERE predicate, which
+     * filters the source rows and is optional here, INSERT also transforms each inserted value in a scalar context.
+     *
+     * <p>
+     * Unlike DELETE and UPDATE, no limit is applied: {@link EETDMLGenerator#insertStatement} renders no ordering or
+     * limit, so one row is inserted per source row the predicate keeps. Nothing about INSERT rules a limit out — its
+     * source SELECT could carry the same ordering and limit the other statement kinds use, and the two runs would still
+     * read the same source rows — it is just not generated.
+     *
+     * @param table
+     *            the table being modified
+     * @param predicate
+     *            the WHERE predicate of the original statement
+     * @param transformedPredicate
+     *            the transformed WHERE predicate, used by the transformed statement
+     *
+     * @return the original statement together with its transformed counterpart
+     */
+    private StatementPair generateInsertStatements(T table, E predicate, E transformedPredicate) {
+        List<E> values = gen.generateInsertValues();
+        List<E> transformedValues = new ArrayList<>();
+        for (E value : values) {
+            transformedValues.add(transformer.transform(value, false));
+        }
+        boolean withPredicate = Randomly.getBoolean();
+        return new StatementPair(gen.insertStatement(table, values, withPredicate ? predicate : null),
+                gen.insertStatement(table, transformedValues, withPredicate ? transformedPredicate : null));
     }
 
     /**

--- a/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLExpressionGenerator.java
@@ -269,6 +269,14 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
     }
 
     @Override
+    public List<MySQLExpression> generateInsertValues() {
+        // One value per content column, in schema order (aligned with the INSERT column list). As with the normal
+        // INSERT workload, each value is an arbitrary expression (not type-matched to the column); any resulting
+        // type/range/constraint error is on the oracle's expected-error allow-list.
+        return columns.stream().map(c -> generateExpression()).collect(Collectors.toList());
+    }
+
+    @Override
     public MySQLSelect generateSelect() {
         return new MySQLSelect();
     }
@@ -407,5 +415,13 @@ public class MySQLExpressionGenerator extends UntypedExpressionGenerator<MySQLEx
     public String rowIdColumnType() {
         // Holds a 36-character UUID string produced by stampRowIdsStatement.
         return "VARCHAR(36)";
+    }
+
+    @Override
+    public String insertedRowIdExpression() {
+        // The source row's identifier with its dashes removed: deterministic (identical across both runs) and unique
+        // per
+        // source row. Fits the identifier column's VARCHAR(36).
+        return String.format("REPLACE(%s, '-', '')", ROW_ID_COLUMN);
     }
 }

--- a/src/sqlancer/mysql/gen/MySQLTableGenerator.java
+++ b/src/sqlancer/mysql/gen/MySQLTableGenerator.java
@@ -164,7 +164,15 @@ public class MySQLTableGenerator {
     }
 
     private void appendTableOptions() {
-        List<TableOptions> tableOptions = TableOptions.getRandomTableOptions();
+        List<TableOptions> tableOptions = new ArrayList<>(TableOptions.getRandomTableOptions());
+        // The EET DML oracle rolls back each statement to compare database states, which requires a transactional
+        // engine. The ENGINE option already forces InnoDB when the oracle is active (see the ENGINE case below), but it
+        // is only emitted when randomly chosen; otherwise the table would inherit the server's default engine, which is
+        // not guaranteed transactional. Force the option to always be present so the engine is never left to the
+        // server default.
+        if (globalState.usesEETDML() && !tableOptions.contains(TableOptions.ENGINE)) {
+            tableOptions.add(TableOptions.ENGINE);
+        }
         int i = 0;
         for (TableOptions o : tableOptions) {
             if (i++ != 0) {


### PR DESCRIPTION
The EET DML oracle (`EETDMLOracle`) previously transformed `DELETE` and `UPDATE` statements. This PR adds `INSERT` to the same oracle. 

The `INSERT` is generated in the `INSERT ... SELECT` form rather than `INSERT ... VALUES`. This is because, when a value expression is transformed, the transformer introduces equivalent sub-expressions that reference the table's columns (for example, the random predicate inside a `CASE WHEN`). Column references are legal in a `SELECT` but not in a `VALUES` clause, so a `VALUES` form would produce invalid SQL without additional workarounds. Note, this does NOT mean that the testing is limited to only insert column references. It can still insert new constants too. For example, `INSERT INTO t (c1) SELECT (123) FROM t WHERE p` would insert `n` rows with the constant `123`, where `n` is the number of rows in `t` which satisfy `p`. So, the `INSERT ... SELECT` form is expected to stress the DBMS at least as much as the `INSERT ... VALUES` form would.

Because `INSERT ... SELECT` inserts one new row per source row, each new row needs an identifier so the two runs' states can be lined up. Although the existing rows are originally stamped with `UUID()`, this cannot be used for the inserted rows, because it would be non-deterministic across the two runs. The implementation chosen here for MySQL simply removes the four dashes from the existing row's rowid, using `REPLACE(rowid, '-', '')`. This is deterministic (both runs assign the same identifiers), unique per source row, and distinct from every existing identifier (a 32-character string never equals the 36-character source string). It also fits the existing identifier column without widening it.