### PR TITLE
Implement query reduction for EET SELECT

### DIFF
--- a/src/sqlancer/Main.java
+++ b/src/sqlancer/Main.java
@@ -270,6 +270,11 @@ public final class Main {
             this.reduceBugInformation = bugInformation;
         }
 
+        // for reducers that rewrite the failing queries themselves (e.g., TransformationReducer)
+        public void updateReducedBugInformation(String bugInformation) {
+            this.reduceBugInformation = bugInformation;
+        }
+
         public void logReduced(StateToReproduce state) {
             nrReductionAttempts++;
             logReduced(state, "Reduction attempt " + nrReductionAttempts
@@ -524,6 +529,11 @@ public final class Main {
                         Reducer<G> astBasedReducer = new ASTBasedReducer<>(provider);
                         astBasedReducer.reduce(state, reproducer, newGlobalState);
                     }
+
+                    // reduces the oracle's transformed query itself; a no-op for reproducers whose queries are not
+                    // built from reducible transformations
+                    Reducer<G> transformationReducer = new TransformationReducer<>(provider);
+                    transformationReducer.reduce(state, reproducer, newGlobalState);
 
                     // reassemble the statements so that the main log looks like one produced
                     // without the reducer, with the generation statements replaced by the reduced

--- a/src/sqlancer/Randomly.java
+++ b/src/sqlancer/Randomly.java
@@ -510,6 +510,29 @@ public final class Randomly {
         return getThreadRandom().get().nextDouble();
     }
 
+    /**
+     * Computes {@code value} with this thread's random number generator temporarily replaced by a fixed-seed one,
+     * restoring the previous generator afterwards. This makes computations that draw randomness deterministic: for
+     * example, rendering an AST to SQL draws random textual variants in some DBMS implementations, and test-case
+     * reduction relies on re-rendering the same AST to the same string.
+     *
+     * @param <T>
+     *            the type of the computed value
+     * @param value
+     *            the computation to run deterministically
+     *
+     * @return the computed value
+     */
+    public static <T> T withFixedSeedRandom(Supplier<T> value) {
+        Random previousRandom = THREAD_RANDOM.get();
+        THREAD_RANDOM.set(new Random(0));
+        try {
+            return value.get();
+        } finally {
+            THREAD_RANDOM.set(previousRandom);
+        }
+    }
+
     public String getChar() {
         while (true) {
             String s = getString();

--- a/src/sqlancer/TransformationReducer.java
+++ b/src/sqlancer/TransformationReducer.java
@@ -1,0 +1,182 @@
+package sqlancer;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import sqlancer.common.query.Query;
+
+/**
+ * Reduces the transformed query of a {@link TransformationReproducer} by disabling transformation sites, searching
+ * (with the same delta-debugging strategy as {@link StatementReducer}) for a minimal set of sites that still triggers
+ * the bug. Because each site is an individually equivalence-preserving rewrite, any subset of sites yields a
+ * transformed query that is still semantically equivalent to the original query, so the reduction is sound. This
+ * reducer runs after statement reduction, evaluating each candidate against the already-reduced database; for
+ * reproducers that do not implement {@link TransformationReproducer}, it does nothing.
+ *
+ * @param <G>
+ *            the DBMS-specific global state class
+ * @param <O>
+ *            the DBMS-specific options class
+ * @param <C>
+ *            the DBMS-specific connection class
+ */
+public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBMSSpecificOptions<?>, C extends SQLancerDBConnection>
+        implements Reducer<G> {
+
+    private final DatabaseProvider<G, O, C> provider;
+    private List<Query<C>> statements;
+    private boolean observedChange;
+    private int partitionNum;
+
+    private long currentReduceSteps;
+    private long currentReduceTime;
+
+    private long maxReduceSteps;
+    private long maxReduceTime;
+
+    private Instant timeOfReductionBegins;
+
+    public TransformationReducer(DatabaseProvider<G, O, C> provider) {
+        this.provider = provider;
+    }
+
+    private boolean hasNotReachedLimit(long curr, long limit) {
+        if (limit == MainOptions.NO_REDUCE_LIMIT) {
+            return true;
+        }
+        return curr < limit;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void reduce(G state, Reproducer<G> reproducer, G newGlobalState) throws Exception {
+        if (!(reproducer instanceof TransformationReproducer)) {
+            return;
+        }
+        TransformationReproducer<G> transformationReproducer = (TransformationReproducer<G>) reproducer;
+
+        maxReduceTime = state.getOptions().getMaxStatementReduceTime();
+        maxReduceSteps = state.getOptions().getMaxStatementReduceSteps();
+
+        // Snapshot the (already reduced) generation statements once: createDatabase logs its setup statements
+        // (DROP/CREATE/USE) into the state, so the state's statement list must be reset for every candidate rather
+        // than read back, lest the setup statements accumulate and get re-executed mid-test-case.
+        statements = new ArrayList<>();
+        for (Query<?> stat : newGlobalState.getState().getStatements()) {
+            statements.add((Query<C>) stat);
+        }
+
+        List<Integer> enabledSites = new ArrayList<>();
+        for (int site = 0; site < transformationReproducer.getTransformationSiteCount(); site++) {
+            enabledSites.add(site);
+        }
+        // With every site disabled the transformed query renders as the original one, which cannot mismatch with
+        // itself, so a single remaining site cannot be reduced further.
+        if (enabledSites.size() < 2) {
+            return;
+        }
+
+        timeOfReductionBegins = Instant.now();
+        currentReduceSteps = 0;
+        currentReduceTime = 0;
+        partitionNum = 2;
+
+        while (enabledSites.size() >= 2 && hasNotReachedLimit(currentReduceSteps, maxReduceSteps)
+                && hasNotReachedLimit(currentReduceTime, maxReduceTime)) {
+            observedChange = false;
+
+            enabledSites = tryReduction(transformationReproducer, newGlobalState, enabledSites);
+
+            if (!observedChange) {
+                if (partitionNum == enabledSites.size()) {
+                    break;
+                }
+                // increase the search granularity
+                partitionNum = Math.min(partitionNum * 2, enabledSites.size());
+            }
+        }
+
+        // Leave the reproducer holding the reduced transformed query (the last candidate tried may have failed), so
+        // the final bug information reflects the reduction.
+        transformationReproducer.setEnabledTransformationSites(new HashSet<>(enabledSites));
+        newGlobalState.getState().setStatements(new ArrayList<>(statements));
+        newGlobalState.getLogger().updateReducedBugInformation(transformationReproducer.getBugInformation());
+        newGlobalState.getLogger().logReduced(newGlobalState.getState(),
+                "Transformation reduction finished; the transformed query was reduced to the one shown below");
+    }
+
+    private List<Integer> tryReduction(TransformationReproducer<G> transformationReproducer, G newGlobalState,
+            List<Integer> enabledSites) throws Exception {
+
+        List<Integer> sites = enabledSites;
+
+        int start = 0;
+        int subLength = sites.size() / partitionNum;
+        while (start < sites.size()) {
+            // candidateSites = sites[:start] + sites[start+subLength:]
+            // in other words, remove [start, start+subLength) from sites
+            List<Integer> candidateSites = new ArrayList<>(sites);
+            int endPoint = Math.min(start + subLength, candidateSites.size());
+            candidateSites.subList(start, endPoint).clear();
+
+            if (bugStillTriggersWith(transformationReproducer, newGlobalState, candidateSites)) {
+                observedChange = true;
+                sites = candidateSites;
+                partitionNum = Math.max(partitionNum - 1, 2);
+                newGlobalState.getLogger().updateReducedBugInformation(transformationReproducer.getBugInformation());
+                newGlobalState.getLogger().logReduced(newGlobalState.getState());
+                break;
+            }
+
+            currentReduceSteps++;
+            currentReduceTime = Duration.between(timeOfReductionBegins, Instant.now()).getSeconds();
+            if (!hasNotReachedLimit(currentReduceSteps, maxReduceSteps)
+                    || !hasNotReachedLimit(currentReduceTime, maxReduceTime)) {
+                return sites;
+            }
+            start = start + subLength;
+        }
+        return sites;
+    }
+
+    /**
+     * Whether the bug still triggers with only {@code candidateSites} applied to the transformed query, evaluated
+     * against a freshly recreated database populated with the (already reduced) generation statements.
+     *
+     * @param transformationReproducer
+     *            the reproducer whose transformed query is being reduced
+     * @param newGlobalState
+     *            the state the candidate is evaluated against
+     * @param candidateSites
+     *            the transformation sites to keep applied
+     *
+     * @return {@code true} if the bug still triggers with the candidate sites
+     */
+    private boolean bugStillTriggersWith(TransformationReproducer<G> transformationReproducer, G newGlobalState,
+            List<Integer> candidateSites) {
+        transformationReproducer.setEnabledTransformationSites(new HashSet<>(candidateSites));
+        try (C con2 = provider.createDatabase(newGlobalState)) {
+            newGlobalState.setConnection(con2);
+            // discard the setup statements createDatabase just logged into the state
+            newGlobalState.getState().setStatements(new ArrayList<>(statements));
+            for (Query<C> s : statements) {
+                try {
+                    s.execute(newGlobalState);
+                } catch (Throwable ignoredException) {
+                    // ignore
+                }
+            }
+            try {
+                return transformationReproducer.bugStillTriggers(newGlobalState);
+            } catch (Throwable ignoredException) {
+                // fall through: this candidate no longer triggers the bug
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/src/sqlancer/TransformationReproducer.java
+++ b/src/sqlancer/TransformationReproducer.java
@@ -1,0 +1,33 @@
+package sqlancer;
+
+import java.util.Set;
+
+/**
+ * A {@link Reproducer} for bugs found by comparing an original query against a transformed one, where the transformed
+ * query was built by applying individually equivalence-preserving transformations (e.g. the EET rules) to the original.
+ * Each such application is a transformation site, identified by an index that stays stable no matter which sites are
+ * enabled. Disabling any subset of sites re-renders a transformed query that is still semantically equivalent to the
+ * original, so {@link TransformationReducer} can soundly search for a minimal set of sites that still triggers the bug.
+ *
+ * @param <G>
+ *            the DBMS-specific global state class
+ */
+public interface TransformationReproducer<G extends GlobalState<?, ?, ?>> extends Reproducer<G> {
+
+    /**
+     * The total number of transformation sites the transformed query was built with. This does not change when sites
+     * are disabled.
+     *
+     * @return the total number of transformation sites
+     */
+    int getTransformationSiteCount();
+
+    /**
+     * Re-renders the transformed query with only the given transformation sites applied. Later
+     * {@link #bugStillTriggers} calls and {@link #getBugInformation} use the re-rendered query.
+     *
+     * @param enabledSites
+     *            the indices ({@code 0} to {@code getTransformationSiteCount() - 1}) of the sites to keep applied
+     */
+    void setEnabledTransformationSites(Set<Integer> enabledSites);
+}

--- a/src/sqlancer/common/oracle/EETOracle.java
+++ b/src/sqlancer/common/oracle/EETOracle.java
@@ -1,12 +1,15 @@
 package sqlancer.common.oracle;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 import sqlancer.ComparatorHelper;
+import sqlancer.Randomly;
 import sqlancer.Reproducer;
 import sqlancer.SQLGlobalState;
+import sqlancer.TransformationReproducer;
 import sqlancer.common.ast.newast.Expression;
 import sqlancer.common.ast.newast.Join;
 import sqlancer.common.ast.newast.Select;
@@ -53,13 +56,72 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
     private Reproducer<G> reproducer;
     private String generatedQueryString;
 
-    private final class EETReproducer extends AbstractComparisonReproducer<G, List<String>> {
+    private final class EETReproducer extends AbstractComparisonReproducer<G, List<String>>
+            implements TransformationReproducer<G> {
         private final String originalQueryString;
-        private final String transformedQueryString;
+        // Mutable: transformation reduction re-renders the transformed query with some transformation sites disabled.
+        private String transformedQueryString;
+        private final String initialTransformedQueryString;
 
-        EETReproducer(String originalQueryString, String transformedQueryString) {
+        // The query parts needed to re-render the transformed query: the SELECT whose fetch columns and WHERE clause
+        // are replaced, the untransformed expressions, and the records of their transformations.
+        private final Z select;
+        private final List<E> fetchColumns;
+        private final List<EETTransformer.TransformationRecord> fetchColumnRecords;
+        private final E whereClause;
+        private final EETTransformer.TransformationRecord whereClauseRecord;
+
+        EETReproducer(String originalQueryString, String transformedQueryString, Z select, List<E> fetchColumns,
+                List<EETTransformer.TransformationRecord> fetchColumnRecords, E whereClause,
+                EETTransformer.TransformationRecord whereClauseRecord) {
             this.originalQueryString = originalQueryString;
             this.transformedQueryString = transformedQueryString;
+            this.initialTransformedQueryString = transformedQueryString;
+            this.select = select;
+            this.fetchColumns = fetchColumns;
+            this.fetchColumnRecords = fetchColumnRecords;
+            this.whereClause = whereClause;
+            this.whereClauseRecord = whereClauseRecord;
+        }
+
+        @Override
+        public int getTransformationSiteCount() {
+            int siteCount = whereClauseRecord.getSiteCount();
+            for (EETTransformer.TransformationRecord record : fetchColumnRecords) {
+                siteCount += record.getSiteCount();
+            }
+            return siteCount;
+        }
+
+        @Override
+        public void setEnabledTransformationSites(Set<Integer> enabledSites) {
+            if (enabledSites.size() == getTransformationSiteCount()) {
+                // With every site enabled, the transformed query is the unreduced one; keep the exact string that
+                // originally detected the bug rather than re-rendering it (rendering an AST draws random textual
+                // variants, so a re-render would produce a semantically equal but untested string).
+                transformedQueryString = initialTransformedQueryString;
+                return;
+            }
+            // Pin the RNG while re-rendering so the same enabled sites always yield the same query string; the string
+            // tested during reduction is then exactly the string the reduced test case reports.
+            transformedQueryString = Randomly.withFixedSeedRandom(() -> {
+                // Global site indices are assigned over the fetch columns' records first (in column order), then the
+                // WHERE clause's record.
+                List<E> replayedFetchColumns = new ArrayList<>();
+                int offset = 0;
+                for (int i = 0; i < fetchColumns.size(); i++) {
+                    int base = offset;
+                    replayedFetchColumns.add(transformer.replay(fetchColumns.get(i), false, fetchColumnRecords.get(i),
+                            site -> enabledSites.contains(base + site)));
+                    offset += fetchColumnRecords.get(i).getSiteCount();
+                }
+                int whereBase = offset;
+                E replayedWhereClause = transformer.replay(whereClause, true, whereClauseRecord,
+                        site -> enabledSites.contains(whereBase + site));
+                select.setFetchColumns(replayedFetchColumns);
+                select.setWhereClause(replayedWhereClause);
+                return select.asString();
+            });
         }
 
         @Override
@@ -160,11 +222,17 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
         }
 
         // Transform the query's expressions into semantically equivalent ones. Fetch columns are scalar expressions,
-        // while the WHERE clause is evaluated in a boolean context.
-        List<E> transformedFetchColumns = fetchColumns.stream().map(c -> transformer.transform(c, false))
-                .collect(Collectors.toList());
+        // while the WHERE clause is evaluated in a boolean context. Each transformation's record is kept so the
+        // reproducer can replay it with transformation sites disabled during reduction.
+        List<E> transformedFetchColumns = new ArrayList<>();
+        List<EETTransformer.TransformationRecord> fetchColumnRecords = new ArrayList<>();
+        for (E fetchColumn : fetchColumns) {
+            transformedFetchColumns.add(transformer.transform(fetchColumn, false));
+            fetchColumnRecords.add(transformer.getLastTransformationRecord());
+        }
         select.setFetchColumns(transformedFetchColumns);
         select.setWhereClause(transformer.transform(whereClause, true));
+        EETTransformer.TransformationRecord whereClauseRecord = transformer.getLastTransformationRecord();
 
         String transformedQueryString = select.asString();
         List<String> transformedResultSet;
@@ -181,7 +249,8 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
 
         // Set the reproducer before the assertion: assumeResultSetsAreEqual throws when the bug is
         // detected, so creating the reproducer afterwards would leave it null and prevent any reduction.
-        reproducer = new EETReproducer(originalQueryString, transformedQueryString);
+        reproducer = new EETReproducer(originalQueryString, transformedQueryString, select, fetchColumns,
+                fetchColumnRecords, whereClause, whereClauseRecord);
 
         ComparatorHelper.assumeResultSetsAreEqual(originalResultSet, transformedResultSet, originalQueryString,
                 List.of(transformedQueryString), state);

--- a/src/sqlancer/common/oracle/EETTransformer.java
+++ b/src/sqlancer/common/oracle/EETTransformer.java
@@ -2,6 +2,8 @@ package sqlancer.common.oracle;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.IntPredicate;
 
 import sqlancer.Randomly;
 import sqlancer.common.ast.newast.Expression;
@@ -17,6 +19,13 @@ import sqlancer.common.ast.newast.Expression;
  * ({@link #inferType} and {@link #generateExpressionOfType}) that realize the paper's {@code rand_expr(type(expr))};
  * everything else (the rule logic, context threading, and tree-walking orchestration) is provided here.
  *
+ * <p>
+ * Every {@link #transform} call records the rule applications it performs. The resulting {@link TransformationRecord}
+ * can later be passed to {@link #replay}, which re-applies the recorded rules with any subset of them disabled; because
+ * each rule application is individually equivalence-preserving, every such replay yields an expression that is still
+ * semantically equivalent to the input. Test-case reduction uses this to undo transformations one subset at a time
+ * while preserving the oracle's soundness.
+ *
  * @param <E>
  *            the DBMS-specific expression class
  * @param <T>
@@ -24,36 +33,72 @@ import sqlancer.common.ast.newast.Expression;
  */
 public abstract class EETTransformer<E extends Expression<?>, T> {
 
-    // true_expr(p) = p OR (NOT p) OR (p IS NULL) -> always TRUE
-    private E trueExpr() {
-        E p = generateBooleanExpression();
-        return orExpr(orExpr(p, not(p)), isNull(p));
-    }
+    private List<Application<E, T>> recording; // non-null while transform() is recording its rule applications
+    private TransformationRecord lastRecord;
 
-    // false_expr(p) = p AND (NOT p) AND (p IS NOT NULL) -> always FALSE
-    private E falseExpr() {
-        E p = generateBooleanExpression();
-        return and(and(p, not(p)), isNotNull(p));
+    private List<Application<E, T>> replayApplications; // non-null while replay() is re-applying a record
+    private IntPredicate replayEnabledSites;
+    private int replayCursor;
+    private int replaySiteCursor;
+
+    /**
+     * The decision made at one {@link #transformNode} call: which rule (if any) was applied at that node, together with
+     * the auxiliary expressions the rule drew randomly. Recording these decisions makes a transformation replayable
+     * with any subset of its rule applications disabled (see {@link #replay}).
+     *
+     * @param <E>
+     *            the DBMS-specific expression class
+     * @param <T>
+     *            the DBMS-specific type domain
+     */
+    private static final class Application<E, T> {
+        private static final Application<?, ?> NONE = new Application<>(null, null, null, null);
+
+        private final Rule rule; // null when no rule was applied at this node
+        private final E auxiliary; // rules No. 1-4: the fresh predicate p; rules No. 5 and 6: the CASE WHEN condition
+        private final E deadBranch; // rules No. 3 and 4: the recorded rand_expr, or null when it degenerated to a copy
+        private final T deadBranchType; // rules No. 3 and 4: the inferred type deadBranch was generated for
+
+        Application(Rule rule, E auxiliary, E deadBranch, T deadBranchType) {
+            this.rule = rule;
+            this.auxiliary = auxiliary;
+            this.deadBranch = deadBranch;
+            this.deadBranchType = deadBranchType;
+        }
     }
 
     /**
-     * Implements the paper's {@code rand_expr(type(expr))}: a random expression whose static type matches that of
-     * {@code expr}. Although the generated expression is never evaluated (it occupies the redundant branch of rules 3
-     * and 4), its static type participates in the DBMS's CASE WHEN result-type resolution, so a type mismatch could
-     * alter the live branch's value or rendering. When the type of {@code expr} cannot be inferred, this falls back to
-     * {@code expr} itself, which trivially has the correct type (degenerating to rules 5 and 6).
-     *
-     * @param expr
-     *            the expression whose static type the generated expression must match
-     *
-     * @return a random expression whose static type matches that of {@code expr}
+     * The rule applications recorded by one {@link #transform} call. The record is opaque: callers can only query the
+     * number of transformation sites and pass the record back to {@link #replay} on the transformer that produced it.
      */
-    private E randExprOfSameType(E expr) {
-        T type = inferType(expr);
-        if (type == null) {
-            return expr;
+    public static final class TransformationRecord {
+        private final List<Application<?, ?>> applications;
+        private final int siteCount;
+
+        private TransformationRecord(List<Application<?, ?>> applications) {
+            this.applications = applications;
+            this.siteCount = (int) applications.stream().filter(application -> application.rule != null).count();
         }
-        return generateExpressionOfType(type);
+
+        /**
+         * The number of transformation sites (rule applications) in this record. {@link #replay} numbers the sites
+         * {@code 0} to {@code getSiteCount() - 1} in the order they were recorded.
+         *
+         * @return the number of transformation sites
+         */
+        public int getSiteCount() {
+            return siteCount;
+        }
+    }
+
+    // true_expr(p) = p OR (NOT p) OR (p IS NULL) -> always TRUE, for any predicate p
+    private E trueExpr(E p) {
+        return orExpr(orExpr(p, not(p)), isNull(p));
+    }
+
+    // false_expr(p) = p AND (NOT p) AND (p IS NOT NULL) -> always FALSE, for any predicate p
+    private E falseExpr(E p) {
+        return and(and(p, not(p)), isNotNull(p));
     }
 
     /**
@@ -61,13 +106,18 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
      * ({@link #apply}) and in which contexts it preserves the expression's value ({@link #isApplicable}). Rule No. 7
      * (transform the expression to itself) is not modelled here: it is the fallback applied by {@link #applyRandomRule}
      * when no other rule is applicable.
+     *
+     * <p>
+     * A rule draws no randomness of its own: the auxiliary expressions it wraps the transformed expression in come from
+     * the {@link Application} recorded for it, so applying a rule again during {@link EETTransformer#replay} reproduces
+     * the same expression.
      */
     private enum Rule {
         // expr => false_expr OR expr
         RULE_1 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, E expr) {
-                return t.orExpr(t.falseExpr(), expr);
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
+                return t.orExpr(t.falseExpr(application.auxiliary), expr);
             }
 
             @Override
@@ -79,8 +129,8 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => true_expr AND expr
         RULE_2 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, E expr) {
-                return t.and(t.trueExpr(), expr);
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
+                return t.and(t.trueExpr(application.auxiliary), expr);
             }
 
             @Override
@@ -92,33 +142,43 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => CASE WHEN false_expr THEN rand_expr(type(expr)) ELSE expr END
         RULE_3 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, E expr) {
-                return t.caseWhen(t.falseExpr(), t.randExprOfSameType(expr), expr);
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
+                return t.caseWhen(t.falseExpr(application.auxiliary), t.deadBranch(application, expr), expr);
             }
 
             @Override
             boolean isApplicable(boolean booleanContext, boolean caseWhenApplicable) {
                 return caseWhenApplicable;
+            }
+
+            @Override
+            boolean usesDeadBranch() {
+                return true;
             }
         },
         // expr => CASE WHEN true_expr THEN expr ELSE rand_expr(type(expr)) END
         RULE_4 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, E expr) {
-                return t.caseWhen(t.trueExpr(), expr, t.randExprOfSameType(expr));
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
+                return t.caseWhen(t.trueExpr(application.auxiliary), expr, t.deadBranch(application, expr));
             }
 
             @Override
             boolean isApplicable(boolean booleanContext, boolean caseWhenApplicable) {
                 return caseWhenApplicable;
             }
+
+            @Override
+            boolean usesDeadBranch() {
+                return true;
+            }
         },
         // expr => CASE WHEN rand_expr(boolean) THEN copy(expr) ELSE expr END
         RULE_5 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, E expr) {
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
                 // deep copy of expr is not needed, as the AST nodes are immutable anyway
-                return t.caseWhen(t.generateBooleanExpression(), expr, expr);
+                return t.caseWhen(application.auxiliary, expr, expr);
             }
 
             @Override
@@ -129,9 +189,9 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => CASE WHEN rand_expr(boolean) THEN expr ELSE copy(expr) END
         RULE_6 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, E expr) {
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
                 // deep copy of expr is not needed, as the AST nodes are immutable anyway
-                return t.caseWhen(t.generateBooleanExpression(), expr, expr);
+                return t.caseWhen(application.auxiliary, expr, expr);
             }
 
             @Override
@@ -141,7 +201,8 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         };
 
         /**
-         * Applies this rule to {@code expr}, producing a semantically equivalent expression.
+         * Applies this rule to {@code expr}, producing a semantically equivalent expression built from the auxiliary
+         * expressions {@code application} recorded for it.
          *
          * @param <E>
          *            the DBMS-specific expression class
@@ -149,12 +210,14 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
          *            the DBMS-specific type domain
          * @param t
          *            the transformer providing the DBMS-specific node factories
+         * @param application
+         *            the recorded application of this rule, supplying its auxiliary expressions
          * @param expr
          *            the expression to transform
          *
          * @return a semantically equivalent expression
          */
-        abstract <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, E expr);
+        abstract <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr);
 
         /**
          * Whether this rule preserves {@code expr}'s value in the given context.
@@ -168,11 +231,22 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
          * @return {@code true} if this rule preserves {@code expr}'s value in the given context
          */
         abstract boolean isApplicable(boolean booleanContext, boolean caseWhenApplicable);
+
+        /**
+         * Whether an application of this rule carries a dead branch: an expression occupying the redundant branch of
+         * its CASE WHEN, which is never evaluated (see {@link EETTransformer#randomApplication}).
+         *
+         * @return {@code true} if applications of this rule carry a dead branch
+         */
+        boolean usesDeadBranch() {
+            return false;
+        }
     }
 
     /**
      * Applies a randomly chosen applicable transformation rule to {@code expr}, returning a semantically equivalent
-     * expression. When no rule is applicable, {@code expr} is returned unchanged (rule No. 7 of the EET paper).
+     * expression. When no rule is applicable, {@code expr} is returned unchanged (rule No. 7 of the EET paper). The
+     * decision is recorded for later {@link #replay}.
      *
      * @param expr
      *            the expression to transform
@@ -190,14 +264,63 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
             }
         }
         if (applicableRules.isEmpty()) {
+            record(noApplication());
             return expr; // rule 7 fallback: transform expression to itself
         }
-        return Randomly.fromList(applicableRules).apply(this, expr);
+        Application<E, T> application = randomApplication(Randomly.fromList(applicableRules), expr);
+        record(application);
+        return application.rule.apply(this, application, expr);
+    }
+
+    /**
+     * Draws the random ingredients of one application of {@code rule} to {@code expr}. For the rules that use one, the
+     * dead branch implements the paper's {@code rand_expr(type(expr))}: a random expression whose static type matches
+     * that of {@code expr}. Although that expression is never evaluated, its static type participates in the DBMS's
+     * CASE WHEN result-type resolution, so a type mismatch could alter the live branch's value or rendering. When the
+     * type of {@code expr} cannot be inferred, no dead-branch expression is generated and the rule degenerates to the
+     * {@code copy_expr} form of rules No. 5 and 6 (see {@link #deadBranch}).
+     *
+     * @param rule
+     *            the transformation rule to draw an application of
+     * @param expr
+     *            the expression the application will wrap
+     *
+     * @return the drawn application
+     */
+    private Application<E, T> randomApplication(Rule rule, E expr) {
+        if (rule.usesDeadBranch()) {
+            T type = inferType(expr);
+            E deadBranch = type == null ? null : generateExpressionOfType(type);
+            return new Application<>(rule, generateBooleanExpression(), deadBranch, type);
+        }
+        return new Application<>(rule, generateBooleanExpression(), null, null);
+    }
+
+    /**
+     * The dead branch of an application of rule No. 3 or 4 around the live expression {@code expr}: the recorded random
+     * expression when its type still matches the type inferred for {@code expr}, and {@code expr} itself otherwise (the
+     * {@code copy_expr} degeneration, which trivially has the correct type). The types can stop matching during
+     * {@link #replay}: disabling transformation sites inside {@code expr} may change its inferred type, and reusing the
+     * recorded dead branch would then no longer be equivalence-preserving.
+     *
+     * @param application
+     *            the application whose dead branch is built
+     * @param expr
+     *            the live expression the application wraps
+     *
+     * @return the dead-branch expression
+     */
+    private E deadBranch(Application<E, T> application, E expr) {
+        if (application.deadBranch != null && Objects.equals(application.deadBranchType, inferType(expr))) {
+            return application.deadBranch;
+        }
+        return expr;
     }
 
     /**
      * Transforms {@code expr} into a semantically equivalent expression. A transformation rule is always applied at the
-     * root, guaranteeing (unless only rule 7 is applicable) that the returned expression differs from the input.
+     * root, guaranteeing (unless only rule 7 is applicable) that the returned expression differs from the input. The
+     * rule applications performed are recorded and available via {@link #getLastTransformationRecord()}.
      *
      * @param expr
      *            the expression to transform
@@ -207,11 +330,75 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
      * @return a semantically equivalent expression
      */
     public E transform(E expr, boolean booleanContext) {
-        return transformNode(expr, booleanContext, true);
+        recording = new ArrayList<>();
+        try {
+            E transformed = transformNode(expr, booleanContext, true);
+            lastRecord = new TransformationRecord(new ArrayList<>(recording));
+            return transformed;
+        } finally {
+            recording = null;
+        }
     }
 
     /**
-     * Descends into {@code expr}, rebuilds it from transformed children, then optionally applies a rule at this node.
+     * Returns the record of the rule applications performed by the most recent {@link #transform} call, for later
+     * {@link #replay}.
+     *
+     * @return the most recent transformation record, or {@code null} if {@link #transform} has not been called yet
+     */
+    public TransformationRecord getLastTransformationRecord() {
+        return lastRecord;
+    }
+
+    /**
+     * Re-applies a recorded transformation to {@code expr} (the same expression that was passed to the
+     * {@link #transform} call that produced {@code record}), keeping only the rule applications whose site index is
+     * accepted by {@code enabledSites}; a disabled application leaves its subexpression untransformed. Because every
+     * recorded rule application is individually equivalence-preserving, the returned expression is semantically
+     * equivalent to {@code expr} for any subset of enabled sites, which makes replay suitable for test-case reduction:
+     * transformations are undone one subset at a time while the transformed query remains equivalent to the original.
+     *
+     * <p>
+     * Replay walks the tree through the same {@link #descend} calls as the recording run, so it relies on
+     * {@code descend} rebuilding nodes deterministically. No new random expressions are generated: all auxiliary
+     * expressions are reused from the record.
+     *
+     * @param expr
+     *            the expression the record's transform call originally transformed
+     * @param booleanContext
+     *            whether {@code expr} is evaluated purely for its truth value (must match the original call)
+     * @param record
+     *            the record produced by this transformer's {@link #transform} call on {@code expr}
+     * @param enabledSites
+     *            accepts the site indices ({@code 0} to {@code record.getSiteCount() - 1}) to keep applied
+     *
+     * @return the partially transformed expression
+     */
+    @SuppressWarnings("unchecked")
+    public E replay(E expr, boolean booleanContext, TransformationRecord record, IntPredicate enabledSites) {
+        replayApplications = new ArrayList<>();
+        for (Application<?, ?> application : record.applications) {
+            // safe: the record was produced by a transformer with the same type parameters
+            replayApplications.add((Application<E, T>) application);
+        }
+        replayEnabledSites = enabledSites;
+        replayCursor = 0;
+        replaySiteCursor = 0;
+        try {
+            E replayed = transformNode(expr, booleanContext, true);
+            if (replayCursor != replayApplications.size()) {
+                throw new IllegalStateException("The replay visited fewer nodes than the record contains");
+            }
+            return replayed;
+        } finally {
+            replayApplications = null;
+            replayEnabledSites = null;
+        }
+    }
+
+    /**
+     * Descends into {@code expr}, rebuilds it from transformed children, then optionally applies a rule at this node
+     * (or, during {@link #replay}, re-applies the recorded rule if its site is enabled).
      *
      * @param expr
      *            the expression to transform
@@ -224,16 +411,57 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
      */
     protected E transformNode(E expr, boolean booleanContext, boolean forceApply) {
         E descended = descend(expr, booleanContext);
+        if (replayApplications != null) {
+            return replayApplication(descended);
+        }
         if (forceApply || Randomly.getBoolean()) {
             return applyRandomRule(descended, booleanContext);
         }
+        record(noApplication());
         return descended;
+    }
+
+    /**
+     * Consumes the next recorded decision and re-applies it to the rebuilt node, unless no rule was applied there or
+     * the application's site is disabled.
+     *
+     * @param descended
+     *            the rebuilt node the decision applies to
+     *
+     * @return the (possibly wrapped) node
+     */
+    private E replayApplication(E descended) {
+        if (replayCursor >= replayApplications.size()) {
+            throw new IllegalStateException("The replay visited more nodes than the record contains");
+        }
+        Application<E, T> application = replayApplications.get(replayCursor++);
+        if (application.rule == null) {
+            return descended;
+        }
+        int site = replaySiteCursor++;
+        if (!replayEnabledSites.test(site)) {
+            return descended;
+        }
+        return application.rule.apply(this, application, descended);
+    }
+
+    private void record(Application<E, T> application) {
+        if (recording != null) {
+            recording.add(application);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Application<E, T> noApplication() {
+        return (Application<E, T>) Application.NONE;
     }
 
     /**
      * Rebuilds {@code expr} with its children transformed, threading the correct boolean/scalar context into each
      * child. Leaf nodes (columns, constants, table references, ...) should be returned unchanged; any applicable
-     * transformation will still be applied to them by the calling {@link #transformNode}.
+     * transformation will still be applied to them by the calling {@link #transformNode}. Implementations must be
+     * deterministic (in particular, visit the children of a given node in a fixed order), as {@link #replay} matches
+     * recorded rule applications to nodes by their visiting order.
      *
      * @param expr
      *            the expression to descend into


### PR DESCRIPTION
The EET oracle detects a bug by transforming a query's expressions into semantically equivalent ones and comparing the two result sets. The transformed query is built by randomly applying EET rules, each wrapping a subexpression in a larger but equivalent form. Every such application is one "transformation site". Until now, reduction only shrank the database setup statements. The transformed query itself was left at full size, which is a problem because EET's transformation can lead to very complex queries which bury the real cause of a bug. This PR adds a second reduction stage that shrinks the transformed query, while keeping it equivalent to the original so the oracle stays sound.

To achieve this, the transformed query is re-rendered with only a chosen subset of the transformation sites applied, and this choice is varied using a delta-debugging strategy. This feature required quite a lot of infrastructure in order to keep track of the applied transformations, reproduce them in a deterministic way, and log the reduction process clearly.

Later, this functionality will be extended to the EET DML oracle.