### PR TITLE
Add per-site simplification to EET transformed query reduction

### DIFF
--- a/src/sqlancer/TransformationReducer.java
+++ b/src/sqlancer/TransformationReducer.java
@@ -5,16 +5,20 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import sqlancer.common.query.Query;
 
 /**
- * Reduces the transformed query of a {@link TransformationReproducer} by disabling transformation sites, searching
- * (with the same delta-debugging strategy as {@link StatementReducer}) for a minimal set of sites that still triggers
- * the bug. Because each site is an individually equivalence-preserving rewrite, any subset of sites yields a
- * transformed query that is still semantically equivalent to the original query, so the reduction is sound. This
- * reducer runs after statement reduction, evaluating each candidate against the already-reduced database; for
- * reproducers that do not implement {@link TransformationReproducer}, it does nothing.
+ * Reduces the transformed query of a {@link TransformationReproducer} in two phases. First, transformation sites are
+ * disabled with the same delta-debugging strategy as {@link StatementReducer}, searching for a minimal set of sites
+ * that still triggers the bug. Second, each surviving site is greedily simplified: its always-true (or always-false)
+ * condition is rendered as a literal constant, and its generated dead branch is replaced by a copy of the live
+ * expression, keeping each simplification only if the bug still triggers. Because each site is an individually
+ * equivalence-preserving rewrite and both simplifications preserve that property, every candidate transformed query
+ * remains semantically equivalent to the original query, so the reduction is sound. This reducer runs after statement
+ * reduction, evaluating each candidate against the already-reduced database; for reproducers that do not implement
+ * {@link TransformationReproducer}, it does nothing.
  *
  * @param <G>
  *            the DBMS-specific global state class
@@ -39,6 +43,9 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
 
     private Instant timeOfReductionBegins;
 
+    private Set<Integer> constantConditionSites;
+    private Set<Integer> copiedDeadBranchSites;
+
     public TransformationReducer(DatabaseProvider<G, O, C> provider) {
         this.provider = provider;
     }
@@ -48,6 +55,18 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
             return true;
         }
         return curr < limit;
+    }
+
+    private boolean withinLimits() {
+        return hasNotReachedLimit(currentReduceSteps, maxReduceSteps)
+                && hasNotReachedLimit(currentReduceTime, maxReduceTime);
+    }
+
+    // Accounts one candidate evaluation against the step/time limits; returns whether reduction may continue.
+    private boolean registerStepAndCheckLimits() {
+        currentReduceSteps++;
+        currentReduceTime = Duration.between(timeOfReductionBegins, Instant.now()).getSeconds();
+        return withinLimits();
     }
 
     @SuppressWarnings("unchecked")
@@ -73,9 +92,7 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
         for (int site = 0; site < transformationReproducer.getTransformationSiteCount(); site++) {
             enabledSites.add(site);
         }
-        // With every site disabled the transformed query renders as the original one, which cannot mismatch with
-        // itself, so a single remaining site cannot be reduced further.
-        if (enabledSites.size() < 2) {
+        if (enabledSites.isEmpty()) {
             return;
         }
 
@@ -83,9 +100,12 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
         currentReduceSteps = 0;
         currentReduceTime = 0;
         partitionNum = 2;
+        constantConditionSites = new HashSet<>();
+        copiedDeadBranchSites = new HashSet<>();
 
-        while (enabledSites.size() >= 2 && hasNotReachedLimit(currentReduceSteps, maxReduceSteps)
-                && hasNotReachedLimit(currentReduceTime, maxReduceTime)) {
+        // Phase 1: delta-debug the enabled-site set. With every site disabled the transformed query renders as the
+        // original one, which cannot mismatch with itself, so a single remaining site is not removable further.
+        while (enabledSites.size() >= 2 && withinLimits()) {
             observedChange = false;
 
             enabledSites = tryReduction(transformationReproducer, newGlobalState, enabledSites);
@@ -99,9 +119,12 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
             }
         }
 
+        simplifySurvivingSites(transformationReproducer, newGlobalState, enabledSites);
+
         // Leave the reproducer holding the reduced transformed query (the last candidate tried may have failed), so
         // the final bug information reflects the reduction.
-        transformationReproducer.setEnabledTransformationSites(new HashSet<>(enabledSites));
+        transformationReproducer.applyTransformationSites(new HashSet<>(enabledSites), constantConditionSites,
+                copiedDeadBranchSites);
         newGlobalState.getState().setStatements(new ArrayList<>(statements));
         newGlobalState.getLogger().updateReducedBugInformation(transformationReproducer.getBugInformation());
         newGlobalState.getLogger().logReduced(newGlobalState.getState(),
@@ -126,15 +149,11 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
                 observedChange = true;
                 sites = candidateSites;
                 partitionNum = Math.max(partitionNum - 1, 2);
-                newGlobalState.getLogger().updateReducedBugInformation(transformationReproducer.getBugInformation());
-                newGlobalState.getLogger().logReduced(newGlobalState.getState());
+                logReductionStep(transformationReproducer, newGlobalState);
                 break;
             }
 
-            currentReduceSteps++;
-            currentReduceTime = Duration.between(timeOfReductionBegins, Instant.now()).getSeconds();
-            if (!hasNotReachedLimit(currentReduceSteps, maxReduceSteps)
-                    || !hasNotReachedLimit(currentReduceTime, maxReduceTime)) {
+            if (!registerStepAndCheckLimits()) {
                 return sites;
             }
             start = start + subLength;
@@ -143,8 +162,59 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
     }
 
     /**
-     * Whether the bug still triggers with only {@code candidateSites} applied to the transformed query, evaluated
-     * against a freshly recreated database populated with the (already reduced) generation statements.
+     * Phase 2: greedily simplifies each surviving site, keeping a simplification only if the bug still triggers. First
+     * the site's condition is rendered as a literal constant (the condition's embedded random predicate is often the
+     * bulk of the transformed query), then, for sites that have one, the generated dead branch is replaced by a copy of
+     * the live expression.
+     *
+     * @param transformationReproducer
+     *            the reproducer whose transformed query is being reduced
+     * @param newGlobalState
+     *            the state the candidates are evaluated against
+     * @param enabledSites
+     *            the sites that survived phase 1
+     */
+    private void simplifySurvivingSites(TransformationReproducer<G> transformationReproducer, G newGlobalState,
+            List<Integer> enabledSites) {
+        Set<Integer> deadBranchSites = transformationReproducer.getDeadBranchSites();
+        for (int site : enabledSites) {
+            if (!withinLimits()) {
+                return;
+            }
+            constantConditionSites.add(site);
+            if (bugStillTriggersWith(transformationReproducer, newGlobalState, enabledSites)) {
+                logReductionStep(transformationReproducer, newGlobalState);
+            } else {
+                constantConditionSites.remove(site);
+            }
+            if (!registerStepAndCheckLimits()) {
+                return;
+            }
+
+            if (deadBranchSites.contains(site)) {
+                copiedDeadBranchSites.add(site);
+                if (bugStillTriggersWith(transformationReproducer, newGlobalState, enabledSites)) {
+                    logReductionStep(transformationReproducer, newGlobalState);
+                } else {
+                    copiedDeadBranchSites.remove(site);
+                }
+                if (!registerStepAndCheckLimits()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    // Logs an accepted reduction step, refreshing the logged bug information with the re-rendered transformed query.
+    private void logReductionStep(TransformationReproducer<G> transformationReproducer, G newGlobalState) {
+        newGlobalState.getLogger().updateReducedBugInformation(transformationReproducer.getBugInformation());
+        newGlobalState.getLogger().logReduced(newGlobalState.getState());
+    }
+
+    /**
+     * Whether the bug still triggers with the given sites applied to the transformed query (further simplified per the
+     * current constant-condition and copied-dead-branch sets), evaluated against a freshly recreated database populated
+     * with the (already reduced) generation statements.
      *
      * @param transformationReproducer
      *            the reproducer whose transformed query is being reduced
@@ -153,11 +223,12 @@ public class TransformationReducer<G extends GlobalState<O, ?, C>, O extends DBM
      * @param candidateSites
      *            the transformation sites to keep applied
      *
-     * @return {@code true} if the bug still triggers with the candidate sites
+     * @return {@code true} if the bug still triggers with the candidate configuration
      */
     private boolean bugStillTriggersWith(TransformationReproducer<G> transformationReproducer, G newGlobalState,
             List<Integer> candidateSites) {
-        transformationReproducer.setEnabledTransformationSites(new HashSet<>(candidateSites));
+        transformationReproducer.applyTransformationSites(new HashSet<>(candidateSites), constantConditionSites,
+                copiedDeadBranchSites);
         try (C con2 = provider.createDatabase(newGlobalState)) {
             newGlobalState.setConnection(con2);
             // discard the setup statements createDatabase just logged into the state

--- a/src/sqlancer/TransformationReproducer.java
+++ b/src/sqlancer/TransformationReproducer.java
@@ -23,11 +23,28 @@ public interface TransformationReproducer<G extends GlobalState<?, ?, ?>> extend
     int getTransformationSiteCount();
 
     /**
-     * Re-renders the transformed query with only the given transformation sites applied. Later
-     * {@link #bugStillTriggers} calls and {@link #getBugInformation} use the re-rendered query.
+     * The transformation sites whose rule application embeds a generated dead-branch expression, which
+     * {@link #applyTransformationSites} may replace with a copy of the live expression.
+     *
+     * @return the indices of the sites with a generated dead branch
+     */
+    Set<Integer> getDeadBranchSites();
+
+    /**
+     * Re-renders the transformed query with only the given transformation sites applied, further simplified per site: a
+     * site in {@code constantConditionSites} renders its always-true (or always-false) condition as the literal
+     * constant of the same truth value, and a site in {@code copiedDeadBranchSites} replaces its generated dead branch
+     * with a copy of the live expression. Both simplifications preserve the equivalence of the transformed query, like
+     * disabling a site does. Later {@link #bugStillTriggers} calls and {@link #getBugInformation} use the re-rendered
+     * query.
      *
      * @param enabledSites
      *            the indices ({@code 0} to {@code getTransformationSiteCount() - 1}) of the sites to keep applied
+     * @param constantConditionSites
+     *            the indices of the enabled sites whose condition is rendered as a literal constant
+     * @param copiedDeadBranchSites
+     *            the indices of the enabled sites whose dead branch is replaced by a copy of the live expression
      */
-    void setEnabledTransformationSites(Set<Integer> enabledSites);
+    void applyTransformationSites(Set<Integer> enabledSites, Set<Integer> constantConditionSites,
+            Set<Integer> copiedDeadBranchSites);
 }

--- a/src/sqlancer/common/oracle/EETOracle.java
+++ b/src/sqlancer/common/oracle/EETOracle.java
@@ -2,6 +2,7 @@ package sqlancer.common.oracle;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -94,34 +95,73 @@ public class EETOracle<Z extends Select<J, E, T, C>, J extends Join<E, T, C>, E 
         }
 
         @Override
-        public void setEnabledTransformationSites(Set<Integer> enabledSites) {
-            if (enabledSites.size() == getTransformationSiteCount()) {
-                // With every site enabled, the transformed query is the unreduced one; keep the exact string that
-                // originally detected the bug rather than re-rendering it (rendering an AST draws random textual
+        public Set<Integer> getDeadBranchSites() {
+            // Global site indices are assigned over the fetch columns' records first (in column order), then the
+            // WHERE clause's record.
+            Set<Integer> deadBranchSites = new HashSet<>();
+            int offset = 0;
+            for (EETTransformer.TransformationRecord record : fetchColumnRecords) {
+                for (int site : record.getDeadBranchSites()) {
+                    deadBranchSites.add(offset + site);
+                }
+                offset += record.getSiteCount();
+            }
+            for (int site : whereClauseRecord.getDeadBranchSites()) {
+                deadBranchSites.add(offset + site);
+            }
+            return deadBranchSites;
+        }
+
+        @Override
+        public void applyTransformationSites(Set<Integer> enabledSites, Set<Integer> constantConditionSites,
+                Set<Integer> copiedDeadBranchSites) {
+            if (enabledSites.size() == getTransformationSiteCount() && constantConditionSites.isEmpty()
+                    && copiedDeadBranchSites.isEmpty()) {
+                // With every site fully enabled, the transformed query is the unreduced one; keep the exact string
+                // that originally detected the bug rather than re-rendering it (rendering an AST draws random textual
                 // variants, so a re-render would produce a semantically equal but untested string).
                 transformedQueryString = initialTransformedQueryString;
                 return;
             }
-            // Pin the RNG while re-rendering so the same enabled sites always yield the same query string; the string
-            // tested during reduction is then exactly the string the reduced test case reports.
+            // Pin the RNG while re-rendering so the same site configuration always yields the same query string; the
+            // string tested during reduction is then exactly the string the reduced test case reports.
             transformedQueryString = Randomly.withFixedSeedRandom(() -> {
                 // Global site indices are assigned over the fetch columns' records first (in column order), then the
                 // WHERE clause's record.
                 List<E> replayedFetchColumns = new ArrayList<>();
                 int offset = 0;
                 for (int i = 0; i < fetchColumns.size(); i++) {
-                    int base = offset;
                     replayedFetchColumns.add(transformer.replay(fetchColumns.get(i), false, fetchColumnRecords.get(i),
-                            site -> enabledSites.contains(base + site)));
+                            directives(enabledSites, constantConditionSites, copiedDeadBranchSites, offset)));
                     offset += fetchColumnRecords.get(i).getSiteCount();
                 }
-                int whereBase = offset;
                 E replayedWhereClause = transformer.replay(whereClause, true, whereClauseRecord,
-                        site -> enabledSites.contains(whereBase + site));
+                        directives(enabledSites, constantConditionSites, copiedDeadBranchSites, offset));
                 select.setFetchColumns(replayedFetchColumns);
                 select.setWhereClause(replayedWhereClause);
                 return select.asString();
             });
+        }
+
+        // Translates the global-index site sets into a record-local directives view starting at the given offset.
+        private EETTransformer.SiteDirectives directives(Set<Integer> enabledSites, Set<Integer> constantConditionSites,
+                Set<Integer> copiedDeadBranchSites, int offset) {
+            return new EETTransformer.SiteDirectives() {
+                @Override
+                public boolean isEnabled(int site) {
+                    return enabledSites.contains(offset + site);
+                }
+
+                @Override
+                public boolean useConstantCondition(int site) {
+                    return constantConditionSites.contains(offset + site);
+                }
+
+                @Override
+                public boolean useCopiedDeadBranch(int site) {
+                    return copiedDeadBranchSites.contains(offset + site);
+                }
+            };
         }
 
         @Override

--- a/src/sqlancer/common/oracle/EETTransformer.java
+++ b/src/sqlancer/common/oracle/EETTransformer.java
@@ -1,9 +1,10 @@
 package sqlancer.common.oracle;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.IntPredicate;
+import java.util.Set;
 
 import sqlancer.Randomly;
 import sqlancer.common.ast.newast.Expression;
@@ -37,9 +38,51 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
     private TransformationRecord lastRecord;
 
     private List<Application<E, T>> replayApplications; // non-null while replay() is re-applying a record
-    private IntPredicate replayEnabledSites;
+    private SiteDirectives replayDirectives;
     private int replayCursor;
     private int replaySiteCursor;
+
+    /**
+     * Per-site directives consulted during {@link #replay}, keyed by the record-local site index. Every combination of
+     * directives yields an expression that is semantically equivalent to the replayed one: a disabled site's rule is
+     * not applied at all; a constant condition renders a site's always-true (or always-false) condition as the literal
+     * constant of the same truth value; a copied dead branch replaces a site's generated dead-branch expression with a
+     * copy of the live expression (the {@code copy_expr} form of rules No. 5 and 6).
+     */
+    public interface SiteDirectives {
+
+        /**
+         * Whether the site's rule is applied at all.
+         *
+         * @param site
+         *            the record-local site index
+         *
+         * @return {@code true} if the site's rule is applied
+         */
+        boolean isEnabled(int site);
+
+        /**
+         * Whether the site's condition is rendered as a literal constant instead of the recorded
+         * {@code true_expr}/{@code false_expr} scaffolding (or, for rules No. 5 and 6, the recorded condition).
+         *
+         * @param site
+         *            the record-local site index
+         *
+         * @return {@code true} if the site's condition is rendered as a literal constant
+         */
+        boolean useConstantCondition(int site);
+
+        /**
+         * Whether the site's generated dead branch (rules No. 3 and 4 only) is replaced by a copy of the live
+         * expression.
+         *
+         * @param site
+         *            the record-local site index
+         *
+         * @return {@code true} if the site's dead branch is replaced by a copy of the live expression
+         */
+        boolean useCopiedDeadBranch(int site);
+    }
 
     /**
      * The decision made at one {@link #transformNode} call: which rule (if any) was applied at that node, together with
@@ -89,6 +132,26 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         public int getSiteCount() {
             return siteCount;
         }
+
+        /**
+         * The sites whose rule application embeds a generated dead-branch expression (rules No. 3 and 4 with an
+         * inferrable type), which a {@link #replay} may replace with a copy of the live expression.
+         *
+         * @return the record-local indices of the sites with a generated dead branch
+         */
+        public Set<Integer> getDeadBranchSites() {
+            Set<Integer> deadBranchSites = new HashSet<>();
+            int site = 0;
+            for (Application<?, ?> application : applications) {
+                if (application.rule != null) {
+                    if (application.deadBranch != null) {
+                        deadBranchSites.add(site);
+                    }
+                    site++;
+                }
+            }
+            return deadBranchSites;
+        }
     }
 
     // true_expr(p) = p OR (NOT p) OR (p IS NULL) -> always TRUE, for any predicate p
@@ -116,8 +179,9 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => false_expr OR expr
         RULE_1 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
-                return t.orExpr(t.falseExpr(application.auxiliary), expr);
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr,
+                    boolean constantCondition, boolean copiedDeadBranch) {
+                return t.orExpr(constantCondition ? t.falseConstant() : t.falseExpr(application.auxiliary), expr);
             }
 
             @Override
@@ -129,8 +193,9 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => true_expr AND expr
         RULE_2 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
-                return t.and(t.trueExpr(application.auxiliary), expr);
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr,
+                    boolean constantCondition, boolean copiedDeadBranch) {
+                return t.and(constantCondition ? t.trueConstant() : t.trueExpr(application.auxiliary), expr);
             }
 
             @Override
@@ -142,8 +207,10 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => CASE WHEN false_expr THEN rand_expr(type(expr)) ELSE expr END
         RULE_3 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
-                return t.caseWhen(t.falseExpr(application.auxiliary), t.deadBranch(application, expr), expr);
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr,
+                    boolean constantCondition, boolean copiedDeadBranch) {
+                return t.caseWhen(constantCondition ? t.falseConstant() : t.falseExpr(application.auxiliary),
+                        t.deadBranch(application, expr, copiedDeadBranch), expr);
             }
 
             @Override
@@ -159,8 +226,10 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => CASE WHEN true_expr THEN expr ELSE rand_expr(type(expr)) END
         RULE_4 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
-                return t.caseWhen(t.trueExpr(application.auxiliary), expr, t.deadBranch(application, expr));
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr,
+                    boolean constantCondition, boolean copiedDeadBranch) {
+                return t.caseWhen(constantCondition ? t.trueConstant() : t.trueExpr(application.auxiliary), expr,
+                        t.deadBranch(application, expr, copiedDeadBranch));
             }
 
             @Override
@@ -176,9 +245,10 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => CASE WHEN rand_expr(boolean) THEN copy(expr) ELSE expr END
         RULE_5 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr,
+                    boolean constantCondition, boolean copiedDeadBranch) {
                 // deep copy of expr is not needed, as the AST nodes are immutable anyway
-                return t.caseWhen(application.auxiliary, expr, expr);
+                return t.caseWhen(constantCondition ? t.trueConstant() : application.auxiliary, expr, expr);
             }
 
             @Override
@@ -189,9 +259,10 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         // expr => CASE WHEN rand_expr(boolean) THEN expr ELSE copy(expr) END
         RULE_6 {
             @Override
-            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr) {
+            <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr,
+                    boolean constantCondition, boolean copiedDeadBranch) {
                 // deep copy of expr is not needed, as the AST nodes are immutable anyway
-                return t.caseWhen(application.auxiliary, expr, expr);
+                return t.caseWhen(constantCondition ? t.trueConstant() : application.auxiliary, expr, expr);
             }
 
             @Override
@@ -202,7 +273,10 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
 
         /**
          * Applies this rule to {@code expr}, producing a semantically equivalent expression built from the auxiliary
-         * expressions {@code application} recorded for it.
+         * expressions {@code application} recorded for it. With {@code constantCondition}, the rule's condition is
+         * rendered as the literal constant of its (fixed) truth value: {@code true_expr}/{@code false_expr} are
+         * TRUE/FALSE for every embedded predicate, and the condition of rules No. 5 and 6 is irrelevant since both
+         * branches are identical, so this always preserves equivalence.
          *
          * @param <E>
          *            the DBMS-specific expression class
@@ -214,10 +288,15 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
          *            the recorded application of this rule, supplying its auxiliary expressions
          * @param expr
          *            the expression to transform
+         * @param constantCondition
+         *            whether the rule's condition is rendered as a literal constant
+         * @param copiedDeadBranch
+         *            whether the rule's generated dead branch (rules No. 3 and 4) is replaced by a copy of {@code expr}
          *
          * @return a semantically equivalent expression
          */
-        abstract <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr);
+        abstract <E extends Expression<?>, T> E apply(EETTransformer<E, T> t, Application<E, T> application, E expr,
+                boolean constantCondition, boolean copiedDeadBranch);
 
         /**
          * Whether this rule preserves {@code expr}'s value in the given context.
@@ -269,7 +348,7 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
         }
         Application<E, T> application = randomApplication(Randomly.fromList(applicableRules), expr);
         record(application);
-        return application.rule.apply(this, application, expr);
+        return application.rule.apply(this, application, expr, false, false);
     }
 
     /**
@@ -298,20 +377,23 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
 
     /**
      * The dead branch of an application of rule No. 3 or 4 around the live expression {@code expr}: the recorded random
-     * expression when its type still matches the type inferred for {@code expr}, and {@code expr} itself otherwise (the
-     * {@code copy_expr} degeneration, which trivially has the correct type). The types can stop matching during
-     * {@link #replay}: disabling transformation sites inside {@code expr} may change its inferred type, and reusing the
-     * recorded dead branch would then no longer be equivalence-preserving.
+     * expression when it is kept and its type still matches the type inferred for {@code expr}, and {@code expr} itself
+     * otherwise (the {@code copy_expr} degeneration, which trivially has the correct type). The types can stop matching
+     * during {@link #replay}: disabling transformation sites inside {@code expr} may change its inferred type, and
+     * reusing the recorded dead branch would then no longer be equivalence-preserving.
      *
      * @param application
      *            the application whose dead branch is built
      * @param expr
      *            the live expression the application wraps
+     * @param copiedDeadBranch
+     *            whether the recorded dead branch is discarded in favor of a copy of {@code expr}
      *
      * @return the dead-branch expression
      */
-    private E deadBranch(Application<E, T> application, E expr) {
-        if (application.deadBranch != null && Objects.equals(application.deadBranchType, inferType(expr))) {
+    private E deadBranch(Application<E, T> application, E expr, boolean copiedDeadBranch) {
+        if (!copiedDeadBranch && application.deadBranch != null
+                && Objects.equals(application.deadBranchType, inferType(expr))) {
             return application.deadBranch;
         }
         return expr;
@@ -352,11 +434,12 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
 
     /**
      * Re-applies a recorded transformation to {@code expr} (the same expression that was passed to the
-     * {@link #transform} call that produced {@code record}), keeping only the rule applications whose site index is
-     * accepted by {@code enabledSites}; a disabled application leaves its subexpression untransformed. Because every
-     * recorded rule application is individually equivalence-preserving, the returned expression is semantically
-     * equivalent to {@code expr} for any subset of enabled sites, which makes replay suitable for test-case reduction:
-     * transformations are undone one subset at a time while the transformed query remains equivalent to the original.
+     * {@link #transform} call that produced {@code record}), honoring the per-site {@code directives}: a disabled
+     * application leaves its subexpression untransformed, and an enabled one may have its condition rendered as a
+     * literal constant or its dead branch copied (see {@link SiteDirectives}). Because every recorded rule application
+     * is individually equivalence-preserving under every directive combination, the returned expression is semantically
+     * equivalent to {@code expr}, which makes replay suitable for test-case reduction: transformations are undone or
+     * simplified one step at a time while the transformed query remains equivalent to the original.
      *
      * <p>
      * Replay walks the tree through the same {@link #descend} calls as the recording run, so it relies on
@@ -369,19 +452,19 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
      *            whether {@code expr} is evaluated purely for its truth value (must match the original call)
      * @param record
      *            the record produced by this transformer's {@link #transform} call on {@code expr}
-     * @param enabledSites
-     *            accepts the site indices ({@code 0} to {@code record.getSiteCount() - 1}) to keep applied
+     * @param directives
+     *            the per-site directives, consulted with site indices {@code 0} to {@code record.getSiteCount() - 1}
      *
      * @return the partially transformed expression
      */
     @SuppressWarnings("unchecked")
-    public E replay(E expr, boolean booleanContext, TransformationRecord record, IntPredicate enabledSites) {
+    public E replay(E expr, boolean booleanContext, TransformationRecord record, SiteDirectives directives) {
         replayApplications = new ArrayList<>();
         for (Application<?, ?> application : record.applications) {
             // safe: the record was produced by a transformer with the same type parameters
             replayApplications.add((Application<E, T>) application);
         }
-        replayEnabledSites = enabledSites;
+        replayDirectives = directives;
         replayCursor = 0;
         replaySiteCursor = 0;
         try {
@@ -392,7 +475,7 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
             return replayed;
         } finally {
             replayApplications = null;
-            replayEnabledSites = null;
+            replayDirectives = null;
         }
     }
 
@@ -422,8 +505,8 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
     }
 
     /**
-     * Consumes the next recorded decision and re-applies it to the rebuilt node, unless no rule was applied there or
-     * the application's site is disabled.
+     * Consumes the next recorded decision and re-applies it to the rebuilt node (honoring the site's directives),
+     * unless no rule was applied there or the application's site is disabled.
      *
      * @param descended
      *            the rebuilt node the decision applies to
@@ -439,10 +522,11 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
             return descended;
         }
         int site = replaySiteCursor++;
-        if (!replayEnabledSites.test(site)) {
+        if (!replayDirectives.isEnabled(site)) {
             return descended;
         }
-        return application.rule.apply(this, application, descended);
+        return application.rule.apply(this, application, descended, replayDirectives.useConstantCondition(site),
+                replayDirectives.useCopiedDeadBranch(site));
     }
 
     private void record(Application<E, T> application) {
@@ -525,6 +609,22 @@ public abstract class EETTransformer<E extends Expression<?>, T> {
      * @return the {@code expr IS NOT NULL} expression
      */
     protected abstract E isNotNull(E expr);
+
+    /**
+     * Builds a constant-TRUE boolean expression (e.g. the literal {@code TRUE}). Only used when a {@link #replay}
+     * renders an always-true condition as a constant (see {@link SiteDirectives#useConstantCondition}).
+     *
+     * @return a constant-TRUE boolean expression
+     */
+    protected abstract E trueConstant();
+
+    /**
+     * Builds a constant-FALSE boolean expression (e.g. the literal {@code FALSE}). Only used when a {@link #replay}
+     * renders an always-false condition as a constant (see {@link SiteDirectives#useConstantCondition}).
+     *
+     * @return a constant-FALSE boolean expression
+     */
+    protected abstract E falseConstant();
 
     /**
      * Builds {@code CASE WHEN condition THEN thenExpr ELSE elseExpr END}.

--- a/src/sqlancer/mysql/oracle/MySQLEETTransformer.java
+++ b/src/sqlancer/mysql/oracle/MySQLEETTransformer.java
@@ -144,6 +144,16 @@ public class MySQLEETTransformer extends EETTransformer<MySQLExpression, CastTyp
     }
 
     @Override
+    protected MySQLExpression trueConstant() {
+        return MySQLConstant.createTrue();
+    }
+
+    @Override
+    protected MySQLExpression falseConstant() {
+        return MySQLConstant.createFalse();
+    }
+
+    @Override
     protected MySQLExpression generateBooleanExpression() {
         return gen.generateBooleanExpression();
     }


### PR DESCRIPTION
The previous PR reduced EET's transformed queries by removing transformation sites. This adds a further reduction stage which simplifies the remaining sites. For example, `CASE WHEN random_true_expression THEN expr ELSE random_expression END` may be simplified to `CASE WHEN TRUE THEN expr ELSE random_expression END`, if the bug is still present in that simplified case.

This is currently applied only to the EET SELECT oracle, but will later be extended to DML.